### PR TITLE
Better error handling

### DIFF
--- a/aws-sdk/a4b.lua
+++ b/aws-sdk/a4b.lua
@@ -8624,7 +8624,7 @@ end
 --
 --- Call DeleteSkillAuthorization asynchronously, invoking a callback when done
 -- @param DeleteSkillAuthorizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSkillAuthorizationAsync(DeleteSkillAuthorizationRequest, cb)
 	assert(DeleteSkillAuthorizationRequest, "You must provide a DeleteSkillAuthorizationRequest")
 	local headers = {
@@ -8647,19 +8647,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSkillAuthorizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSkillAuthorizationSync(DeleteSkillAuthorizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSkillAuthorizationAsync(DeleteSkillAuthorizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSkillAuthorizationAsync(DeleteSkillAuthorizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateContactWithAddressBook asynchronously, invoking a callback when done
 -- @param AssociateContactWithAddressBookRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateContactWithAddressBookAsync(AssociateContactWithAddressBookRequest, cb)
 	assert(AssociateContactWithAddressBookRequest, "You must provide a AssociateContactWithAddressBookRequest")
 	local headers = {
@@ -8682,19 +8683,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateContactWithAddressBookRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateContactWithAddressBookSync(AssociateContactWithAddressBookRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateContactWithAddressBookAsync(AssociateContactWithAddressBookRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateContactWithAddressBookAsync(AssociateContactWithAddressBookRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListConferenceProviders asynchronously, invoking a callback when done
 -- @param ListConferenceProvidersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListConferenceProvidersAsync(ListConferenceProvidersRequest, cb)
 	assert(ListConferenceProvidersRequest, "You must provide a ListConferenceProvidersRequest")
 	local headers = {
@@ -8717,19 +8719,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListConferenceProvidersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListConferenceProvidersSync(ListConferenceProvidersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListConferenceProvidersAsync(ListConferenceProvidersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListConferenceProvidersAsync(ListConferenceProvidersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetProfile asynchronously, invoking a callback when done
 -- @param GetProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetProfileAsync(GetProfileRequest, cb)
 	assert(GetProfileRequest, "You must provide a GetProfileRequest")
 	local headers = {
@@ -8752,19 +8755,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetProfileSync(GetProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetProfileAsync(GetProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetProfileAsync(GetProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterAVSDevice asynchronously, invoking a callback when done
 -- @param RegisterAVSDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterAVSDeviceAsync(RegisterAVSDeviceRequest, cb)
 	assert(RegisterAVSDeviceRequest, "You must provide a RegisterAVSDeviceRequest")
 	local headers = {
@@ -8787,19 +8791,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterAVSDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterAVSDeviceSync(RegisterAVSDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterAVSDeviceAsync(RegisterAVSDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterAVSDeviceAsync(RegisterAVSDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSkillsStoreCategories asynchronously, invoking a callback when done
 -- @param ListSkillsStoreCategoriesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSkillsStoreCategoriesAsync(ListSkillsStoreCategoriesRequest, cb)
 	assert(ListSkillsStoreCategoriesRequest, "You must provide a ListSkillsStoreCategoriesRequest")
 	local headers = {
@@ -8822,19 +8827,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSkillsStoreCategoriesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSkillsStoreCategoriesSync(ListSkillsStoreCategoriesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSkillsStoreCategoriesAsync(ListSkillsStoreCategoriesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSkillsStoreCategoriesAsync(ListSkillsStoreCategoriesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchContacts asynchronously, invoking a callback when done
 -- @param SearchContactsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchContactsAsync(SearchContactsRequest, cb)
 	assert(SearchContactsRequest, "You must provide a SearchContactsRequest")
 	local headers = {
@@ -8857,19 +8863,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchContactsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchContactsSync(SearchContactsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchContactsAsync(SearchContactsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchContactsAsync(SearchContactsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConferenceProvider asynchronously, invoking a callback when done
 -- @param GetConferenceProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConferenceProviderAsync(GetConferenceProviderRequest, cb)
 	assert(GetConferenceProviderRequest, "You must provide a GetConferenceProviderRequest")
 	local headers = {
@@ -8892,19 +8899,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConferenceProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConferenceProviderSync(GetConferenceProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConferenceProviderAsync(GetConferenceProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConferenceProviderAsync(GetConferenceProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -8927,19 +8935,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateDeviceWithRoom asynchronously, invoking a callback when done
 -- @param AssociateDeviceWithRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateDeviceWithRoomAsync(AssociateDeviceWithRoomRequest, cb)
 	assert(AssociateDeviceWithRoomRequest, "You must provide a AssociateDeviceWithRoomRequest")
 	local headers = {
@@ -8962,19 +8971,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateDeviceWithRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateDeviceWithRoomSync(AssociateDeviceWithRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateDeviceWithRoomAsync(AssociateDeviceWithRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateDeviceWithRoomAsync(AssociateDeviceWithRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutSkillAuthorization asynchronously, invoking a callback when done
 -- @param PutSkillAuthorizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutSkillAuthorizationAsync(PutSkillAuthorizationRequest, cb)
 	assert(PutSkillAuthorizationRequest, "You must provide a PutSkillAuthorizationRequest")
 	local headers = {
@@ -8997,19 +9007,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutSkillAuthorizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutSkillAuthorizationSync(PutSkillAuthorizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutSkillAuthorizationAsync(PutSkillAuthorizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutSkillAuthorizationAsync(PutSkillAuthorizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetContact asynchronously, invoking a callback when done
 -- @param GetContactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetContactAsync(GetContactRequest, cb)
 	assert(GetContactRequest, "You must provide a GetContactRequest")
 	local headers = {
@@ -9032,19 +9043,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetContactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetContactSync(GetContactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetContactAsync(GetContactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetContactAsync(GetContactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSkillGroup asynchronously, invoking a callback when done
 -- @param UpdateSkillGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSkillGroupAsync(UpdateSkillGroupRequest, cb)
 	assert(UpdateSkillGroupRequest, "You must provide a UpdateSkillGroupRequest")
 	local headers = {
@@ -9067,19 +9079,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSkillGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSkillGroupSync(UpdateSkillGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSkillGroupAsync(UpdateSkillGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSkillGroupAsync(UpdateSkillGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConferenceProvider asynchronously, invoking a callback when done
 -- @param DeleteConferenceProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConferenceProviderAsync(DeleteConferenceProviderRequest, cb)
 	assert(DeleteConferenceProviderRequest, "You must provide a DeleteConferenceProviderRequest")
 	local headers = {
@@ -9102,19 +9115,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConferenceProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConferenceProviderSync(DeleteConferenceProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConferenceProviderAsync(DeleteConferenceProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConferenceProviderAsync(DeleteConferenceProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRoom asynchronously, invoking a callback when done
 -- @param GetRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRoomAsync(GetRoomRequest, cb)
 	assert(GetRoomRequest, "You must provide a GetRoomRequest")
 	local headers = {
@@ -9137,19 +9151,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRoomSync(GetRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRoomAsync(GetRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRoomAsync(GetRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSkillsStoreSkillsByCategory asynchronously, invoking a callback when done
 -- @param ListSkillsStoreSkillsByCategoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSkillsStoreSkillsByCategoryAsync(ListSkillsStoreSkillsByCategoryRequest, cb)
 	assert(ListSkillsStoreSkillsByCategoryRequest, "You must provide a ListSkillsStoreSkillsByCategoryRequest")
 	local headers = {
@@ -9172,19 +9187,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSkillsStoreSkillsByCategoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSkillsStoreSkillsByCategorySync(ListSkillsStoreSkillsByCategoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSkillsStoreSkillsByCategoryAsync(ListSkillsStoreSkillsByCategoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSkillsStoreSkillsByCategoryAsync(ListSkillsStoreSkillsByCategoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSkillGroup asynchronously, invoking a callback when done
 -- @param CreateSkillGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSkillGroupAsync(CreateSkillGroupRequest, cb)
 	assert(CreateSkillGroupRequest, "You must provide a CreateSkillGroupRequest")
 	local headers = {
@@ -9207,19 +9223,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSkillGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSkillGroupSync(CreateSkillGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSkillGroupAsync(CreateSkillGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSkillGroupAsync(CreateSkillGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAddressBook asynchronously, invoking a callback when done
 -- @param CreateAddressBookRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAddressBookAsync(CreateAddressBookRequest, cb)
 	assert(CreateAddressBookRequest, "You must provide a CreateAddressBookRequest")
 	local headers = {
@@ -9242,19 +9259,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAddressBookRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAddressBookSync(CreateAddressBookRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAddressBookAsync(CreateAddressBookRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAddressBookAsync(CreateAddressBookRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProfile asynchronously, invoking a callback when done
 -- @param CreateProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProfileAsync(CreateProfileRequest, cb)
 	assert(CreateProfileRequest, "You must provide a CreateProfileRequest")
 	local headers = {
@@ -9277,19 +9295,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProfileSync(CreateProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProfileAsync(CreateProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProfileAsync(CreateProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendInvitation asynchronously, invoking a callback when done
 -- @param SendInvitationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendInvitationAsync(SendInvitationRequest, cb)
 	assert(SendInvitationRequest, "You must provide a SendInvitationRequest")
 	local headers = {
@@ -9312,19 +9331,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendInvitationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendInvitationSync(SendInvitationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendInvitationAsync(SendInvitationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendInvitationAsync(SendInvitationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSkills asynchronously, invoking a callback when done
 -- @param ListSkillsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSkillsAsync(ListSkillsRequest, cb)
 	assert(ListSkillsRequest, "You must provide a ListSkillsRequest")
 	local headers = {
@@ -9347,19 +9367,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSkillsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSkillsSync(ListSkillsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSkillsAsync(ListSkillsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSkillsAsync(ListSkillsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchSkillGroups asynchronously, invoking a callback when done
 -- @param SearchSkillGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchSkillGroupsAsync(SearchSkillGroupsRequest, cb)
 	assert(SearchSkillGroupsRequest, "You must provide a SearchSkillGroupsRequest")
 	local headers = {
@@ -9382,19 +9403,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchSkillGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchSkillGroupsSync(SearchSkillGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchSkillGroupsAsync(SearchSkillGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchSkillGroupsAsync(SearchSkillGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeInvitation asynchronously, invoking a callback when done
 -- @param RevokeInvitationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeInvitationAsync(RevokeInvitationRequest, cb)
 	assert(RevokeInvitationRequest, "You must provide a RevokeInvitationRequest")
 	local headers = {
@@ -9417,19 +9439,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeInvitationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeInvitationSync(RevokeInvitationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeInvitationAsync(RevokeInvitationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeInvitationAsync(RevokeInvitationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateSkillWithSkillGroup asynchronously, invoking a callback when done
 -- @param AssociateSkillWithSkillGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateSkillWithSkillGroupAsync(AssociateSkillWithSkillGroupRequest, cb)
 	assert(AssociateSkillWithSkillGroupRequest, "You must provide a AssociateSkillWithSkillGroupRequest")
 	local headers = {
@@ -9452,19 +9475,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateSkillWithSkillGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateSkillWithSkillGroupSync(AssociateSkillWithSkillGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateSkillWithSkillGroupAsync(AssociateSkillWithSkillGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateSkillWithSkillGroupAsync(AssociateSkillWithSkillGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProfile asynchronously, invoking a callback when done
 -- @param DeleteProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProfileAsync(DeleteProfileRequest, cb)
 	assert(DeleteProfileRequest, "You must provide a DeleteProfileRequest")
 	local headers = {
@@ -9487,19 +9511,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProfileSync(DeleteProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProfileAsync(DeleteProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProfileAsync(DeleteProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRoomSkillParameter asynchronously, invoking a callback when done
 -- @param DeleteRoomSkillParameterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRoomSkillParameterAsync(DeleteRoomSkillParameterRequest, cb)
 	assert(DeleteRoomSkillParameterRequest, "You must provide a DeleteRoomSkillParameterRequest")
 	local headers = {
@@ -9522,19 +9547,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRoomSkillParameterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRoomSkillParameterSync(DeleteRoomSkillParameterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRoomSkillParameterAsync(DeleteRoomSkillParameterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRoomSkillParameterAsync(DeleteRoomSkillParameterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateSkillFromSkillGroup asynchronously, invoking a callback when done
 -- @param DisassociateSkillFromSkillGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateSkillFromSkillGroupAsync(DisassociateSkillFromSkillGroupRequest, cb)
 	assert(DisassociateSkillFromSkillGroupRequest, "You must provide a DisassociateSkillFromSkillGroupRequest")
 	local headers = {
@@ -9557,19 +9583,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateSkillFromSkillGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateSkillFromSkillGroupSync(DisassociateSkillFromSkillGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateSkillFromSkillGroupAsync(DisassociateSkillFromSkillGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateSkillFromSkillGroupAsync(DisassociateSkillFromSkillGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDevice asynchronously, invoking a callback when done
 -- @param DeleteDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDeviceAsync(DeleteDeviceRequest, cb)
 	assert(DeleteDeviceRequest, "You must provide a DeleteDeviceRequest")
 	local headers = {
@@ -9592,19 +9619,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDeviceSync(DeleteDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDeviceAsync(DeleteDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDeviceAsync(DeleteDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartDeviceSync asynchronously, invoking a callback when done
 -- @param StartDeviceSyncRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartDeviceSyncAsync(StartDeviceSyncRequest, cb)
 	assert(StartDeviceSyncRequest, "You must provide a StartDeviceSyncRequest")
 	local headers = {
@@ -9627,19 +9655,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartDeviceSyncRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartDeviceSyncSync(StartDeviceSyncRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartDeviceSyncAsync(StartDeviceSyncRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartDeviceSyncAsync(StartDeviceSyncRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSkillGroup asynchronously, invoking a callback when done
 -- @param DeleteSkillGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSkillGroupAsync(DeleteSkillGroupRequest, cb)
 	assert(DeleteSkillGroupRequest, "You must provide a DeleteSkillGroupRequest")
 	local headers = {
@@ -9662,19 +9691,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSkillGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSkillGroupSync(DeleteSkillGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSkillGroupAsync(DeleteSkillGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSkillGroupAsync(DeleteSkillGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectSkill asynchronously, invoking a callback when done
 -- @param RejectSkillRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectSkillAsync(RejectSkillRequest, cb)
 	assert(RejectSkillRequest, "You must provide a RejectSkillRequest")
 	local headers = {
@@ -9697,19 +9727,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectSkillRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectSkillSync(RejectSkillRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectSkillAsync(RejectSkillRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectSkillAsync(RejectSkillRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeviceEvents asynchronously, invoking a callback when done
 -- @param ListDeviceEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeviceEventsAsync(ListDeviceEventsRequest, cb)
 	assert(ListDeviceEventsRequest, "You must provide a ListDeviceEventsRequest")
 	local headers = {
@@ -9732,19 +9763,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeviceEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeviceEventsSync(ListDeviceEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeviceEventsAsync(ListDeviceEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeviceEventsAsync(ListDeviceEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSkillGroup asynchronously, invoking a callback when done
 -- @param GetSkillGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSkillGroupAsync(GetSkillGroupRequest, cb)
 	assert(GetSkillGroupRequest, "You must provide a GetSkillGroupRequest")
 	local headers = {
@@ -9767,19 +9799,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSkillGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSkillGroupSync(GetSkillGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSkillGroupAsync(GetSkillGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSkillGroupAsync(GetSkillGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchUsers asynchronously, invoking a callback when done
 -- @param SearchUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchUsersAsync(SearchUsersRequest, cb)
 	assert(SearchUsersRequest, "You must provide a SearchUsersRequest")
 	local headers = {
@@ -9802,19 +9835,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchUsersSync(SearchUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchUsersAsync(SearchUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchUsersAsync(SearchUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRoom asynchronously, invoking a callback when done
 -- @param UpdateRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRoomAsync(UpdateRoomRequest, cb)
 	assert(UpdateRoomRequest, "You must provide a UpdateRoomRequest")
 	local headers = {
@@ -9837,19 +9871,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRoomSync(UpdateRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRoomAsync(UpdateRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRoomAsync(UpdateRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -9872,19 +9907,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAddressBook asynchronously, invoking a callback when done
 -- @param GetAddressBookRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAddressBookAsync(GetAddressBookRequest, cb)
 	assert(GetAddressBookRequest, "You must provide a GetAddressBookRequest")
 	local headers = {
@@ -9907,19 +9943,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAddressBookRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAddressBookSync(GetAddressBookRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAddressBookAsync(GetAddressBookRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAddressBookAsync(GetAddressBookRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRoomSkillParameter asynchronously, invoking a callback when done
 -- @param PutRoomSkillParameterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRoomSkillParameterAsync(PutRoomSkillParameterRequest, cb)
 	assert(PutRoomSkillParameterRequest, "You must provide a PutRoomSkillParameterRequest")
 	local headers = {
@@ -9942,19 +9979,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRoomSkillParameterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRoomSkillParameterSync(PutRoomSkillParameterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRoomSkillParameterAsync(PutRoomSkillParameterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRoomSkillParameterAsync(PutRoomSkillParameterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateDeviceFromRoom asynchronously, invoking a callback when done
 -- @param DisassociateDeviceFromRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateDeviceFromRoomAsync(DisassociateDeviceFromRoomRequest, cb)
 	assert(DisassociateDeviceFromRoomRequest, "You must provide a DisassociateDeviceFromRoomRequest")
 	local headers = {
@@ -9977,19 +10015,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateDeviceFromRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateDeviceFromRoomSync(DisassociateDeviceFromRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateDeviceFromRoomAsync(DisassociateDeviceFromRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateDeviceFromRoomAsync(DisassociateDeviceFromRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchRooms asynchronously, invoking a callback when done
 -- @param SearchRoomsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchRoomsAsync(SearchRoomsRequest, cb)
 	assert(SearchRoomsRequest, "You must provide a SearchRoomsRequest")
 	local headers = {
@@ -10012,19 +10051,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchRoomsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchRoomsSync(SearchRoomsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchRoomsAsync(SearchRoomsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchRoomsAsync(SearchRoomsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteContact asynchronously, invoking a callback when done
 -- @param DeleteContactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteContactAsync(DeleteContactRequest, cb)
 	assert(DeleteContactRequest, "You must provide a DeleteContactRequest")
 	local headers = {
@@ -10047,19 +10087,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteContactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteContactSync(DeleteContactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteContactAsync(DeleteContactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteContactAsync(DeleteContactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDevice asynchronously, invoking a callback when done
 -- @param UpdateDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDeviceAsync(UpdateDeviceRequest, cb)
 	assert(UpdateDeviceRequest, "You must provide a UpdateDeviceRequest")
 	local headers = {
@@ -10082,19 +10123,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDeviceSync(UpdateDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDeviceAsync(UpdateDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDeviceAsync(UpdateDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutConferencePreference asynchronously, invoking a callback when done
 -- @param PutConferencePreferenceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutConferencePreferenceAsync(PutConferencePreferenceRequest, cb)
 	assert(PutConferencePreferenceRequest, "You must provide a PutConferencePreferenceRequest")
 	local headers = {
@@ -10117,19 +10159,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutConferencePreferenceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutConferencePreferenceSync(PutConferencePreferenceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutConferencePreferenceAsync(PutConferencePreferenceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutConferencePreferenceAsync(PutConferencePreferenceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ForgetSmartHomeAppliances asynchronously, invoking a callback when done
 -- @param ForgetSmartHomeAppliancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ForgetSmartHomeAppliancesAsync(ForgetSmartHomeAppliancesRequest, cb)
 	assert(ForgetSmartHomeAppliancesRequest, "You must provide a ForgetSmartHomeAppliancesRequest")
 	local headers = {
@@ -10152,19 +10195,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ForgetSmartHomeAppliancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ForgetSmartHomeAppliancesSync(ForgetSmartHomeAppliancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ForgetSmartHomeAppliancesAsync(ForgetSmartHomeAppliancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ForgetSmartHomeAppliancesAsync(ForgetSmartHomeAppliancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevice asynchronously, invoking a callback when done
 -- @param GetDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeviceAsync(GetDeviceRequest, cb)
 	assert(GetDeviceRequest, "You must provide a GetDeviceRequest")
 	local headers = {
@@ -10187,19 +10231,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeviceSync(GetDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeviceAsync(GetDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeviceAsync(GetDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateSkillGroupWithRoom asynchronously, invoking a callback when done
 -- @param AssociateSkillGroupWithRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateSkillGroupWithRoomAsync(AssociateSkillGroupWithRoomRequest, cb)
 	assert(AssociateSkillGroupWithRoomRequest, "You must provide a AssociateSkillGroupWithRoomRequest")
 	local headers = {
@@ -10222,19 +10267,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateSkillGroupWithRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateSkillGroupWithRoomSync(AssociateSkillGroupWithRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateSkillGroupWithRoomAsync(AssociateSkillGroupWithRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateSkillGroupWithRoomAsync(AssociateSkillGroupWithRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateSkillGroupFromRoom asynchronously, invoking a callback when done
 -- @param DisassociateSkillGroupFromRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateSkillGroupFromRoomAsync(DisassociateSkillGroupFromRoomRequest, cb)
 	assert(DisassociateSkillGroupFromRoomRequest, "You must provide a DisassociateSkillGroupFromRoomRequest")
 	local headers = {
@@ -10257,19 +10303,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateSkillGroupFromRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateSkillGroupFromRoomSync(DisassociateSkillGroupFromRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateSkillGroupFromRoomAsync(DisassociateSkillGroupFromRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateSkillGroupFromRoomAsync(DisassociateSkillGroupFromRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateContact asynchronously, invoking a callback when done
 -- @param CreateContactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateContactAsync(CreateContactRequest, cb)
 	assert(CreateContactRequest, "You must provide a CreateContactRequest")
 	local headers = {
@@ -10292,19 +10339,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateContactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateContactSync(CreateContactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateContactAsync(CreateContactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateContactAsync(CreateContactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchAddressBooks asynchronously, invoking a callback when done
 -- @param SearchAddressBooksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchAddressBooksAsync(SearchAddressBooksRequest, cb)
 	assert(SearchAddressBooksRequest, "You must provide a SearchAddressBooksRequest")
 	local headers = {
@@ -10327,19 +10375,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchAddressBooksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchAddressBooksSync(SearchAddressBooksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchAddressBooksAsync(SearchAddressBooksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchAddressBooksAsync(SearchAddressBooksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSmartHomeApplianceDiscovery asynchronously, invoking a callback when done
 -- @param StartSmartHomeApplianceDiscoveryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSmartHomeApplianceDiscoveryAsync(StartSmartHomeApplianceDiscoveryRequest, cb)
 	assert(StartSmartHomeApplianceDiscoveryRequest, "You must provide a StartSmartHomeApplianceDiscoveryRequest")
 	local headers = {
@@ -10362,19 +10411,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSmartHomeApplianceDiscoveryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSmartHomeApplianceDiscoverySync(StartSmartHomeApplianceDiscoveryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSmartHomeApplianceDiscoveryAsync(StartSmartHomeApplianceDiscoveryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSmartHomeApplianceDiscoveryAsync(StartSmartHomeApplianceDiscoveryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -10397,19 +10447,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateContact asynchronously, invoking a callback when done
 -- @param UpdateContactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateContactAsync(UpdateContactRequest, cb)
 	assert(UpdateContactRequest, "You must provide a UpdateContactRequest")
 	local headers = {
@@ -10432,19 +10483,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateContactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateContactSync(UpdateContactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateContactAsync(UpdateContactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateContactAsync(UpdateContactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAddressBook asynchronously, invoking a callback when done
 -- @param UpdateAddressBookRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAddressBookAsync(UpdateAddressBookRequest, cb)
 	assert(UpdateAddressBookRequest, "You must provide a UpdateAddressBookRequest")
 	local headers = {
@@ -10467,19 +10519,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAddressBookRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAddressBookSync(UpdateAddressBookRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAddressBookAsync(UpdateAddressBookRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAddressBookAsync(UpdateAddressBookRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConferenceProvider asynchronously, invoking a callback when done
 -- @param CreateConferenceProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConferenceProviderAsync(CreateConferenceProviderRequest, cb)
 	assert(CreateConferenceProviderRequest, "You must provide a CreateConferenceProviderRequest")
 	local headers = {
@@ -10502,19 +10555,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConferenceProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConferenceProviderSync(CreateConferenceProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConferenceProviderAsync(CreateConferenceProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConferenceProviderAsync(CreateConferenceProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -10537,19 +10591,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchDevices asynchronously, invoking a callback when done
 -- @param SearchDevicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchDevicesAsync(SearchDevicesRequest, cb)
 	assert(SearchDevicesRequest, "You must provide a SearchDevicesRequest")
 	local headers = {
@@ -10572,19 +10627,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchDevicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchDevicesSync(SearchDevicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchDevicesAsync(SearchDevicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchDevicesAsync(SearchDevicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConferenceProvider asynchronously, invoking a callback when done
 -- @param UpdateConferenceProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConferenceProviderAsync(UpdateConferenceProviderRequest, cb)
 	assert(UpdateConferenceProviderRequest, "You must provide a UpdateConferenceProviderRequest")
 	local headers = {
@@ -10607,19 +10663,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConferenceProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConferenceProviderSync(UpdateConferenceProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConferenceProviderAsync(UpdateConferenceProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConferenceProviderAsync(UpdateConferenceProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProfile asynchronously, invoking a callback when done
 -- @param UpdateProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProfileAsync(UpdateProfileRequest, cb)
 	assert(UpdateProfileRequest, "You must provide a UpdateProfileRequest")
 	local headers = {
@@ -10642,19 +10699,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProfileSync(UpdateProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProfileAsync(UpdateProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProfileAsync(UpdateProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ApproveSkill asynchronously, invoking a callback when done
 -- @param ApproveSkillRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ApproveSkillAsync(ApproveSkillRequest, cb)
 	assert(ApproveSkillRequest, "You must provide a ApproveSkillRequest")
 	local headers = {
@@ -10677,19 +10735,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ApproveSkillRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ApproveSkillSync(ApproveSkillRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ApproveSkillAsync(ApproveSkillRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ApproveSkillAsync(ApproveSkillRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRoom asynchronously, invoking a callback when done
 -- @param DeleteRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRoomAsync(DeleteRoomRequest, cb)
 	assert(DeleteRoomRequest, "You must provide a DeleteRoomRequest")
 	local headers = {
@@ -10712,19 +10771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRoomSync(DeleteRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRoomAsync(DeleteRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRoomAsync(DeleteRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateContactFromAddressBook asynchronously, invoking a callback when done
 -- @param DisassociateContactFromAddressBookRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateContactFromAddressBookAsync(DisassociateContactFromAddressBookRequest, cb)
 	assert(DisassociateContactFromAddressBookRequest, "You must provide a DisassociateContactFromAddressBookRequest")
 	local headers = {
@@ -10747,19 +10807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateContactFromAddressBookRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateContactFromAddressBookSync(DisassociateContactFromAddressBookRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateContactFromAddressBookAsync(DisassociateContactFromAddressBookRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateContactFromAddressBookAsync(DisassociateContactFromAddressBookRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSmartHomeAppliances asynchronously, invoking a callback when done
 -- @param ListSmartHomeAppliancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSmartHomeAppliancesAsync(ListSmartHomeAppliancesRequest, cb)
 	assert(ListSmartHomeAppliancesRequest, "You must provide a ListSmartHomeAppliancesRequest")
 	local headers = {
@@ -10782,19 +10843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSmartHomeAppliancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSmartHomeAppliancesSync(ListSmartHomeAppliancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSmartHomeAppliancesAsync(ListSmartHomeAppliancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSmartHomeAppliancesAsync(ListSmartHomeAppliancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRoomSkillParameter asynchronously, invoking a callback when done
 -- @param GetRoomSkillParameterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRoomSkillParameterAsync(GetRoomSkillParameterRequest, cb)
 	assert(GetRoomSkillParameterRequest, "You must provide a GetRoomSkillParameterRequest")
 	local headers = {
@@ -10817,19 +10879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRoomSkillParameterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRoomSkillParameterSync(GetRoomSkillParameterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRoomSkillParameterAsync(GetRoomSkillParameterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRoomSkillParameterAsync(GetRoomSkillParameterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAddressBook asynchronously, invoking a callback when done
 -- @param DeleteAddressBookRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAddressBookAsync(DeleteAddressBookRequest, cb)
 	assert(DeleteAddressBookRequest, "You must provide a DeleteAddressBookRequest")
 	local headers = {
@@ -10852,19 +10915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAddressBookRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAddressBookSync(DeleteAddressBookRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAddressBookAsync(DeleteAddressBookRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAddressBookAsync(DeleteAddressBookRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResolveRoom asynchronously, invoking a callback when done
 -- @param ResolveRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResolveRoomAsync(ResolveRoomRequest, cb)
 	assert(ResolveRoomRequest, "You must provide a ResolveRoomRequest")
 	local headers = {
@@ -10887,19 +10951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResolveRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResolveRoomSync(ResolveRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResolveRoomAsync(ResolveRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResolveRoomAsync(ResolveRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUser asynchronously, invoking a callback when done
 -- @param CreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserAsync(CreateUserRequest, cb)
 	assert(CreateUserRequest, "You must provide a CreateUserRequest")
 	local headers = {
@@ -10922,19 +10987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserSync(CreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserAsync(CreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserAsync(CreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchProfiles asynchronously, invoking a callback when done
 -- @param SearchProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchProfilesAsync(SearchProfilesRequest, cb)
 	assert(SearchProfilesRequest, "You must provide a SearchProfilesRequest")
 	local headers = {
@@ -10957,19 +11023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchProfilesSync(SearchProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchProfilesAsync(SearchProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchProfilesAsync(SearchProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConferencePreference asynchronously, invoking a callback when done
 -- @param GetConferencePreferenceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConferencePreferenceAsync(GetConferencePreferenceRequest, cb)
 	assert(GetConferencePreferenceRequest, "You must provide a GetConferencePreferenceRequest")
 	local headers = {
@@ -10992,19 +11059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConferencePreferenceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConferencePreferenceSync(GetConferencePreferenceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConferencePreferenceAsync(GetConferencePreferenceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConferencePreferenceAsync(GetConferencePreferenceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRoom asynchronously, invoking a callback when done
 -- @param CreateRoomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRoomAsync(CreateRoomRequest, cb)
 	assert(CreateRoomRequest, "You must provide a CreateRoomRequest")
 	local headers = {
@@ -11027,12 +11095,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRoomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRoomSync(CreateRoomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRoomAsync(CreateRoomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRoomAsync(CreateRoomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/acm-pca.lua
+++ b/aws-sdk/acm-pca.lua
@@ -2653,7 +2653,7 @@ end
 --
 --- Call RestoreCertificateAuthority asynchronously, invoking a callback when done
 -- @param RestoreCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreCertificateAuthorityAsync(RestoreCertificateAuthorityRequest, cb)
 	assert(RestoreCertificateAuthorityRequest, "You must provide a RestoreCertificateAuthorityRequest")
 	local headers = {
@@ -2676,19 +2676,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreCertificateAuthoritySync(RestoreCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreCertificateAuthorityAsync(RestoreCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreCertificateAuthorityAsync(RestoreCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCertificateAuthorities asynchronously, invoking a callback when done
 -- @param ListCertificateAuthoritiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCertificateAuthoritiesAsync(ListCertificateAuthoritiesRequest, cb)
 	assert(ListCertificateAuthoritiesRequest, "You must provide a ListCertificateAuthoritiesRequest")
 	local headers = {
@@ -2711,19 +2712,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCertificateAuthoritiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCertificateAuthoritiesSync(ListCertificateAuthoritiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCertificateAuthoritiesAsync(ListCertificateAuthoritiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCertificateAuthoritiesAsync(ListCertificateAuthoritiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -2746,19 +2748,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagCertificateAuthority asynchronously, invoking a callback when done
 -- @param UntagCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagCertificateAuthorityAsync(UntagCertificateAuthorityRequest, cb)
 	assert(UntagCertificateAuthorityRequest, "You must provide a UntagCertificateAuthorityRequest")
 	local headers = {
@@ -2781,19 +2784,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagCertificateAuthoritySync(UntagCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagCertificateAuthorityAsync(UntagCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagCertificateAuthorityAsync(UntagCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCertificateAuthority asynchronously, invoking a callback when done
 -- @param UpdateCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCertificateAuthorityAsync(UpdateCertificateAuthorityRequest, cb)
 	assert(UpdateCertificateAuthorityRequest, "You must provide a UpdateCertificateAuthorityRequest")
 	local headers = {
@@ -2816,19 +2820,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCertificateAuthoritySync(UpdateCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCertificateAuthorityAsync(UpdateCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCertificateAuthorityAsync(UpdateCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCertificateAuthorityCertificate asynchronously, invoking a callback when done
 -- @param GetCertificateAuthorityCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCertificateAuthorityCertificateAsync(GetCertificateAuthorityCertificateRequest, cb)
 	assert(GetCertificateAuthorityCertificateRequest, "You must provide a GetCertificateAuthorityCertificateRequest")
 	local headers = {
@@ -2851,19 +2856,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCertificateAuthorityCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCertificateAuthorityCertificateSync(GetCertificateAuthorityCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCertificateAuthorityCertificateAsync(GetCertificateAuthorityCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCertificateAuthorityCertificateAsync(GetCertificateAuthorityCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportCertificateAuthorityCertificate asynchronously, invoking a callback when done
 -- @param ImportCertificateAuthorityCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportCertificateAuthorityCertificateAsync(ImportCertificateAuthorityCertificateRequest, cb)
 	assert(ImportCertificateAuthorityCertificateRequest, "You must provide a ImportCertificateAuthorityCertificateRequest")
 	local headers = {
@@ -2886,19 +2892,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportCertificateAuthorityCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportCertificateAuthorityCertificateSync(ImportCertificateAuthorityCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportCertificateAuthorityCertificateAsync(ImportCertificateAuthorityCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportCertificateAuthorityCertificateAsync(ImportCertificateAuthorityCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call IssueCertificate asynchronously, invoking a callback when done
 -- @param IssueCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.IssueCertificateAsync(IssueCertificateRequest, cb)
 	assert(IssueCertificateRequest, "You must provide a IssueCertificateRequest")
 	local headers = {
@@ -2921,19 +2928,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IssueCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.IssueCertificateSync(IssueCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.IssueCertificateAsync(IssueCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.IssueCertificateAsync(IssueCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCertificate asynchronously, invoking a callback when done
 -- @param GetCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCertificateAsync(GetCertificateRequest, cb)
 	assert(GetCertificateRequest, "You must provide a GetCertificateRequest")
 	local headers = {
@@ -2956,19 +2964,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCertificateSync(GetCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCertificateAsync(GetCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCertificateAsync(GetCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagCertificateAuthority asynchronously, invoking a callback when done
 -- @param TagCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagCertificateAuthorityAsync(TagCertificateAuthorityRequest, cb)
 	assert(TagCertificateAuthorityRequest, "You must provide a TagCertificateAuthorityRequest")
 	local headers = {
@@ -2991,19 +3000,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagCertificateAuthoritySync(TagCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagCertificateAuthorityAsync(TagCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagCertificateAuthorityAsync(TagCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCertificateAuthorityAuditReport asynchronously, invoking a callback when done
 -- @param DescribeCertificateAuthorityAuditReportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCertificateAuthorityAuditReportAsync(DescribeCertificateAuthorityAuditReportRequest, cb)
 	assert(DescribeCertificateAuthorityAuditReportRequest, "You must provide a DescribeCertificateAuthorityAuditReportRequest")
 	local headers = {
@@ -3026,19 +3036,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCertificateAuthorityAuditReportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCertificateAuthorityAuditReportSync(DescribeCertificateAuthorityAuditReportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCertificateAuthorityAuditReportAsync(DescribeCertificateAuthorityAuditReportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCertificateAuthorityAuditReportAsync(DescribeCertificateAuthorityAuditReportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCertificateAuthority asynchronously, invoking a callback when done
 -- @param DescribeCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCertificateAuthorityAsync(DescribeCertificateAuthorityRequest, cb)
 	assert(DescribeCertificateAuthorityRequest, "You must provide a DescribeCertificateAuthorityRequest")
 	local headers = {
@@ -3061,19 +3072,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCertificateAuthoritySync(DescribeCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCertificateAuthorityAsync(DescribeCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCertificateAuthorityAsync(DescribeCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCertificateAuthorityCsr asynchronously, invoking a callback when done
 -- @param GetCertificateAuthorityCsrRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCertificateAuthorityCsrAsync(GetCertificateAuthorityCsrRequest, cb)
 	assert(GetCertificateAuthorityCsrRequest, "You must provide a GetCertificateAuthorityCsrRequest")
 	local headers = {
@@ -3096,19 +3108,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCertificateAuthorityCsrRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCertificateAuthorityCsrSync(GetCertificateAuthorityCsrRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCertificateAuthorityCsrAsync(GetCertificateAuthorityCsrRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCertificateAuthorityCsrAsync(GetCertificateAuthorityCsrRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCertificateAuthority asynchronously, invoking a callback when done
 -- @param CreateCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCertificateAuthorityAsync(CreateCertificateAuthorityRequest, cb)
 	assert(CreateCertificateAuthorityRequest, "You must provide a CreateCertificateAuthorityRequest")
 	local headers = {
@@ -3131,19 +3144,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCertificateAuthoritySync(CreateCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCertificateAuthorityAsync(CreateCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCertificateAuthorityAsync(CreateCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCertificateAuthority asynchronously, invoking a callback when done
 -- @param DeleteCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCertificateAuthorityAsync(DeleteCertificateAuthorityRequest, cb)
 	assert(DeleteCertificateAuthorityRequest, "You must provide a DeleteCertificateAuthorityRequest")
 	local headers = {
@@ -3166,19 +3180,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCertificateAuthoritySync(DeleteCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCertificateAuthorityAsync(DeleteCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCertificateAuthorityAsync(DeleteCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeCertificate asynchronously, invoking a callback when done
 -- @param RevokeCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeCertificateAsync(RevokeCertificateRequest, cb)
 	assert(RevokeCertificateRequest, "You must provide a RevokeCertificateRequest")
 	local headers = {
@@ -3201,19 +3216,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeCertificateSync(RevokeCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeCertificateAsync(RevokeCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeCertificateAsync(RevokeCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCertificateAuthorityAuditReport asynchronously, invoking a callback when done
 -- @param CreateCertificateAuthorityAuditReportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCertificateAuthorityAuditReportAsync(CreateCertificateAuthorityAuditReportRequest, cb)
 	assert(CreateCertificateAuthorityAuditReportRequest, "You must provide a CreateCertificateAuthorityAuditReportRequest")
 	local headers = {
@@ -3236,12 +3252,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCertificateAuthorityAuditReportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCertificateAuthorityAuditReportSync(CreateCertificateAuthorityAuditReportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCertificateAuthorityAuditReportAsync(CreateCertificateAuthorityAuditReportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCertificateAuthorityAuditReportAsync(CreateCertificateAuthorityAuditReportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/acm.lua
+++ b/aws-sdk/acm.lua
@@ -2290,7 +2290,7 @@ end
 --
 --- Call ResendValidationEmail asynchronously, invoking a callback when done
 -- @param ResendValidationEmailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResendValidationEmailAsync(ResendValidationEmailRequest, cb)
 	assert(ResendValidationEmailRequest, "You must provide a ResendValidationEmailRequest")
 	local headers = {
@@ -2313,19 +2313,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResendValidationEmailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResendValidationEmailSync(ResendValidationEmailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResendValidationEmailAsync(ResendValidationEmailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResendValidationEmailAsync(ResendValidationEmailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToCertificate asynchronously, invoking a callback when done
 -- @param AddTagsToCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToCertificateAsync(AddTagsToCertificateRequest, cb)
 	assert(AddTagsToCertificateRequest, "You must provide a AddTagsToCertificateRequest")
 	local headers = {
@@ -2348,19 +2349,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToCertificateSync(AddTagsToCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToCertificateAsync(AddTagsToCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToCertificateAsync(AddTagsToCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCertificates asynchronously, invoking a callback when done
 -- @param ListCertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCertificatesAsync(ListCertificatesRequest, cb)
 	assert(ListCertificatesRequest, "You must provide a ListCertificatesRequest")
 	local headers = {
@@ -2383,19 +2385,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCertificatesSync(ListCertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCertificatesAsync(ListCertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCertificatesAsync(ListCertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCertificateOptions asynchronously, invoking a callback when done
 -- @param UpdateCertificateOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCertificateOptionsAsync(UpdateCertificateOptionsRequest, cb)
 	assert(UpdateCertificateOptionsRequest, "You must provide a UpdateCertificateOptionsRequest")
 	local headers = {
@@ -2418,19 +2421,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCertificateOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCertificateOptionsSync(UpdateCertificateOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCertificateOptionsAsync(UpdateCertificateOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCertificateOptionsAsync(UpdateCertificateOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCertificate asynchronously, invoking a callback when done
 -- @param GetCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCertificateAsync(GetCertificateRequest, cb)
 	assert(GetCertificateRequest, "You must provide a GetCertificateRequest")
 	local headers = {
@@ -2453,19 +2457,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCertificateSync(GetCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCertificateAsync(GetCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCertificateAsync(GetCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForCertificate asynchronously, invoking a callback when done
 -- @param ListTagsForCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForCertificateAsync(ListTagsForCertificateRequest, cb)
 	assert(ListTagsForCertificateRequest, "You must provide a ListTagsForCertificateRequest")
 	local headers = {
@@ -2488,19 +2493,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForCertificateSync(ListTagsForCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForCertificateAsync(ListTagsForCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForCertificateAsync(ListTagsForCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromCertificate asynchronously, invoking a callback when done
 -- @param RemoveTagsFromCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromCertificateAsync(RemoveTagsFromCertificateRequest, cb)
 	assert(RemoveTagsFromCertificateRequest, "You must provide a RemoveTagsFromCertificateRequest")
 	local headers = {
@@ -2523,19 +2529,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromCertificateSync(RemoveTagsFromCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromCertificateAsync(RemoveTagsFromCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromCertificateAsync(RemoveTagsFromCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RequestCertificate asynchronously, invoking a callback when done
 -- @param RequestCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RequestCertificateAsync(RequestCertificateRequest, cb)
 	assert(RequestCertificateRequest, "You must provide a RequestCertificateRequest")
 	local headers = {
@@ -2558,19 +2565,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RequestCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RequestCertificateSync(RequestCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RequestCertificateAsync(RequestCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RequestCertificateAsync(RequestCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportCertificate asynchronously, invoking a callback when done
 -- @param ImportCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportCertificateAsync(ImportCertificateRequest, cb)
 	assert(ImportCertificateRequest, "You must provide a ImportCertificateRequest")
 	local headers = {
@@ -2593,19 +2601,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportCertificateSync(ImportCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportCertificateAsync(ImportCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportCertificateAsync(ImportCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCertificate asynchronously, invoking a callback when done
 -- @param DeleteCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCertificateAsync(DeleteCertificateRequest, cb)
 	assert(DeleteCertificateRequest, "You must provide a DeleteCertificateRequest")
 	local headers = {
@@ -2628,19 +2637,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCertificateSync(DeleteCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCertificateAsync(DeleteCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCertificateAsync(DeleteCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ExportCertificate asynchronously, invoking a callback when done
 -- @param ExportCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExportCertificateAsync(ExportCertificateRequest, cb)
 	assert(ExportCertificateRequest, "You must provide a ExportCertificateRequest")
 	local headers = {
@@ -2663,19 +2673,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExportCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExportCertificateSync(ExportCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExportCertificateAsync(ExportCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExportCertificateAsync(ExportCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCertificate asynchronously, invoking a callback when done
 -- @param DescribeCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCertificateAsync(DescribeCertificateRequest, cb)
 	assert(DescribeCertificateRequest, "You must provide a DescribeCertificateRequest")
 	local headers = {
@@ -2698,12 +2709,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCertificateSync(DescribeCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCertificateAsync(DescribeCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCertificateAsync(DescribeCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/api_mediatailor.lua
+++ b/aws-sdk/api_mediatailor.lua
@@ -668,7 +668,7 @@ end
 --
 --- Call GetPlaybackConfiguration asynchronously, invoking a callback when done
 -- @param GetPlaybackConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPlaybackConfigurationAsync(GetPlaybackConfigurationRequest, cb)
 	assert(GetPlaybackConfigurationRequest, "You must provide a GetPlaybackConfigurationRequest")
 	local headers = {
@@ -691,19 +691,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPlaybackConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPlaybackConfigurationSync(GetPlaybackConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPlaybackConfigurationAsync(GetPlaybackConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPlaybackConfigurationAsync(GetPlaybackConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPlaybackConfigurations asynchronously, invoking a callback when done
 -- @param ListPlaybackConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPlaybackConfigurationsAsync(ListPlaybackConfigurationsRequest, cb)
 	assert(ListPlaybackConfigurationsRequest, "You must provide a ListPlaybackConfigurationsRequest")
 	local headers = {
@@ -726,19 +727,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPlaybackConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPlaybackConfigurationsSync(ListPlaybackConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPlaybackConfigurationsAsync(ListPlaybackConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPlaybackConfigurationsAsync(ListPlaybackConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutPlaybackConfiguration asynchronously, invoking a callback when done
 -- @param PutPlaybackConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutPlaybackConfigurationAsync(PutPlaybackConfigurationRequest, cb)
 	assert(PutPlaybackConfigurationRequest, "You must provide a PutPlaybackConfigurationRequest")
 	local headers = {
@@ -761,19 +763,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutPlaybackConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutPlaybackConfigurationSync(PutPlaybackConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutPlaybackConfigurationAsync(PutPlaybackConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutPlaybackConfigurationAsync(PutPlaybackConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePlaybackConfiguration asynchronously, invoking a callback when done
 -- @param DeletePlaybackConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePlaybackConfigurationAsync(DeletePlaybackConfigurationRequest, cb)
 	assert(DeletePlaybackConfigurationRequest, "You must provide a DeletePlaybackConfigurationRequest")
 	local headers = {
@@ -796,12 +799,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePlaybackConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePlaybackConfigurationSync(DeletePlaybackConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePlaybackConfigurationAsync(DeletePlaybackConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePlaybackConfigurationAsync(DeletePlaybackConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/api_pricing.lua
+++ b/aws-sdk/api_pricing.lua
@@ -780,7 +780,7 @@ end
 --
 --- Call GetProducts asynchronously, invoking a callback when done
 -- @param GetProductsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetProductsAsync(GetProductsRequest, cb)
 	assert(GetProductsRequest, "You must provide a GetProductsRequest")
 	local headers = {
@@ -803,19 +803,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetProductsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetProductsSync(GetProductsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetProductsAsync(GetProductsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetProductsAsync(GetProductsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeServices asynchronously, invoking a callback when done
 -- @param DescribeServicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeServicesAsync(DescribeServicesRequest, cb)
 	assert(DescribeServicesRequest, "You must provide a DescribeServicesRequest")
 	local headers = {
@@ -838,19 +839,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeServicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeServicesSync(DescribeServicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeServicesAsync(DescribeServicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeServicesAsync(DescribeServicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAttributeValues asynchronously, invoking a callback when done
 -- @param GetAttributeValuesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAttributeValuesAsync(GetAttributeValuesRequest, cb)
 	assert(GetAttributeValuesRequest, "You must provide a GetAttributeValuesRequest")
 	local headers = {
@@ -873,12 +875,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAttributeValuesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAttributeValuesSync(GetAttributeValuesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAttributeValuesAsync(GetAttributeValuesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAttributeValuesAsync(GetAttributeValuesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/api_sagemaker.lua
+++ b/aws-sdk/api_sagemaker.lua
@@ -7617,7 +7617,7 @@ end
 --
 --- Call DeleteTags asynchronously, invoking a callback when done
 -- @param DeleteTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsAsync(DeleteTagsInput, cb)
 	assert(DeleteTagsInput, "You must provide a DeleteTagsInput")
 	local headers = {
@@ -7640,19 +7640,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsSync(DeleteTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsAsync(DeleteTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsAsync(DeleteTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTransformJobs asynchronously, invoking a callback when done
 -- @param ListTransformJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTransformJobsAsync(ListTransformJobsRequest, cb)
 	assert(ListTransformJobsRequest, "You must provide a ListTransformJobsRequest")
 	local headers = {
@@ -7675,19 +7676,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTransformJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTransformJobsSync(ListTransformJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTransformJobsAsync(ListTransformJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTransformJobsAsync(ListTransformJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeModel asynchronously, invoking a callback when done
 -- @param DescribeModelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeModelAsync(DescribeModelInput, cb)
 	assert(DescribeModelInput, "You must provide a DescribeModelInput")
 	local headers = {
@@ -7710,19 +7712,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeModelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeModelSync(DescribeModelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeModelAsync(DescribeModelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeModelAsync(DescribeModelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateNotebookInstance asynchronously, invoking a callback when done
 -- @param UpdateNotebookInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateNotebookInstanceAsync(UpdateNotebookInstanceInput, cb)
 	assert(UpdateNotebookInstanceInput, "You must provide a UpdateNotebookInstanceInput")
 	local headers = {
@@ -7745,19 +7748,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateNotebookInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateNotebookInstanceSync(UpdateNotebookInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateNotebookInstanceAsync(UpdateNotebookInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateNotebookInstanceAsync(UpdateNotebookInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEndpointConfig asynchronously, invoking a callback when done
 -- @param DeleteEndpointConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEndpointConfigAsync(DeleteEndpointConfigInput, cb)
 	assert(DeleteEndpointConfigInput, "You must provide a DeleteEndpointConfigInput")
 	local headers = {
@@ -7780,19 +7784,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEndpointConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEndpointConfigSync(DeleteEndpointConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEndpointConfigAsync(DeleteEndpointConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEndpointConfigAsync(DeleteEndpointConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHyperParameterTuningJobs asynchronously, invoking a callback when done
 -- @param ListHyperParameterTuningJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHyperParameterTuningJobsAsync(ListHyperParameterTuningJobsRequest, cb)
 	assert(ListHyperParameterTuningJobsRequest, "You must provide a ListHyperParameterTuningJobsRequest")
 	local headers = {
@@ -7815,19 +7820,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHyperParameterTuningJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHyperParameterTuningJobsSync(ListHyperParameterTuningJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHyperParameterTuningJobsAsync(ListHyperParameterTuningJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHyperParameterTuningJobsAsync(ListHyperParameterTuningJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTransformJob asynchronously, invoking a callback when done
 -- @param CreateTransformJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTransformJobAsync(CreateTransformJobRequest, cb)
 	assert(CreateTransformJobRequest, "You must provide a CreateTransformJobRequest")
 	local headers = {
@@ -7850,19 +7856,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTransformJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTransformJobSync(CreateTransformJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTransformJobAsync(CreateTransformJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTransformJobAsync(CreateTransformJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNotebookInstanceLifecycleConfig asynchronously, invoking a callback when done
 -- @param DeleteNotebookInstanceLifecycleConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNotebookInstanceLifecycleConfigAsync(DeleteNotebookInstanceLifecycleConfigInput, cb)
 	assert(DeleteNotebookInstanceLifecycleConfigInput, "You must provide a DeleteNotebookInstanceLifecycleConfigInput")
 	local headers = {
@@ -7885,19 +7892,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNotebookInstanceLifecycleConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNotebookInstanceLifecycleConfigSync(DeleteNotebookInstanceLifecycleConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNotebookInstanceLifecycleConfigAsync(DeleteNotebookInstanceLifecycleConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNotebookInstanceLifecycleConfigAsync(DeleteNotebookInstanceLifecycleConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEndpointConfig asynchronously, invoking a callback when done
 -- @param CreateEndpointConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEndpointConfigAsync(CreateEndpointConfigInput, cb)
 	assert(CreateEndpointConfigInput, "You must provide a CreateEndpointConfigInput")
 	local headers = {
@@ -7920,19 +7928,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEndpointConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEndpointConfigSync(CreateEndpointConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEndpointConfigAsync(CreateEndpointConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEndpointConfigAsync(CreateEndpointConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTrainingJobs asynchronously, invoking a callback when done
 -- @param ListTrainingJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTrainingJobsAsync(ListTrainingJobsRequest, cb)
 	assert(ListTrainingJobsRequest, "You must provide a ListTrainingJobsRequest")
 	local headers = {
@@ -7955,19 +7964,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTrainingJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTrainingJobsSync(ListTrainingJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTrainingJobsAsync(ListTrainingJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTrainingJobsAsync(ListTrainingJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartNotebookInstance asynchronously, invoking a callback when done
 -- @param StartNotebookInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartNotebookInstanceAsync(StartNotebookInstanceInput, cb)
 	assert(StartNotebookInstanceInput, "You must provide a StartNotebookInstanceInput")
 	local headers = {
@@ -7990,19 +8000,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartNotebookInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartNotebookInstanceSync(StartNotebookInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartNotebookInstanceAsync(StartNotebookInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartNotebookInstanceAsync(StartNotebookInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNotebookInstance asynchronously, invoking a callback when done
 -- @param DeleteNotebookInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNotebookInstanceAsync(DeleteNotebookInstanceInput, cb)
 	assert(DeleteNotebookInstanceInput, "You must provide a DeleteNotebookInstanceInput")
 	local headers = {
@@ -8025,19 +8036,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNotebookInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNotebookInstanceSync(DeleteNotebookInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNotebookInstanceAsync(DeleteNotebookInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNotebookInstanceAsync(DeleteNotebookInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNotebookInstanceLifecycleConfig asynchronously, invoking a callback when done
 -- @param CreateNotebookInstanceLifecycleConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNotebookInstanceLifecycleConfigAsync(CreateNotebookInstanceLifecycleConfigInput, cb)
 	assert(CreateNotebookInstanceLifecycleConfigInput, "You must provide a CreateNotebookInstanceLifecycleConfigInput")
 	local headers = {
@@ -8060,19 +8072,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNotebookInstanceLifecycleConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNotebookInstanceLifecycleConfigSync(CreateNotebookInstanceLifecycleConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNotebookInstanceLifecycleConfigAsync(CreateNotebookInstanceLifecycleConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNotebookInstanceLifecycleConfigAsync(CreateNotebookInstanceLifecycleConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTrainingJobsForHyperParameterTuningJob asynchronously, invoking a callback when done
 -- @param ListTrainingJobsForHyperParameterTuningJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTrainingJobsForHyperParameterTuningJobAsync(ListTrainingJobsForHyperParameterTuningJobRequest, cb)
 	assert(ListTrainingJobsForHyperParameterTuningJobRequest, "You must provide a ListTrainingJobsForHyperParameterTuningJobRequest")
 	local headers = {
@@ -8095,19 +8108,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTrainingJobsForHyperParameterTuningJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTrainingJobsForHyperParameterTuningJobSync(ListTrainingJobsForHyperParameterTuningJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTrainingJobsForHyperParameterTuningJobAsync(ListTrainingJobsForHyperParameterTuningJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTrainingJobsForHyperParameterTuningJobAsync(ListTrainingJobsForHyperParameterTuningJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateNotebookInstanceLifecycleConfig asynchronously, invoking a callback when done
 -- @param UpdateNotebookInstanceLifecycleConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateNotebookInstanceLifecycleConfigAsync(UpdateNotebookInstanceLifecycleConfigInput, cb)
 	assert(UpdateNotebookInstanceLifecycleConfigInput, "You must provide a UpdateNotebookInstanceLifecycleConfigInput")
 	local headers = {
@@ -8130,19 +8144,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateNotebookInstanceLifecycleConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateNotebookInstanceLifecycleConfigSync(UpdateNotebookInstanceLifecycleConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateNotebookInstanceLifecycleConfigAsync(UpdateNotebookInstanceLifecycleConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateNotebookInstanceLifecycleConfigAsync(UpdateNotebookInstanceLifecycleConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePresignedNotebookInstanceUrl asynchronously, invoking a callback when done
 -- @param CreatePresignedNotebookInstanceUrlInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePresignedNotebookInstanceUrlAsync(CreatePresignedNotebookInstanceUrlInput, cb)
 	assert(CreatePresignedNotebookInstanceUrlInput, "You must provide a CreatePresignedNotebookInstanceUrlInput")
 	local headers = {
@@ -8165,19 +8180,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePresignedNotebookInstanceUrlInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePresignedNotebookInstanceUrlSync(CreatePresignedNotebookInstanceUrlInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePresignedNotebookInstanceUrlAsync(CreatePresignedNotebookInstanceUrlInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePresignedNotebookInstanceUrlAsync(CreatePresignedNotebookInstanceUrlInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListNotebookInstances asynchronously, invoking a callback when done
 -- @param ListNotebookInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListNotebookInstancesAsync(ListNotebookInstancesInput, cb)
 	assert(ListNotebookInstancesInput, "You must provide a ListNotebookInstancesInput")
 	local headers = {
@@ -8200,19 +8216,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListNotebookInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListNotebookInstancesSync(ListNotebookInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListNotebookInstancesAsync(ListNotebookInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListNotebookInstancesAsync(ListNotebookInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEndpoint asynchronously, invoking a callback when done
 -- @param CreateEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEndpointAsync(CreateEndpointInput, cb)
 	assert(CreateEndpointInput, "You must provide a CreateEndpointInput")
 	local headers = {
@@ -8235,19 +8252,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEndpointSync(CreateEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEndpointAsync(CreateEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEndpointAsync(CreateEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEndpoint asynchronously, invoking a callback when done
 -- @param DescribeEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEndpointAsync(DescribeEndpointInput, cb)
 	assert(DescribeEndpointInput, "You must provide a DescribeEndpointInput")
 	local headers = {
@@ -8270,19 +8288,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEndpointSync(DescribeEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEndpointAsync(DescribeEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEndpointAsync(DescribeEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListNotebookInstanceLifecycleConfigs asynchronously, invoking a callback when done
 -- @param ListNotebookInstanceLifecycleConfigsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListNotebookInstanceLifecycleConfigsAsync(ListNotebookInstanceLifecycleConfigsInput, cb)
 	assert(ListNotebookInstanceLifecycleConfigsInput, "You must provide a ListNotebookInstanceLifecycleConfigsInput")
 	local headers = {
@@ -8305,19 +8324,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListNotebookInstanceLifecycleConfigsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListNotebookInstanceLifecycleConfigsSync(ListNotebookInstanceLifecycleConfigsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListNotebookInstanceLifecycleConfigsAsync(ListNotebookInstanceLifecycleConfigsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListNotebookInstanceLifecycleConfigsAsync(ListNotebookInstanceLifecycleConfigsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTrainingJob asynchronously, invoking a callback when done
 -- @param DescribeTrainingJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTrainingJobAsync(DescribeTrainingJobRequest, cb)
 	assert(DescribeTrainingJobRequest, "You must provide a DescribeTrainingJobRequest")
 	local headers = {
@@ -8340,19 +8360,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTrainingJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTrainingJobSync(DescribeTrainingJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTrainingJobAsync(DescribeTrainingJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTrainingJobAsync(DescribeTrainingJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopNotebookInstance asynchronously, invoking a callback when done
 -- @param StopNotebookInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopNotebookInstanceAsync(StopNotebookInstanceInput, cb)
 	assert(StopNotebookInstanceInput, "You must provide a StopNotebookInstanceInput")
 	local headers = {
@@ -8375,19 +8396,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopNotebookInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopNotebookInstanceSync(StopNotebookInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopNotebookInstanceAsync(StopNotebookInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopNotebookInstanceAsync(StopNotebookInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHyperParameterTuningJob asynchronously, invoking a callback when done
 -- @param DescribeHyperParameterTuningJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHyperParameterTuningJobAsync(DescribeHyperParameterTuningJobRequest, cb)
 	assert(DescribeHyperParameterTuningJobRequest, "You must provide a DescribeHyperParameterTuningJobRequest")
 	local headers = {
@@ -8410,19 +8432,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHyperParameterTuningJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHyperParameterTuningJobSync(DescribeHyperParameterTuningJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHyperParameterTuningJobAsync(DescribeHyperParameterTuningJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHyperParameterTuningJobAsync(DescribeHyperParameterTuningJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTransformJob asynchronously, invoking a callback when done
 -- @param DescribeTransformJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTransformJobAsync(DescribeTransformJobRequest, cb)
 	assert(DescribeTransformJobRequest, "You must provide a DescribeTransformJobRequest")
 	local headers = {
@@ -8445,19 +8468,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTransformJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTransformJobSync(DescribeTransformJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTransformJobAsync(DescribeTransformJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTransformJobAsync(DescribeTransformJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListModels asynchronously, invoking a callback when done
 -- @param ListModelsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListModelsAsync(ListModelsInput, cb)
 	assert(ListModelsInput, "You must provide a ListModelsInput")
 	local headers = {
@@ -8480,19 +8504,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListModelsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListModelsSync(ListModelsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListModelsAsync(ListModelsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListModelsAsync(ListModelsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNotebookInstance asynchronously, invoking a callback when done
 -- @param CreateNotebookInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNotebookInstanceAsync(CreateNotebookInstanceInput, cb)
 	assert(CreateNotebookInstanceInput, "You must provide a CreateNotebookInstanceInput")
 	local headers = {
@@ -8515,19 +8540,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNotebookInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNotebookInstanceSync(CreateNotebookInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNotebookInstanceAsync(CreateNotebookInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNotebookInstanceAsync(CreateNotebookInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEndpoint asynchronously, invoking a callback when done
 -- @param DeleteEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEndpointAsync(DeleteEndpointInput, cb)
 	assert(DeleteEndpointInput, "You must provide a DeleteEndpointInput")
 	local headers = {
@@ -8550,19 +8576,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEndpointSync(DeleteEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEndpointAsync(DeleteEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEndpointAsync(DeleteEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsInput, cb)
 	assert(ListTagsInput, "You must provide a ListTagsInput")
 	local headers = {
@@ -8585,19 +8612,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEndpointConfig asynchronously, invoking a callback when done
 -- @param DescribeEndpointConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEndpointConfigAsync(DescribeEndpointConfigInput, cb)
 	assert(DescribeEndpointConfigInput, "You must provide a DescribeEndpointConfigInput")
 	local headers = {
@@ -8620,19 +8648,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEndpointConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEndpointConfigSync(DescribeEndpointConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEndpointConfigAsync(DescribeEndpointConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEndpointConfigAsync(DescribeEndpointConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateModel asynchronously, invoking a callback when done
 -- @param CreateModelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateModelAsync(CreateModelInput, cb)
 	assert(CreateModelInput, "You must provide a CreateModelInput")
 	local headers = {
@@ -8655,19 +8684,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateModelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateModelSync(CreateModelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateModelAsync(CreateModelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateModelAsync(CreateModelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHyperParameterTuningJob asynchronously, invoking a callback when done
 -- @param CreateHyperParameterTuningJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHyperParameterTuningJobAsync(CreateHyperParameterTuningJobRequest, cb)
 	assert(CreateHyperParameterTuningJobRequest, "You must provide a CreateHyperParameterTuningJobRequest")
 	local headers = {
@@ -8690,19 +8720,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHyperParameterTuningJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHyperParameterTuningJobSync(CreateHyperParameterTuningJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHyperParameterTuningJobAsync(CreateHyperParameterTuningJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHyperParameterTuningJobAsync(CreateHyperParameterTuningJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTags asynchronously, invoking a callback when done
 -- @param AddTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsAsync(AddTagsInput, cb)
 	assert(AddTagsInput, "You must provide a AddTagsInput")
 	local headers = {
@@ -8725,19 +8756,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsSync(AddTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsAsync(AddTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsAsync(AddTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNotebookInstanceLifecycleConfig asynchronously, invoking a callback when done
 -- @param DescribeNotebookInstanceLifecycleConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNotebookInstanceLifecycleConfigAsync(DescribeNotebookInstanceLifecycleConfigInput, cb)
 	assert(DescribeNotebookInstanceLifecycleConfigInput, "You must provide a DescribeNotebookInstanceLifecycleConfigInput")
 	local headers = {
@@ -8760,19 +8792,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNotebookInstanceLifecycleConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNotebookInstanceLifecycleConfigSync(DescribeNotebookInstanceLifecycleConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNotebookInstanceLifecycleConfigAsync(DescribeNotebookInstanceLifecycleConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNotebookInstanceLifecycleConfigAsync(DescribeNotebookInstanceLifecycleConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListEndpoints asynchronously, invoking a callback when done
 -- @param ListEndpointsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEndpointsAsync(ListEndpointsInput, cb)
 	assert(ListEndpointsInput, "You must provide a ListEndpointsInput")
 	local headers = {
@@ -8795,19 +8828,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEndpointsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEndpointsSync(ListEndpointsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEndpointsAsync(ListEndpointsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEndpointsAsync(ListEndpointsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListEndpointConfigs asynchronously, invoking a callback when done
 -- @param ListEndpointConfigsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEndpointConfigsAsync(ListEndpointConfigsInput, cb)
 	assert(ListEndpointConfigsInput, "You must provide a ListEndpointConfigsInput")
 	local headers = {
@@ -8830,19 +8864,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEndpointConfigsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEndpointConfigsSync(ListEndpointConfigsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEndpointConfigsAsync(ListEndpointConfigsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEndpointConfigsAsync(ListEndpointConfigsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNotebookInstance asynchronously, invoking a callback when done
 -- @param DescribeNotebookInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNotebookInstanceAsync(DescribeNotebookInstanceInput, cb)
 	assert(DescribeNotebookInstanceInput, "You must provide a DescribeNotebookInstanceInput")
 	local headers = {
@@ -8865,19 +8900,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNotebookInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNotebookInstanceSync(DescribeNotebookInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNotebookInstanceAsync(DescribeNotebookInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNotebookInstanceAsync(DescribeNotebookInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopHyperParameterTuningJob asynchronously, invoking a callback when done
 -- @param StopHyperParameterTuningJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopHyperParameterTuningJobAsync(StopHyperParameterTuningJobRequest, cb)
 	assert(StopHyperParameterTuningJobRequest, "You must provide a StopHyperParameterTuningJobRequest")
 	local headers = {
@@ -8900,19 +8936,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopHyperParameterTuningJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopHyperParameterTuningJobSync(StopHyperParameterTuningJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopHyperParameterTuningJobAsync(StopHyperParameterTuningJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopHyperParameterTuningJobAsync(StopHyperParameterTuningJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEndpoint asynchronously, invoking a callback when done
 -- @param UpdateEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEndpointAsync(UpdateEndpointInput, cb)
 	assert(UpdateEndpointInput, "You must provide a UpdateEndpointInput")
 	local headers = {
@@ -8935,19 +8972,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEndpointSync(UpdateEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEndpointAsync(UpdateEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEndpointAsync(UpdateEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteModel asynchronously, invoking a callback when done
 -- @param DeleteModelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteModelAsync(DeleteModelInput, cb)
 	assert(DeleteModelInput, "You must provide a DeleteModelInput")
 	local headers = {
@@ -8970,19 +9008,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteModelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteModelSync(DeleteModelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteModelAsync(DeleteModelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteModelAsync(DeleteModelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTrainingJob asynchronously, invoking a callback when done
 -- @param CreateTrainingJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTrainingJobAsync(CreateTrainingJobRequest, cb)
 	assert(CreateTrainingJobRequest, "You must provide a CreateTrainingJobRequest")
 	local headers = {
@@ -9005,19 +9044,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTrainingJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTrainingJobSync(CreateTrainingJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTrainingJobAsync(CreateTrainingJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTrainingJobAsync(CreateTrainingJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEndpointWeightsAndCapacities asynchronously, invoking a callback when done
 -- @param UpdateEndpointWeightsAndCapacitiesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEndpointWeightsAndCapacitiesAsync(UpdateEndpointWeightsAndCapacitiesInput, cb)
 	assert(UpdateEndpointWeightsAndCapacitiesInput, "You must provide a UpdateEndpointWeightsAndCapacitiesInput")
 	local headers = {
@@ -9040,19 +9080,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEndpointWeightsAndCapacitiesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEndpointWeightsAndCapacitiesSync(UpdateEndpointWeightsAndCapacitiesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEndpointWeightsAndCapacitiesAsync(UpdateEndpointWeightsAndCapacitiesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEndpointWeightsAndCapacitiesAsync(UpdateEndpointWeightsAndCapacitiesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopTrainingJob asynchronously, invoking a callback when done
 -- @param StopTrainingJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopTrainingJobAsync(StopTrainingJobRequest, cb)
 	assert(StopTrainingJobRequest, "You must provide a StopTrainingJobRequest")
 	local headers = {
@@ -9075,19 +9116,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopTrainingJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopTrainingJobSync(StopTrainingJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopTrainingJobAsync(StopTrainingJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopTrainingJobAsync(StopTrainingJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopTransformJob asynchronously, invoking a callback when done
 -- @param StopTransformJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopTransformJobAsync(StopTransformJobRequest, cb)
 	assert(StopTransformJobRequest, "You must provide a StopTransformJobRequest")
 	local headers = {
@@ -9110,12 +9152,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopTransformJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopTransformJobSync(StopTransformJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopTransformJobAsync(StopTransformJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopTransformJobAsync(StopTransformJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/apigateway.lua
+++ b/aws-sdk/apigateway.lua
@@ -9865,7 +9865,7 @@ end
 --
 --- Call GetGatewayResponses asynchronously, invoking a callback when done
 -- @param GetGatewayResponsesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGatewayResponsesAsync(GetGatewayResponsesRequest, cb)
 	assert(GetGatewayResponsesRequest, "You must provide a GetGatewayResponsesRequest")
 	local headers = {
@@ -9888,19 +9888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGatewayResponsesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGatewayResponsesSync(GetGatewayResponsesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGatewayResponsesAsync(GetGatewayResponsesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGatewayResponsesAsync(GetGatewayResponsesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportDocumentationParts asynchronously, invoking a callback when done
 -- @param ImportDocumentationPartsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportDocumentationPartsAsync(ImportDocumentationPartsRequest, cb)
 	assert(ImportDocumentationPartsRequest, "You must provide a ImportDocumentationPartsRequest")
 	local headers = {
@@ -9923,19 +9924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportDocumentationPartsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportDocumentationPartsSync(ImportDocumentationPartsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportDocumentationPartsAsync(ImportDocumentationPartsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportDocumentationPartsAsync(ImportDocumentationPartsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAuthorizer asynchronously, invoking a callback when done
 -- @param DeleteAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAuthorizerAsync(DeleteAuthorizerRequest, cb)
 	assert(DeleteAuthorizerRequest, "You must provide a DeleteAuthorizerRequest")
 	local headers = {
@@ -9958,19 +9960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAuthorizerSync(DeleteAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAuthorizerAsync(DeleteAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAuthorizerAsync(DeleteAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateModel asynchronously, invoking a callback when done
 -- @param UpdateModelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateModelAsync(UpdateModelRequest, cb)
 	assert(UpdateModelRequest, "You must provide a UpdateModelRequest")
 	local headers = {
@@ -9993,19 +9996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateModelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateModelSync(UpdateModelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateModelAsync(UpdateModelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateModelAsync(UpdateModelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeployment asynchronously, invoking a callback when done
 -- @param CreateDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeploymentAsync(CreateDeploymentRequest, cb)
 	assert(CreateDeploymentRequest, "You must provide a CreateDeploymentRequest")
 	local headers = {
@@ -10028,19 +10032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeploymentSync(CreateDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeploymentAsync(CreateDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeploymentAsync(CreateDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRestApi asynchronously, invoking a callback when done
 -- @param GetRestApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRestApiAsync(GetRestApiRequest, cb)
 	assert(GetRestApiRequest, "You must provide a GetRestApiRequest")
 	local headers = {
@@ -10063,19 +10068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRestApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRestApiSync(GetRestApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRestApiAsync(GetRestApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRestApiAsync(GetRestApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRequestValidator asynchronously, invoking a callback when done
 -- @param UpdateRequestValidatorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRequestValidatorAsync(UpdateRequestValidatorRequest, cb)
 	assert(UpdateRequestValidatorRequest, "You must provide a UpdateRequestValidatorRequest")
 	local headers = {
@@ -10098,19 +10104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRequestValidatorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRequestValidatorSync(UpdateRequestValidatorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRequestValidatorAsync(UpdateRequestValidatorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRequestValidatorAsync(UpdateRequestValidatorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGatewayResponse asynchronously, invoking a callback when done
 -- @param GetGatewayResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGatewayResponseAsync(GetGatewayResponseRequest, cb)
 	assert(GetGatewayResponseRequest, "You must provide a GetGatewayResponseRequest")
 	local headers = {
@@ -10133,19 +10140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGatewayResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGatewayResponseSync(GetGatewayResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGatewayResponseAsync(GetGatewayResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGatewayResponseAsync(GetGatewayResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteClientCertificate asynchronously, invoking a callback when done
 -- @param DeleteClientCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClientCertificateAsync(DeleteClientCertificateRequest, cb)
 	assert(DeleteClientCertificateRequest, "You must provide a DeleteClientCertificateRequest")
 	local headers = {
@@ -10168,19 +10176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClientCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClientCertificateSync(DeleteClientCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClientCertificateAsync(DeleteClientCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClientCertificateAsync(DeleteClientCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAuthorizer asynchronously, invoking a callback when done
 -- @param GetAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAuthorizerAsync(GetAuthorizerRequest, cb)
 	assert(GetAuthorizerRequest, "You must provide a GetAuthorizerRequest")
 	local headers = {
@@ -10203,19 +10212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAuthorizerSync(GetAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAuthorizerAsync(GetAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAuthorizerAsync(GetAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetModels asynchronously, invoking a callback when done
 -- @param GetModelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetModelsAsync(GetModelsRequest, cb)
 	assert(GetModelsRequest, "You must provide a GetModelsRequest")
 	local headers = {
@@ -10238,19 +10248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetModelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetModelsSync(GetModelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetModelsAsync(GetModelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetModelsAsync(GetModelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GenerateClientCertificate asynchronously, invoking a callback when done
 -- @param GenerateClientCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GenerateClientCertificateAsync(GenerateClientCertificateRequest, cb)
 	assert(GenerateClientCertificateRequest, "You must provide a GenerateClientCertificateRequest")
 	local headers = {
@@ -10273,19 +10284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GenerateClientCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GenerateClientCertificateSync(GenerateClientCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GenerateClientCertificateAsync(GenerateClientCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GenerateClientCertificateAsync(GenerateClientCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutGatewayResponse asynchronously, invoking a callback when done
 -- @param PutGatewayResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutGatewayResponseAsync(PutGatewayResponseRequest, cb)
 	assert(PutGatewayResponseRequest, "You must provide a PutGatewayResponseRequest")
 	local headers = {
@@ -10308,19 +10320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutGatewayResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutGatewayResponseSync(PutGatewayResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutGatewayResponseAsync(PutGatewayResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutGatewayResponseAsync(PutGatewayResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRestApi asynchronously, invoking a callback when done
 -- @param DeleteRestApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRestApiAsync(DeleteRestApiRequest, cb)
 	assert(DeleteRestApiRequest, "You must provide a DeleteRestApiRequest")
 	local headers = {
@@ -10343,19 +10356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRestApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRestApiSync(DeleteRestApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRestApiAsync(DeleteRestApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRestApiAsync(DeleteRestApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMethod asynchronously, invoking a callback when done
 -- @param GetMethodRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMethodAsync(GetMethodRequest, cb)
 	assert(GetMethodRequest, "You must provide a GetMethodRequest")
 	local headers = {
@@ -10378,19 +10392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMethodRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMethodSync(GetMethodRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMethodAsync(GetMethodRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMethodAsync(GetMethodRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSdkTypes asynchronously, invoking a callback when done
 -- @param GetSdkTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSdkTypesAsync(GetSdkTypesRequest, cb)
 	assert(GetSdkTypesRequest, "You must provide a GetSdkTypesRequest")
 	local headers = {
@@ -10413,19 +10428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSdkTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSdkTypesSync(GetSdkTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSdkTypesAsync(GetSdkTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSdkTypesAsync(GetSdkTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDocumentationVersion asynchronously, invoking a callback when done
 -- @param UpdateDocumentationVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDocumentationVersionAsync(UpdateDocumentationVersionRequest, cb)
 	assert(UpdateDocumentationVersionRequest, "You must provide a UpdateDocumentationVersionRequest")
 	local headers = {
@@ -10448,19 +10464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDocumentationVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDocumentationVersionSync(UpdateDocumentationVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDocumentationVersionAsync(UpdateDocumentationVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDocumentationVersionAsync(UpdateDocumentationVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateModel asynchronously, invoking a callback when done
 -- @param CreateModelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateModelAsync(CreateModelRequest, cb)
 	assert(CreateModelRequest, "You must provide a CreateModelRequest")
 	local headers = {
@@ -10483,19 +10500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateModelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateModelSync(CreateModelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateModelAsync(CreateModelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateModelAsync(CreateModelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call FlushStageCache asynchronously, invoking a callback when done
 -- @param FlushStageCacheRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.FlushStageCacheAsync(FlushStageCacheRequest, cb)
 	assert(FlushStageCacheRequest, "You must provide a FlushStageCacheRequest")
 	local headers = {
@@ -10518,19 +10536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param FlushStageCacheRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.FlushStageCacheSync(FlushStageCacheRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.FlushStageCacheAsync(FlushStageCacheRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.FlushStageCacheAsync(FlushStageCacheRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUsagePlanKey asynchronously, invoking a callback when done
 -- @param CreateUsagePlanKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUsagePlanKeyAsync(CreateUsagePlanKeyRequest, cb)
 	assert(CreateUsagePlanKeyRequest, "You must provide a CreateUsagePlanKeyRequest")
 	local headers = {
@@ -10553,19 +10572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUsagePlanKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUsagePlanKeySync(CreateUsagePlanKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUsagePlanKeyAsync(CreateUsagePlanKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUsagePlanKeyAsync(CreateUsagePlanKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUsagePlanKey asynchronously, invoking a callback when done
 -- @param GetUsagePlanKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUsagePlanKeyAsync(GetUsagePlanKeyRequest, cb)
 	assert(GetUsagePlanKeyRequest, "You must provide a GetUsagePlanKeyRequest")
 	local headers = {
@@ -10588,19 +10608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUsagePlanKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUsagePlanKeySync(GetUsagePlanKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUsagePlanKeyAsync(GetUsagePlanKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUsagePlanKeyAsync(GetUsagePlanKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIntegration asynchronously, invoking a callback when done
 -- @param DeleteIntegrationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIntegrationAsync(DeleteIntegrationRequest, cb)
 	assert(DeleteIntegrationRequest, "You must provide a DeleteIntegrationRequest")
 	local headers = {
@@ -10623,19 +10644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIntegrationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIntegrationSync(DeleteIntegrationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIntegrationAsync(DeleteIntegrationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIntegrationAsync(DeleteIntegrationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMethodResponse asynchronously, invoking a callback when done
 -- @param GetMethodResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMethodResponseAsync(GetMethodResponseRequest, cb)
 	assert(GetMethodResponseRequest, "You must provide a GetMethodResponseRequest")
 	local headers = {
@@ -10658,19 +10680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMethodResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMethodResponseSync(GetMethodResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMethodResponseAsync(GetMethodResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMethodResponseAsync(GetMethodResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutMethodResponse asynchronously, invoking a callback when done
 -- @param PutMethodResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutMethodResponseAsync(PutMethodResponseRequest, cb)
 	assert(PutMethodResponseRequest, "You must provide a PutMethodResponseRequest")
 	local headers = {
@@ -10693,19 +10716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutMethodResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutMethodResponseSync(PutMethodResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutMethodResponseAsync(PutMethodResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutMethodResponseAsync(PutMethodResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteModel asynchronously, invoking a callback when done
 -- @param DeleteModelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteModelAsync(DeleteModelRequest, cb)
 	assert(DeleteModelRequest, "You must provide a DeleteModelRequest")
 	local headers = {
@@ -10728,19 +10752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteModelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteModelSync(DeleteModelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteModelAsync(DeleteModelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteModelAsync(DeleteModelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStage asynchronously, invoking a callback when done
 -- @param GetStageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStageAsync(GetStageRequest, cb)
 	assert(GetStageRequest, "You must provide a GetStageRequest")
 	local headers = {
@@ -10763,19 +10788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStageSync(GetStageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStageAsync(GetStageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStageAsync(GetStageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStages asynchronously, invoking a callback when done
 -- @param GetStagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStagesAsync(GetStagesRequest, cb)
 	assert(GetStagesRequest, "You must provide a GetStagesRequest")
 	local headers = {
@@ -10798,19 +10824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStagesSync(GetStagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStagesAsync(GetStagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStagesAsync(GetStagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDocumentationVersion asynchronously, invoking a callback when done
 -- @param DeleteDocumentationVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDocumentationVersionAsync(DeleteDocumentationVersionRequest, cb)
 	assert(DeleteDocumentationVersionRequest, "You must provide a DeleteDocumentationVersionRequest")
 	local headers = {
@@ -10833,19 +10860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDocumentationVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDocumentationVersionSync(DeleteDocumentationVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDocumentationVersionAsync(DeleteDocumentationVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDocumentationVersionAsync(DeleteDocumentationVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIntegration asynchronously, invoking a callback when done
 -- @param UpdateIntegrationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIntegrationAsync(UpdateIntegrationRequest, cb)
 	assert(UpdateIntegrationRequest, "You must provide a UpdateIntegrationRequest")
 	local headers = {
@@ -10868,19 +10896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateIntegrationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIntegrationSync(UpdateIntegrationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIntegrationAsync(UpdateIntegrationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIntegrationAsync(UpdateIntegrationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUsagePlan asynchronously, invoking a callback when done
 -- @param DeleteUsagePlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUsagePlanAsync(DeleteUsagePlanRequest, cb)
 	assert(DeleteUsagePlanRequest, "You must provide a DeleteUsagePlanRequest")
 	local headers = {
@@ -10903,19 +10932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUsagePlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUsagePlanSync(DeleteUsagePlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUsagePlanAsync(DeleteUsagePlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUsagePlanAsync(DeleteUsagePlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDomainNames asynchronously, invoking a callback when done
 -- @param GetDomainNamesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDomainNamesAsync(GetDomainNamesRequest, cb)
 	assert(GetDomainNamesRequest, "You must provide a GetDomainNamesRequest")
 	local headers = {
@@ -10938,19 +10968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDomainNamesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDomainNamesSync(GetDomainNamesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDomainNamesAsync(GetDomainNamesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDomainNamesAsync(GetDomainNamesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDocumentationPart asynchronously, invoking a callback when done
 -- @param UpdateDocumentationPartRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDocumentationPartAsync(UpdateDocumentationPartRequest, cb)
 	assert(UpdateDocumentationPartRequest, "You must provide a UpdateDocumentationPartRequest")
 	local headers = {
@@ -10973,19 +11004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDocumentationPartRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDocumentationPartSync(UpdateDocumentationPartRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDocumentationPartAsync(UpdateDocumentationPartRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDocumentationPartAsync(UpdateDocumentationPartRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestInvokeMethod asynchronously, invoking a callback when done
 -- @param TestInvokeMethodRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestInvokeMethodAsync(TestInvokeMethodRequest, cb)
 	assert(TestInvokeMethodRequest, "You must provide a TestInvokeMethodRequest")
 	local headers = {
@@ -11008,19 +11040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestInvokeMethodRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestInvokeMethodSync(TestInvokeMethodRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestInvokeMethodAsync(TestInvokeMethodRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestInvokeMethodAsync(TestInvokeMethodRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpcLink asynchronously, invoking a callback when done
 -- @param CreateVpcLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcLinkAsync(CreateVpcLinkRequest, cb)
 	assert(CreateVpcLinkRequest, "You must provide a CreateVpcLinkRequest")
 	local headers = {
@@ -11043,19 +11076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcLinkSync(CreateVpcLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcLinkAsync(CreateVpcLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcLinkAsync(CreateVpcLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpcLink asynchronously, invoking a callback when done
 -- @param DeleteVpcLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcLinkAsync(DeleteVpcLinkRequest, cb)
 	assert(DeleteVpcLinkRequest, "You must provide a DeleteVpcLinkRequest")
 	local headers = {
@@ -11078,19 +11112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcLinkSync(DeleteVpcLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcLinkAsync(DeleteVpcLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcLinkAsync(DeleteVpcLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStage asynchronously, invoking a callback when done
 -- @param UpdateStageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStageAsync(UpdateStageRequest, cb)
 	assert(UpdateStageRequest, "You must provide a UpdateStageRequest")
 	local headers = {
@@ -11113,19 +11148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStageSync(UpdateStageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStageAsync(UpdateStageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStageAsync(UpdateStageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBasePathMapping asynchronously, invoking a callback when done
 -- @param DeleteBasePathMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBasePathMappingAsync(DeleteBasePathMappingRequest, cb)
 	assert(DeleteBasePathMappingRequest, "You must provide a DeleteBasePathMappingRequest")
 	local headers = {
@@ -11148,19 +11184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBasePathMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBasePathMappingSync(DeleteBasePathMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBasePathMappingAsync(DeleteBasePathMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBasePathMappingAsync(DeleteBasePathMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRequestValidator asynchronously, invoking a callback when done
 -- @param CreateRequestValidatorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRequestValidatorAsync(CreateRequestValidatorRequest, cb)
 	assert(CreateRequestValidatorRequest, "You must provide a CreateRequestValidatorRequest")
 	local headers = {
@@ -11183,19 +11220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRequestValidatorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRequestValidatorSync(CreateRequestValidatorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRequestValidatorAsync(CreateRequestValidatorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRequestValidatorAsync(CreateRequestValidatorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestInvokeAuthorizer asynchronously, invoking a callback when done
 -- @param TestInvokeAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestInvokeAuthorizerAsync(TestInvokeAuthorizerRequest, cb)
 	assert(TestInvokeAuthorizerRequest, "You must provide a TestInvokeAuthorizerRequest")
 	local headers = {
@@ -11218,19 +11256,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestInvokeAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestInvokeAuthorizerSync(TestInvokeAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestInvokeAuthorizerAsync(TestInvokeAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestInvokeAuthorizerAsync(TestInvokeAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocumentationVersion asynchronously, invoking a callback when done
 -- @param GetDocumentationVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentationVersionAsync(GetDocumentationVersionRequest, cb)
 	assert(GetDocumentationVersionRequest, "You must provide a GetDocumentationVersionRequest")
 	local headers = {
@@ -11253,19 +11292,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentationVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentationVersionSync(GetDocumentationVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentationVersionAsync(GetDocumentationVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentationVersionAsync(GetDocumentationVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMethod asynchronously, invoking a callback when done
 -- @param UpdateMethodRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMethodAsync(UpdateMethodRequest, cb)
 	assert(UpdateMethodRequest, "You must provide a UpdateMethodRequest")
 	local headers = {
@@ -11288,19 +11328,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMethodRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMethodSync(UpdateMethodRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMethodAsync(UpdateMethodRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMethodAsync(UpdateMethodRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApiKey asynchronously, invoking a callback when done
 -- @param GetApiKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApiKeyAsync(GetApiKeyRequest, cb)
 	assert(GetApiKeyRequest, "You must provide a GetApiKeyRequest")
 	local headers = {
@@ -11323,19 +11364,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApiKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApiKeySync(GetApiKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApiKeyAsync(GetApiKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApiKeyAsync(GetApiKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSdkType asynchronously, invoking a callback when done
 -- @param GetSdkTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSdkTypeAsync(GetSdkTypeRequest, cb)
 	assert(GetSdkTypeRequest, "You must provide a GetSdkTypeRequest")
 	local headers = {
@@ -11358,19 +11400,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSdkTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSdkTypeSync(GetSdkTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSdkTypeAsync(GetSdkTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSdkTypeAsync(GetSdkTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIntegration asynchronously, invoking a callback when done
 -- @param GetIntegrationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIntegrationAsync(GetIntegrationRequest, cb)
 	assert(GetIntegrationRequest, "You must provide a GetIntegrationRequest")
 	local headers = {
@@ -11393,19 +11436,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIntegrationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIntegrationSync(GetIntegrationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIntegrationAsync(GetIntegrationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIntegrationAsync(GetIntegrationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -11428,19 +11472,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGatewayResponse asynchronously, invoking a callback when done
 -- @param UpdateGatewayResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGatewayResponseAsync(UpdateGatewayResponseRequest, cb)
 	assert(UpdateGatewayResponseRequest, "You must provide a UpdateGatewayResponseRequest")
 	local headers = {
@@ -11463,19 +11508,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGatewayResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGatewayResponseSync(UpdateGatewayResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGatewayResponseAsync(UpdateGatewayResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGatewayResponseAsync(UpdateGatewayResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDeployment asynchronously, invoking a callback when done
 -- @param DeleteDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDeploymentAsync(DeleteDeploymentRequest, cb)
 	assert(DeleteDeploymentRequest, "You must provide a DeleteDeploymentRequest")
 	local headers = {
@@ -11498,19 +11544,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDeploymentSync(DeleteDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDeploymentAsync(DeleteDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDeploymentAsync(DeleteDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUsagePlan asynchronously, invoking a callback when done
 -- @param GetUsagePlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUsagePlanAsync(GetUsagePlanRequest, cb)
 	assert(GetUsagePlanRequest, "You must provide a GetUsagePlanRequest")
 	local headers = {
@@ -11533,19 +11580,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUsagePlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUsagePlanSync(GetUsagePlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUsagePlanAsync(GetUsagePlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUsagePlanAsync(GetUsagePlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetVpcLink asynchronously, invoking a callback when done
 -- @param GetVpcLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetVpcLinkAsync(GetVpcLinkRequest, cb)
 	assert(GetVpcLinkRequest, "You must provide a GetVpcLinkRequest")
 	local headers = {
@@ -11568,19 +11616,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetVpcLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetVpcLinkSync(GetVpcLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetVpcLinkAsync(GetVpcLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetVpcLinkAsync(GetVpcLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUsagePlan asynchronously, invoking a callback when done
 -- @param UpdateUsagePlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUsagePlanAsync(UpdateUsagePlanRequest, cb)
 	assert(UpdateUsagePlanRequest, "You must provide a UpdateUsagePlanRequest")
 	local headers = {
@@ -11603,19 +11652,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUsagePlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUsagePlanSync(UpdateUsagePlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUsagePlanAsync(UpdateUsagePlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUsagePlanAsync(UpdateUsagePlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAuthorizer asynchronously, invoking a callback when done
 -- @param CreateAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAuthorizerAsync(CreateAuthorizerRequest, cb)
 	assert(CreateAuthorizerRequest, "You must provide a CreateAuthorizerRequest")
 	local headers = {
@@ -11638,19 +11688,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAuthorizerSync(CreateAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAuthorizerAsync(CreateAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAuthorizerAsync(CreateAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetClientCertificate asynchronously, invoking a callback when done
 -- @param GetClientCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetClientCertificateAsync(GetClientCertificateRequest, cb)
 	assert(GetClientCertificateRequest, "You must provide a GetClientCertificateRequest")
 	local headers = {
@@ -11673,19 +11724,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetClientCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetClientCertificateSync(GetClientCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetClientCertificateAsync(GetClientCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetClientCertificateAsync(GetClientCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDeployment asynchronously, invoking a callback when done
 -- @param UpdateDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDeploymentAsync(UpdateDeploymentRequest, cb)
 	assert(UpdateDeploymentRequest, "You must provide a UpdateDeploymentRequest")
 	local headers = {
@@ -11708,19 +11760,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDeploymentSync(UpdateDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDeploymentAsync(UpdateDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDeploymentAsync(UpdateDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetModelTemplate asynchronously, invoking a callback when done
 -- @param GetModelTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetModelTemplateAsync(GetModelTemplateRequest, cb)
 	assert(GetModelTemplateRequest, "You must provide a GetModelTemplateRequest")
 	local headers = {
@@ -11743,19 +11796,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetModelTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetModelTemplateSync(GetModelTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetModelTemplateAsync(GetModelTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetModelTemplateAsync(GetModelTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBasePathMappings asynchronously, invoking a callback when done
 -- @param GetBasePathMappingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBasePathMappingsAsync(GetBasePathMappingsRequest, cb)
 	assert(GetBasePathMappingsRequest, "You must provide a GetBasePathMappingsRequest")
 	local headers = {
@@ -11778,19 +11832,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBasePathMappingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBasePathMappingsSync(GetBasePathMappingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBasePathMappingsAsync(GetBasePathMappingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBasePathMappingsAsync(GetBasePathMappingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSdk asynchronously, invoking a callback when done
 -- @param GetSdkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSdkAsync(GetSdkRequest, cb)
 	assert(GetSdkRequest, "You must provide a GetSdkRequest")
 	local headers = {
@@ -11813,19 +11868,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSdkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSdkSync(GetSdkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSdkAsync(GetSdkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSdkAsync(GetSdkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRequestValidator asynchronously, invoking a callback when done
 -- @param GetRequestValidatorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRequestValidatorAsync(GetRequestValidatorRequest, cb)
 	assert(GetRequestValidatorRequest, "You must provide a GetRequestValidatorRequest")
 	local headers = {
@@ -11848,19 +11904,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRequestValidatorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRequestValidatorSync(GetRequestValidatorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRequestValidatorAsync(GetRequestValidatorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRequestValidatorAsync(GetRequestValidatorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call FlushStageAuthorizersCache asynchronously, invoking a callback when done
 -- @param FlushStageAuthorizersCacheRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.FlushStageAuthorizersCacheAsync(FlushStageAuthorizersCacheRequest, cb)
 	assert(FlushStageAuthorizersCacheRequest, "You must provide a FlushStageAuthorizersCacheRequest")
 	local headers = {
@@ -11883,19 +11940,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param FlushStageAuthorizersCacheRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.FlushStageAuthorizersCacheSync(FlushStageAuthorizersCacheRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.FlushStageAuthorizersCacheAsync(FlushStageAuthorizersCacheRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.FlushStageAuthorizersCacheAsync(FlushStageAuthorizersCacheRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIntegrationResponse asynchronously, invoking a callback when done
 -- @param GetIntegrationResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIntegrationResponseAsync(GetIntegrationResponseRequest, cb)
 	assert(GetIntegrationResponseRequest, "You must provide a GetIntegrationResponseRequest")
 	local headers = {
@@ -11918,19 +11976,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIntegrationResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIntegrationResponseSync(GetIntegrationResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIntegrationResponseAsync(GetIntegrationResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIntegrationResponseAsync(GetIntegrationResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeployments asynchronously, invoking a callback when done
 -- @param GetDeploymentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeploymentsAsync(GetDeploymentsRequest, cb)
 	assert(GetDeploymentsRequest, "You must provide a GetDeploymentsRequest")
 	local headers = {
@@ -11953,19 +12012,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeploymentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeploymentsSync(GetDeploymentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeploymentsAsync(GetDeploymentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeploymentsAsync(GetDeploymentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResource asynchronously, invoking a callback when done
 -- @param CreateResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResourceAsync(CreateResourceRequest, cb)
 	assert(CreateResourceRequest, "You must provide a CreateResourceRequest")
 	local headers = {
@@ -11988,19 +12048,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResourceSync(CreateResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResourceAsync(CreateResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResourceAsync(CreateResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApiKeys asynchronously, invoking a callback when done
 -- @param GetApiKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApiKeysAsync(GetApiKeysRequest, cb)
 	assert(GetApiKeysRequest, "You must provide a GetApiKeysRequest")
 	local headers = {
@@ -12023,19 +12084,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApiKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApiKeysSync(GetApiKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApiKeysAsync(GetApiKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApiKeysAsync(GetApiKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApiKey asynchronously, invoking a callback when done
 -- @param DeleteApiKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApiKeyAsync(DeleteApiKeyRequest, cb)
 	assert(DeleteApiKeyRequest, "You must provide a DeleteApiKeyRequest")
 	local headers = {
@@ -12058,19 +12120,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApiKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApiKeySync(DeleteApiKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApiKeyAsync(DeleteApiKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApiKeyAsync(DeleteApiKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApiKey asynchronously, invoking a callback when done
 -- @param CreateApiKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApiKeyAsync(CreateApiKeyRequest, cb)
 	assert(CreateApiKeyRequest, "You must provide a CreateApiKeyRequest")
 	local headers = {
@@ -12093,19 +12156,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApiKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApiKeySync(CreateApiKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApiKeyAsync(CreateApiKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApiKeyAsync(CreateApiKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAuthorizer asynchronously, invoking a callback when done
 -- @param UpdateAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAuthorizerAsync(UpdateAuthorizerRequest, cb)
 	assert(UpdateAuthorizerRequest, "You must provide a UpdateAuthorizerRequest")
 	local headers = {
@@ -12128,19 +12192,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAuthorizerSync(UpdateAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAuthorizerAsync(UpdateAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAuthorizerAsync(UpdateAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetModel asynchronously, invoking a callback when done
 -- @param GetModelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetModelAsync(GetModelRequest, cb)
 	assert(GetModelRequest, "You must provide a GetModelRequest")
 	local headers = {
@@ -12163,19 +12228,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetModelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetModelSync(GetModelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetModelAsync(GetModelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetModelAsync(GetModelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUsagePlanKeys asynchronously, invoking a callback when done
 -- @param GetUsagePlanKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUsagePlanKeysAsync(GetUsagePlanKeysRequest, cb)
 	assert(GetUsagePlanKeysRequest, "You must provide a GetUsagePlanKeysRequest")
 	local headers = {
@@ -12198,19 +12264,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUsagePlanKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUsagePlanKeysSync(GetUsagePlanKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUsagePlanKeysAsync(GetUsagePlanKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUsagePlanKeysAsync(GetUsagePlanKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMethodResponse asynchronously, invoking a callback when done
 -- @param DeleteMethodResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMethodResponseAsync(DeleteMethodResponseRequest, cb)
 	assert(DeleteMethodResponseRequest, "You must provide a DeleteMethodResponseRequest")
 	local headers = {
@@ -12233,19 +12300,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMethodResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMethodResponseSync(DeleteMethodResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMethodResponseAsync(DeleteMethodResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMethodResponseAsync(DeleteMethodResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResources asynchronously, invoking a callback when done
 -- @param GetResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourcesAsync(GetResourcesRequest, cb)
 	assert(GetResourcesRequest, "You must provide a GetResourcesRequest")
 	local headers = {
@@ -12268,19 +12336,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourcesSync(GetResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourcesAsync(GetResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourcesAsync(GetResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRestApis asynchronously, invoking a callback when done
 -- @param GetRestApisRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRestApisAsync(GetRestApisRequest, cb)
 	assert(GetRestApisRequest, "You must provide a GetRestApisRequest")
 	local headers = {
@@ -12303,19 +12372,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRestApisRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRestApisSync(GetRestApisRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRestApisAsync(GetRestApisRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRestApisAsync(GetRestApisRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResource asynchronously, invoking a callback when done
 -- @param GetResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourceAsync(GetResourceRequest, cb)
 	assert(GetResourceRequest, "You must provide a GetResourceRequest")
 	local headers = {
@@ -12338,19 +12408,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourceSync(GetResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourceAsync(GetResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourceAsync(GetResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIntegrationResponse asynchronously, invoking a callback when done
 -- @param DeleteIntegrationResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIntegrationResponseAsync(DeleteIntegrationResponseRequest, cb)
 	assert(DeleteIntegrationResponseRequest, "You must provide a DeleteIntegrationResponseRequest")
 	local headers = {
@@ -12373,19 +12444,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIntegrationResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIntegrationResponseSync(DeleteIntegrationResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIntegrationResponseAsync(DeleteIntegrationResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIntegrationResponseAsync(DeleteIntegrationResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUsagePlans asynchronously, invoking a callback when done
 -- @param GetUsagePlansRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUsagePlansAsync(GetUsagePlansRequest, cb)
 	assert(GetUsagePlansRequest, "You must provide a GetUsagePlansRequest")
 	local headers = {
@@ -12408,19 +12480,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUsagePlansRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUsagePlansSync(GetUsagePlansRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUsagePlansAsync(GetUsagePlansRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUsagePlansAsync(GetUsagePlansRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportApiKeys asynchronously, invoking a callback when done
 -- @param ImportApiKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportApiKeysAsync(ImportApiKeysRequest, cb)
 	assert(ImportApiKeysRequest, "You must provide a ImportApiKeysRequest")
 	local headers = {
@@ -12443,19 +12516,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportApiKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportApiKeysSync(ImportApiKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportApiKeysAsync(ImportApiKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportApiKeysAsync(ImportApiKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBasePathMapping asynchronously, invoking a callback when done
 -- @param GetBasePathMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBasePathMappingAsync(GetBasePathMappingRequest, cb)
 	assert(GetBasePathMappingRequest, "You must provide a GetBasePathMappingRequest")
 	local headers = {
@@ -12478,19 +12552,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBasePathMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBasePathMappingSync(GetBasePathMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBasePathMappingAsync(GetBasePathMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBasePathMappingAsync(GetBasePathMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetExport asynchronously, invoking a callback when done
 -- @param GetExportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetExportAsync(GetExportRequest, cb)
 	assert(GetExportRequest, "You must provide a GetExportRequest")
 	local headers = {
@@ -12513,19 +12588,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetExportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetExportSync(GetExportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetExportAsync(GetExportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetExportAsync(GetExportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateResource asynchronously, invoking a callback when done
 -- @param UpdateResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateResourceAsync(UpdateResourceRequest, cb)
 	assert(UpdateResourceRequest, "You must provide a UpdateResourceRequest")
 	local headers = {
@@ -12548,19 +12624,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateResourceSync(UpdateResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateResourceAsync(UpdateResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateResourceAsync(UpdateResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDomainName asynchronously, invoking a callback when done
 -- @param GetDomainNameRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDomainNameAsync(GetDomainNameRequest, cb)
 	assert(GetDomainNameRequest, "You must provide a GetDomainNameRequest")
 	local headers = {
@@ -12583,19 +12660,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDomainNameRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDomainNameSync(GetDomainNameRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDomainNameAsync(GetDomainNameRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDomainNameAsync(GetDomainNameRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDomainName asynchronously, invoking a callback when done
 -- @param UpdateDomainNameRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDomainNameAsync(UpdateDomainNameRequest, cb)
 	assert(UpdateDomainNameRequest, "You must provide a UpdateDomainNameRequest")
 	local headers = {
@@ -12618,19 +12696,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDomainNameRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDomainNameSync(UpdateDomainNameRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDomainNameAsync(UpdateDomainNameRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDomainNameAsync(UpdateDomainNameRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateClientCertificate asynchronously, invoking a callback when done
 -- @param UpdateClientCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateClientCertificateAsync(UpdateClientCertificateRequest, cb)
 	assert(UpdateClientCertificateRequest, "You must provide a UpdateClientCertificateRequest")
 	local headers = {
@@ -12653,19 +12732,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateClientCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateClientCertificateSync(UpdateClientCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateClientCertificateAsync(UpdateClientCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateClientCertificateAsync(UpdateClientCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDomainName asynchronously, invoking a callback when done
 -- @param CreateDomainNameRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDomainNameAsync(CreateDomainNameRequest, cb)
 	assert(CreateDomainNameRequest, "You must provide a CreateDomainNameRequest")
 	local headers = {
@@ -12688,19 +12768,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDomainNameRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDomainNameSync(CreateDomainNameRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDomainNameAsync(CreateDomainNameRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDomainNameAsync(CreateDomainNameRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDomainName asynchronously, invoking a callback when done
 -- @param DeleteDomainNameRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDomainNameAsync(DeleteDomainNameRequest, cb)
 	assert(DeleteDomainNameRequest, "You must provide a DeleteDomainNameRequest")
 	local headers = {
@@ -12723,19 +12804,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDomainNameRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDomainNameSync(DeleteDomainNameRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDomainNameAsync(DeleteDomainNameRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDomainNameAsync(DeleteDomainNameRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutMethod asynchronously, invoking a callback when done
 -- @param PutMethodRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutMethodAsync(PutMethodRequest, cb)
 	assert(PutMethodRequest, "You must provide a PutMethodRequest")
 	local headers = {
@@ -12758,19 +12840,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutMethodRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutMethodSync(PutMethodRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutMethodAsync(PutMethodRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutMethodAsync(PutMethodRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStage asynchronously, invoking a callback when done
 -- @param DeleteStageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStageAsync(DeleteStageRequest, cb)
 	assert(DeleteStageRequest, "You must provide a DeleteStageRequest")
 	local headers = {
@@ -12793,19 +12876,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStageSync(DeleteStageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStageAsync(DeleteStageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStageAsync(DeleteStageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocumentationPart asynchronously, invoking a callback when done
 -- @param GetDocumentationPartRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentationPartAsync(GetDocumentationPartRequest, cb)
 	assert(GetDocumentationPartRequest, "You must provide a GetDocumentationPartRequest")
 	local headers = {
@@ -12828,19 +12912,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentationPartRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentationPartSync(GetDocumentationPartRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentationPartAsync(GetDocumentationPartRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentationPartAsync(GetDocumentationPartRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAccount asynchronously, invoking a callback when done
 -- @param UpdateAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAccountAsync(UpdateAccountRequest, cb)
 	assert(UpdateAccountRequest, "You must provide a UpdateAccountRequest")
 	local headers = {
@@ -12863,19 +12948,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAccountSync(UpdateAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAccountAsync(UpdateAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAccountAsync(UpdateAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRestApi asynchronously, invoking a callback when done
 -- @param PutRestApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRestApiAsync(PutRestApiRequest, cb)
 	assert(PutRestApiRequest, "You must provide a PutRestApiRequest")
 	local headers = {
@@ -12898,19 +12984,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRestApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRestApiSync(PutRestApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRestApiAsync(PutRestApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRestApiAsync(PutRestApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUsage asynchronously, invoking a callback when done
 -- @param GetUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUsageAsync(GetUsageRequest, cb)
 	assert(GetUsageRequest, "You must provide a GetUsageRequest")
 	local headers = {
@@ -12933,19 +13020,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUsageSync(GetUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUsageAsync(GetUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUsageAsync(GetUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeployment asynchronously, invoking a callback when done
 -- @param GetDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeploymentAsync(GetDeploymentRequest, cb)
 	assert(GetDeploymentRequest, "You must provide a GetDeploymentRequest")
 	local headers = {
@@ -12968,19 +13056,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeploymentSync(GetDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeploymentAsync(GetDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeploymentAsync(GetDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRestApi asynchronously, invoking a callback when done
 -- @param CreateRestApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRestApiAsync(CreateRestApiRequest, cb)
 	assert(CreateRestApiRequest, "You must provide a CreateRestApiRequest")
 	local headers = {
@@ -13003,19 +13092,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRestApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRestApiSync(CreateRestApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRestApiAsync(CreateRestApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRestApiAsync(CreateRestApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTags asynchronously, invoking a callback when done
 -- @param GetTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTagsAsync(GetTagsRequest, cb)
 	assert(GetTagsRequest, "You must provide a GetTagsRequest")
 	local headers = {
@@ -13038,19 +13128,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTagsSync(GetTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTagsAsync(GetTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTagsAsync(GetTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateVpcLink asynchronously, invoking a callback when done
 -- @param UpdateVpcLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateVpcLinkAsync(UpdateVpcLinkRequest, cb)
 	assert(UpdateVpcLinkRequest, "You must provide a UpdateVpcLinkRequest")
 	local headers = {
@@ -13073,19 +13164,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateVpcLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateVpcLinkSync(UpdateVpcLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateVpcLinkAsync(UpdateVpcLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateVpcLinkAsync(UpdateVpcLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAuthorizers asynchronously, invoking a callback when done
 -- @param GetAuthorizersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAuthorizersAsync(GetAuthorizersRequest, cb)
 	assert(GetAuthorizersRequest, "You must provide a GetAuthorizersRequest")
 	local headers = {
@@ -13108,19 +13200,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAuthorizersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAuthorizersSync(GetAuthorizersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAuthorizersAsync(GetAuthorizersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAuthorizersAsync(GetAuthorizersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetClientCertificates asynchronously, invoking a callback when done
 -- @param GetClientCertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetClientCertificatesAsync(GetClientCertificatesRequest, cb)
 	assert(GetClientCertificatesRequest, "You must provide a GetClientCertificatesRequest")
 	local headers = {
@@ -13143,19 +13236,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetClientCertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetClientCertificatesSync(GetClientCertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetClientCertificatesAsync(GetClientCertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetClientCertificatesAsync(GetClientCertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDocumentationPart asynchronously, invoking a callback when done
 -- @param DeleteDocumentationPartRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDocumentationPartAsync(DeleteDocumentationPartRequest, cb)
 	assert(DeleteDocumentationPartRequest, "You must provide a DeleteDocumentationPartRequest")
 	local headers = {
@@ -13178,19 +13272,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDocumentationPartRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDocumentationPartSync(DeleteDocumentationPartRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDocumentationPartAsync(DeleteDocumentationPartRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDocumentationPartAsync(DeleteDocumentationPartRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResource asynchronously, invoking a callback when done
 -- @param DeleteResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourceAsync(DeleteResourceRequest, cb)
 	assert(DeleteResourceRequest, "You must provide a DeleteResourceRequest")
 	local headers = {
@@ -13213,19 +13308,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourceSync(DeleteResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourceAsync(DeleteResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourceAsync(DeleteResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStage asynchronously, invoking a callback when done
 -- @param CreateStageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStageAsync(CreateStageRequest, cb)
 	assert(CreateStageRequest, "You must provide a CreateStageRequest")
 	local headers = {
@@ -13248,19 +13344,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStageSync(CreateStageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStageAsync(CreateStageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStageAsync(CreateStageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateBasePathMapping asynchronously, invoking a callback when done
 -- @param UpdateBasePathMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateBasePathMappingAsync(UpdateBasePathMappingRequest, cb)
 	assert(UpdateBasePathMappingRequest, "You must provide a UpdateBasePathMappingRequest")
 	local headers = {
@@ -13283,19 +13380,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateBasePathMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateBasePathMappingSync(UpdateBasePathMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateBasePathMappingAsync(UpdateBasePathMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateBasePathMappingAsync(UpdateBasePathMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMethodResponse asynchronously, invoking a callback when done
 -- @param UpdateMethodResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMethodResponseAsync(UpdateMethodResponseRequest, cb)
 	assert(UpdateMethodResponseRequest, "You must provide a UpdateMethodResponseRequest")
 	local headers = {
@@ -13318,19 +13416,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMethodResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMethodResponseSync(UpdateMethodResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMethodResponseAsync(UpdateMethodResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMethodResponseAsync(UpdateMethodResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUsage asynchronously, invoking a callback when done
 -- @param UpdateUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUsageAsync(UpdateUsageRequest, cb)
 	assert(UpdateUsageRequest, "You must provide a UpdateUsageRequest")
 	local headers = {
@@ -13353,19 +13452,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUsageSync(UpdateUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUsageAsync(UpdateUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUsageAsync(UpdateUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocumentationParts asynchronously, invoking a callback when done
 -- @param GetDocumentationPartsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentationPartsAsync(GetDocumentationPartsRequest, cb)
 	assert(GetDocumentationPartsRequest, "You must provide a GetDocumentationPartsRequest")
 	local headers = {
@@ -13388,19 +13488,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentationPartsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentationPartsSync(GetDocumentationPartsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentationPartsAsync(GetDocumentationPartsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentationPartsAsync(GetDocumentationPartsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDocumentationPart asynchronously, invoking a callback when done
 -- @param CreateDocumentationPartRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDocumentationPartAsync(CreateDocumentationPartRequest, cb)
 	assert(CreateDocumentationPartRequest, "You must provide a CreateDocumentationPartRequest")
 	local headers = {
@@ -13423,19 +13524,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDocumentationPartRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDocumentationPartSync(CreateDocumentationPartRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDocumentationPartAsync(CreateDocumentationPartRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDocumentationPartAsync(CreateDocumentationPartRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBasePathMapping asynchronously, invoking a callback when done
 -- @param CreateBasePathMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBasePathMappingAsync(CreateBasePathMappingRequest, cb)
 	assert(CreateBasePathMappingRequest, "You must provide a CreateBasePathMappingRequest")
 	local headers = {
@@ -13458,19 +13560,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBasePathMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBasePathMappingSync(CreateBasePathMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBasePathMappingAsync(CreateBasePathMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBasePathMappingAsync(CreateBasePathMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUsagePlan asynchronously, invoking a callback when done
 -- @param CreateUsagePlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUsagePlanAsync(CreateUsagePlanRequest, cb)
 	assert(CreateUsagePlanRequest, "You must provide a CreateUsagePlanRequest")
 	local headers = {
@@ -13493,19 +13596,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUsagePlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUsagePlanSync(CreateUsagePlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUsagePlanAsync(CreateUsagePlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUsagePlanAsync(CreateUsagePlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApiKey asynchronously, invoking a callback when done
 -- @param UpdateApiKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApiKeyAsync(UpdateApiKeyRequest, cb)
 	assert(UpdateApiKeyRequest, "You must provide a UpdateApiKeyRequest")
 	local headers = {
@@ -13528,19 +13632,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApiKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApiKeySync(UpdateApiKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApiKeyAsync(UpdateApiKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApiKeyAsync(UpdateApiKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGatewayResponse asynchronously, invoking a callback when done
 -- @param DeleteGatewayResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGatewayResponseAsync(DeleteGatewayResponseRequest, cb)
 	assert(DeleteGatewayResponseRequest, "You must provide a DeleteGatewayResponseRequest")
 	local headers = {
@@ -13563,19 +13668,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGatewayResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGatewayResponseSync(DeleteGatewayResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGatewayResponseAsync(DeleteGatewayResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGatewayResponseAsync(DeleteGatewayResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportRestApi asynchronously, invoking a callback when done
 -- @param ImportRestApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportRestApiAsync(ImportRestApiRequest, cb)
 	assert(ImportRestApiRequest, "You must provide a ImportRestApiRequest")
 	local headers = {
@@ -13598,19 +13704,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportRestApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportRestApiSync(ImportRestApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportRestApiAsync(ImportRestApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportRestApiAsync(ImportRestApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRestApi asynchronously, invoking a callback when done
 -- @param UpdateRestApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRestApiAsync(UpdateRestApiRequest, cb)
 	assert(UpdateRestApiRequest, "You must provide a UpdateRestApiRequest")
 	local headers = {
@@ -13633,19 +13740,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRestApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRestApiSync(UpdateRestApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRestApiAsync(UpdateRestApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRestApiAsync(UpdateRestApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDocumentationVersion asynchronously, invoking a callback when done
 -- @param CreateDocumentationVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDocumentationVersionAsync(CreateDocumentationVersionRequest, cb)
 	assert(CreateDocumentationVersionRequest, "You must provide a CreateDocumentationVersionRequest")
 	local headers = {
@@ -13668,19 +13776,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDocumentationVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDocumentationVersionSync(CreateDocumentationVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDocumentationVersionAsync(CreateDocumentationVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDocumentationVersionAsync(CreateDocumentationVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutIntegrationResponse asynchronously, invoking a callback when done
 -- @param PutIntegrationResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutIntegrationResponseAsync(PutIntegrationResponseRequest, cb)
 	assert(PutIntegrationResponseRequest, "You must provide a PutIntegrationResponseRequest")
 	local headers = {
@@ -13703,19 +13812,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutIntegrationResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutIntegrationResponseSync(PutIntegrationResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutIntegrationResponseAsync(PutIntegrationResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutIntegrationResponseAsync(PutIntegrationResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocumentationVersions asynchronously, invoking a callback when done
 -- @param GetDocumentationVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentationVersionsAsync(GetDocumentationVersionsRequest, cb)
 	assert(GetDocumentationVersionsRequest, "You must provide a GetDocumentationVersionsRequest")
 	local headers = {
@@ -13738,19 +13848,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentationVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentationVersionsSync(GetDocumentationVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentationVersionsAsync(GetDocumentationVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentationVersionsAsync(GetDocumentationVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMethod asynchronously, invoking a callback when done
 -- @param DeleteMethodRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMethodAsync(DeleteMethodRequest, cb)
 	assert(DeleteMethodRequest, "You must provide a DeleteMethodRequest")
 	local headers = {
@@ -13773,19 +13884,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMethodRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMethodSync(DeleteMethodRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMethodAsync(DeleteMethodRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMethodAsync(DeleteMethodRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRequestValidators asynchronously, invoking a callback when done
 -- @param GetRequestValidatorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRequestValidatorsAsync(GetRequestValidatorsRequest, cb)
 	assert(GetRequestValidatorsRequest, "You must provide a GetRequestValidatorsRequest")
 	local headers = {
@@ -13808,19 +13920,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRequestValidatorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRequestValidatorsSync(GetRequestValidatorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRequestValidatorsAsync(GetRequestValidatorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRequestValidatorsAsync(GetRequestValidatorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccount asynchronously, invoking a callback when done
 -- @param GetAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountAsync(GetAccountRequest, cb)
 	assert(GetAccountRequest, "You must provide a GetAccountRequest")
 	local headers = {
@@ -13843,19 +13956,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountSync(GetAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountAsync(GetAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountAsync(GetAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUsagePlanKey asynchronously, invoking a callback when done
 -- @param DeleteUsagePlanKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUsagePlanKeyAsync(DeleteUsagePlanKeyRequest, cb)
 	assert(DeleteUsagePlanKeyRequest, "You must provide a DeleteUsagePlanKeyRequest")
 	local headers = {
@@ -13878,19 +13992,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUsagePlanKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUsagePlanKeySync(DeleteUsagePlanKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUsagePlanKeyAsync(DeleteUsagePlanKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUsagePlanKeyAsync(DeleteUsagePlanKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRequestValidator asynchronously, invoking a callback when done
 -- @param DeleteRequestValidatorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRequestValidatorAsync(DeleteRequestValidatorRequest, cb)
 	assert(DeleteRequestValidatorRequest, "You must provide a DeleteRequestValidatorRequest")
 	local headers = {
@@ -13913,19 +14028,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRequestValidatorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRequestValidatorSync(DeleteRequestValidatorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRequestValidatorAsync(DeleteRequestValidatorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRequestValidatorAsync(DeleteRequestValidatorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -13948,19 +14064,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutIntegration asynchronously, invoking a callback when done
 -- @param PutIntegrationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutIntegrationAsync(PutIntegrationRequest, cb)
 	assert(PutIntegrationRequest, "You must provide a PutIntegrationRequest")
 	local headers = {
@@ -13983,19 +14100,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutIntegrationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutIntegrationSync(PutIntegrationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutIntegrationAsync(PutIntegrationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutIntegrationAsync(PutIntegrationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIntegrationResponse asynchronously, invoking a callback when done
 -- @param UpdateIntegrationResponseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIntegrationResponseAsync(UpdateIntegrationResponseRequest, cb)
 	assert(UpdateIntegrationResponseRequest, "You must provide a UpdateIntegrationResponseRequest")
 	local headers = {
@@ -14018,19 +14136,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateIntegrationResponseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIntegrationResponseSync(UpdateIntegrationResponseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIntegrationResponseAsync(UpdateIntegrationResponseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIntegrationResponseAsync(UpdateIntegrationResponseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetVpcLinks asynchronously, invoking a callback when done
 -- @param GetVpcLinksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetVpcLinksAsync(GetVpcLinksRequest, cb)
 	assert(GetVpcLinksRequest, "You must provide a GetVpcLinksRequest")
 	local headers = {
@@ -14053,12 +14172,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetVpcLinksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetVpcLinksSync(GetVpcLinksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetVpcLinksAsync(GetVpcLinksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetVpcLinksAsync(GetVpcLinksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/appstream2.lua
+++ b/aws-sdk/appstream2.lua
@@ -6109,7 +6109,7 @@ end
 --
 --- Call StopImageBuilder asynchronously, invoking a callback when done
 -- @param StopImageBuilderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopImageBuilderAsync(StopImageBuilderRequest, cb)
 	assert(StopImageBuilderRequest, "You must provide a StopImageBuilderRequest")
 	local headers = {
@@ -6132,19 +6132,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopImageBuilderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopImageBuilderSync(StopImageBuilderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopImageBuilderAsync(StopImageBuilderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopImageBuilderAsync(StopImageBuilderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFleet asynchronously, invoking a callback when done
 -- @param DeleteFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFleetAsync(DeleteFleetRequest, cb)
 	assert(DeleteFleetRequest, "You must provide a DeleteFleetRequest")
 	local headers = {
@@ -6167,19 +6168,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFleetSync(DeleteFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFleetAsync(DeleteFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFleetAsync(DeleteFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssociatedStacks asynchronously, invoking a callback when done
 -- @param ListAssociatedStacksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssociatedStacksAsync(ListAssociatedStacksRequest, cb)
 	assert(ListAssociatedStacksRequest, "You must provide a ListAssociatedStacksRequest")
 	local headers = {
@@ -6202,19 +6204,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssociatedStacksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssociatedStacksSync(ListAssociatedStacksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssociatedStacksAsync(ListAssociatedStacksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssociatedStacksAsync(ListAssociatedStacksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ExpireSession asynchronously, invoking a callback when done
 -- @param ExpireSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExpireSessionAsync(ExpireSessionRequest, cb)
 	assert(ExpireSessionRequest, "You must provide a ExpireSessionRequest")
 	local headers = {
@@ -6237,19 +6240,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExpireSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExpireSessionSync(ExpireSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExpireSessionAsync(ExpireSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExpireSessionAsync(ExpireSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateFleet asynchronously, invoking a callback when done
 -- @param AssociateFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateFleetAsync(AssociateFleetRequest, cb)
 	assert(AssociateFleetRequest, "You must provide a AssociateFleetRequest")
 	local headers = {
@@ -6272,19 +6276,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateFleetSync(AssociateFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateFleetAsync(AssociateFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateFleetAsync(AssociateFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateImageBuilder asynchronously, invoking a callback when done
 -- @param CreateImageBuilderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateImageBuilderAsync(CreateImageBuilderRequest, cb)
 	assert(CreateImageBuilderRequest, "You must provide a CreateImageBuilderRequest")
 	local headers = {
@@ -6307,19 +6312,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateImageBuilderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateImageBuilderSync(CreateImageBuilderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateImageBuilderAsync(CreateImageBuilderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateImageBuilderAsync(CreateImageBuilderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteImageBuilder asynchronously, invoking a callback when done
 -- @param DeleteImageBuilderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteImageBuilderAsync(DeleteImageBuilderRequest, cb)
 	assert(DeleteImageBuilderRequest, "You must provide a DeleteImageBuilderRequest")
 	local headers = {
@@ -6342,19 +6348,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteImageBuilderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteImageBuilderSync(DeleteImageBuilderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteImageBuilderAsync(DeleteImageBuilderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteImageBuilderAsync(DeleteImageBuilderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImages asynchronously, invoking a callback when done
 -- @param DescribeImagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImagesAsync(DescribeImagesRequest, cb)
 	assert(DescribeImagesRequest, "You must provide a DescribeImagesRequest")
 	local headers = {
@@ -6377,19 +6384,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImagesSync(DescribeImagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImagesAsync(DescribeImagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImagesAsync(DescribeImagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableUser asynchronously, invoking a callback when done
 -- @param EnableUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableUserAsync(EnableUserRequest, cb)
 	assert(EnableUserRequest, "You must provide a EnableUserRequest")
 	local headers = {
@@ -6412,19 +6420,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableUserSync(EnableUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableUserAsync(EnableUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableUserAsync(EnableUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUsers asynchronously, invoking a callback when done
 -- @param DescribeUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUsersAsync(DescribeUsersRequest, cb)
 	assert(DescribeUsersRequest, "You must provide a DescribeUsersRequest")
 	local headers = {
@@ -6447,19 +6456,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUsersSync(DescribeUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUsersAsync(DescribeUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUsersAsync(DescribeUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDirectoryConfig asynchronously, invoking a callback when done
 -- @param CreateDirectoryConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDirectoryConfigAsync(CreateDirectoryConfigRequest, cb)
 	assert(CreateDirectoryConfigRequest, "You must provide a CreateDirectoryConfigRequest")
 	local headers = {
@@ -6482,19 +6492,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDirectoryConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDirectoryConfigSync(CreateDirectoryConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDirectoryConfigAsync(CreateDirectoryConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDirectoryConfigAsync(CreateDirectoryConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDisassociateUserStack asynchronously, invoking a callback when done
 -- @param BatchDisassociateUserStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDisassociateUserStackAsync(BatchDisassociateUserStackRequest, cb)
 	assert(BatchDisassociateUserStackRequest, "You must provide a BatchDisassociateUserStackRequest")
 	local headers = {
@@ -6517,19 +6528,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDisassociateUserStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDisassociateUserStackSync(BatchDisassociateUserStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDisassociateUserStackAsync(BatchDisassociateUserStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDisassociateUserStackAsync(BatchDisassociateUserStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateImagePermissions asynchronously, invoking a callback when done
 -- @param UpdateImagePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateImagePermissionsAsync(UpdateImagePermissionsRequest, cb)
 	assert(UpdateImagePermissionsRequest, "You must provide a UpdateImagePermissionsRequest")
 	local headers = {
@@ -6552,19 +6564,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateImagePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateImagePermissionsSync(UpdateImagePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateImagePermissionsAsync(UpdateImagePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateImagePermissionsAsync(UpdateImagePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStack asynchronously, invoking a callback when done
 -- @param CreateStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStackAsync(CreateStackRequest, cb)
 	assert(CreateStackRequest, "You must provide a CreateStackRequest")
 	local headers = {
@@ -6587,19 +6600,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStackSync(CreateStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStackAsync(CreateStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStackAsync(CreateStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDirectoryConfigs asynchronously, invoking a callback when done
 -- @param DescribeDirectoryConfigsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDirectoryConfigsAsync(DescribeDirectoryConfigsRequest, cb)
 	assert(DescribeDirectoryConfigsRequest, "You must provide a DescribeDirectoryConfigsRequest")
 	local headers = {
@@ -6622,19 +6636,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDirectoryConfigsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDirectoryConfigsSync(DescribeDirectoryConfigsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDirectoryConfigsAsync(DescribeDirectoryConfigsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDirectoryConfigsAsync(DescribeDirectoryConfigsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableUser asynchronously, invoking a callback when done
 -- @param DisableUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableUserAsync(DisableUserRequest, cb)
 	assert(DisableUserRequest, "You must provide a DisableUserRequest")
 	local headers = {
@@ -6657,19 +6672,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableUserSync(DisableUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableUserAsync(DisableUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableUserAsync(DisableUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -6692,19 +6708,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateImageBuilderStreamingURL asynchronously, invoking a callback when done
 -- @param CreateImageBuilderStreamingURLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateImageBuilderStreamingURLAsync(CreateImageBuilderStreamingURLRequest, cb)
 	assert(CreateImageBuilderStreamingURLRequest, "You must provide a CreateImageBuilderStreamingURLRequest")
 	local headers = {
@@ -6727,19 +6744,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateImageBuilderStreamingURLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateImageBuilderStreamingURLSync(CreateImageBuilderStreamingURLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateImageBuilderStreamingURLAsync(CreateImageBuilderStreamingURLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateImageBuilderStreamingURLAsync(CreateImageBuilderStreamingURLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDirectoryConfig asynchronously, invoking a callback when done
 -- @param UpdateDirectoryConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDirectoryConfigAsync(UpdateDirectoryConfigRequest, cb)
 	assert(UpdateDirectoryConfigRequest, "You must provide a UpdateDirectoryConfigRequest")
 	local headers = {
@@ -6762,19 +6780,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDirectoryConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDirectoryConfigSync(UpdateDirectoryConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDirectoryConfigAsync(UpdateDirectoryConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDirectoryConfigAsync(UpdateDirectoryConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyImage asynchronously, invoking a callback when done
 -- @param CopyImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyImageAsync(CopyImageRequest, cb)
 	assert(CopyImageRequest, "You must provide a CopyImageRequest")
 	local headers = {
@@ -6797,19 +6816,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyImageSync(CopyImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyImageAsync(CopyImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyImageAsync(CopyImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFleet asynchronously, invoking a callback when done
 -- @param CreateFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFleetAsync(CreateFleetRequest, cb)
 	assert(CreateFleetRequest, "You must provide a CreateFleetRequest")
 	local headers = {
@@ -6832,19 +6852,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFleetSync(CreateFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFleetAsync(CreateFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFleetAsync(CreateFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSessions asynchronously, invoking a callback when done
 -- @param DescribeSessionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSessionsAsync(DescribeSessionsRequest, cb)
 	assert(DescribeSessionsRequest, "You must provide a DescribeSessionsRequest")
 	local headers = {
@@ -6867,19 +6888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSessionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSessionsSync(DescribeSessionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSessionsAsync(DescribeSessionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSessionsAsync(DescribeSessionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImagePermissions asynchronously, invoking a callback when done
 -- @param DescribeImagePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImagePermissionsAsync(DescribeImagePermissionsRequest, cb)
 	assert(DescribeImagePermissionsRequest, "You must provide a DescribeImagePermissionsRequest")
 	local headers = {
@@ -6902,19 +6924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImagePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImagePermissionsSync(DescribeImagePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImagePermissionsAsync(DescribeImagePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImagePermissionsAsync(DescribeImagePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStack asynchronously, invoking a callback when done
 -- @param UpdateStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStackAsync(UpdateStackRequest, cb)
 	assert(UpdateStackRequest, "You must provide a UpdateStackRequest")
 	local headers = {
@@ -6937,19 +6960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStackSync(UpdateStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStackAsync(UpdateStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStackAsync(UpdateStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -6972,19 +6996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopFleet asynchronously, invoking a callback when done
 -- @param StopFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopFleetAsync(StopFleetRequest, cb)
 	assert(StopFleetRequest, "You must provide a StopFleetRequest")
 	local headers = {
@@ -7007,19 +7032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopFleetSync(StopFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopFleetAsync(StopFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopFleetAsync(StopFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFleet asynchronously, invoking a callback when done
 -- @param UpdateFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFleetAsync(UpdateFleetRequest, cb)
 	assert(UpdateFleetRequest, "You must provide a UpdateFleetRequest")
 	local headers = {
@@ -7042,19 +7068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFleetSync(UpdateFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFleetAsync(UpdateFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFleetAsync(UpdateFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleets asynchronously, invoking a callback when done
 -- @param DescribeFleetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetsAsync(DescribeFleetsRequest, cb)
 	assert(DescribeFleetsRequest, "You must provide a DescribeFleetsRequest")
 	local headers = {
@@ -7077,19 +7104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetsSync(DescribeFleetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetsAsync(DescribeFleetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetsAsync(DescribeFleetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImageBuilders asynchronously, invoking a callback when done
 -- @param DescribeImageBuildersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImageBuildersAsync(DescribeImageBuildersRequest, cb)
 	assert(DescribeImageBuildersRequest, "You must provide a DescribeImageBuildersRequest")
 	local headers = {
@@ -7112,19 +7140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImageBuildersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImageBuildersSync(DescribeImageBuildersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImageBuildersAsync(DescribeImageBuildersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImageBuildersAsync(DescribeImageBuildersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssociatedFleets asynchronously, invoking a callback when done
 -- @param ListAssociatedFleetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssociatedFleetsAsync(ListAssociatedFleetsRequest, cb)
 	assert(ListAssociatedFleetsRequest, "You must provide a ListAssociatedFleetsRequest")
 	local headers = {
@@ -7147,19 +7176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssociatedFleetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssociatedFleetsSync(ListAssociatedFleetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssociatedFleetsAsync(ListAssociatedFleetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssociatedFleetsAsync(ListAssociatedFleetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartFleet asynchronously, invoking a callback when done
 -- @param StartFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartFleetAsync(StartFleetRequest, cb)
 	assert(StartFleetRequest, "You must provide a StartFleetRequest")
 	local headers = {
@@ -7182,19 +7212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartFleetSync(StartFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartFleetAsync(StartFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartFleetAsync(StartFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserStackAssociations asynchronously, invoking a callback when done
 -- @param DescribeUserStackAssociationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserStackAssociationsAsync(DescribeUserStackAssociationsRequest, cb)
 	assert(DescribeUserStackAssociationsRequest, "You must provide a DescribeUserStackAssociationsRequest")
 	local headers = {
@@ -7217,19 +7248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserStackAssociationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserStackAssociationsSync(DescribeUserStackAssociationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserStackAssociationsAsync(DescribeUserStackAssociationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserStackAssociationsAsync(DescribeUserStackAssociationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStacks asynchronously, invoking a callback when done
 -- @param DescribeStacksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStacksAsync(DescribeStacksRequest, cb)
 	assert(DescribeStacksRequest, "You must provide a DescribeStacksRequest")
 	local headers = {
@@ -7252,19 +7284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStacksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStacksSync(DescribeStacksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStacksAsync(DescribeStacksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStacksAsync(DescribeStacksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchAssociateUserStack asynchronously, invoking a callback when done
 -- @param BatchAssociateUserStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchAssociateUserStackAsync(BatchAssociateUserStackRequest, cb)
 	assert(BatchAssociateUserStackRequest, "You must provide a BatchAssociateUserStackRequest")
 	local headers = {
@@ -7287,19 +7320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchAssociateUserStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchAssociateUserStackSync(BatchAssociateUserStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchAssociateUserStackAsync(BatchAssociateUserStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchAssociateUserStackAsync(BatchAssociateUserStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -7322,19 +7356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStreamingURL asynchronously, invoking a callback when done
 -- @param CreateStreamingURLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStreamingURLAsync(CreateStreamingURLRequest, cb)
 	assert(CreateStreamingURLRequest, "You must provide a CreateStreamingURLRequest")
 	local headers = {
@@ -7357,19 +7392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStreamingURLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStreamingURLSync(CreateStreamingURLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStreamingURLAsync(CreateStreamingURLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStreamingURLAsync(CreateStreamingURLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -7392,19 +7428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateFleet asynchronously, invoking a callback when done
 -- @param DisassociateFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateFleetAsync(DisassociateFleetRequest, cb)
 	assert(DisassociateFleetRequest, "You must provide a DisassociateFleetRequest")
 	local headers = {
@@ -7427,19 +7464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateFleetSync(DisassociateFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateFleetAsync(DisassociateFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateFleetAsync(DisassociateFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteImagePermissions asynchronously, invoking a callback when done
 -- @param DeleteImagePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteImagePermissionsAsync(DeleteImagePermissionsRequest, cb)
 	assert(DeleteImagePermissionsRequest, "You must provide a DeleteImagePermissionsRequest")
 	local headers = {
@@ -7462,19 +7500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteImagePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteImagePermissionsSync(DeleteImagePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteImagePermissionsAsync(DeleteImagePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteImagePermissionsAsync(DeleteImagePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStack asynchronously, invoking a callback when done
 -- @param DeleteStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStackAsync(DeleteStackRequest, cb)
 	assert(DeleteStackRequest, "You must provide a DeleteStackRequest")
 	local headers = {
@@ -7497,19 +7536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStackSync(DeleteStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStackAsync(DeleteStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStackAsync(DeleteStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUser asynchronously, invoking a callback when done
 -- @param CreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserAsync(CreateUserRequest, cb)
 	assert(CreateUserRequest, "You must provide a CreateUserRequest")
 	local headers = {
@@ -7532,19 +7572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserSync(CreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserAsync(CreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserAsync(CreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDirectoryConfig asynchronously, invoking a callback when done
 -- @param DeleteDirectoryConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDirectoryConfigAsync(DeleteDirectoryConfigRequest, cb)
 	assert(DeleteDirectoryConfigRequest, "You must provide a DeleteDirectoryConfigRequest")
 	local headers = {
@@ -7567,19 +7608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDirectoryConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDirectoryConfigSync(DeleteDirectoryConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDirectoryConfigAsync(DeleteDirectoryConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDirectoryConfigAsync(DeleteDirectoryConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteImage asynchronously, invoking a callback when done
 -- @param DeleteImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteImageAsync(DeleteImageRequest, cb)
 	assert(DeleteImageRequest, "You must provide a DeleteImageRequest")
 	local headers = {
@@ -7602,19 +7644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteImageSync(DeleteImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteImageAsync(DeleteImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteImageAsync(DeleteImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartImageBuilder asynchronously, invoking a callback when done
 -- @param StartImageBuilderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartImageBuilderAsync(StartImageBuilderRequest, cb)
 	assert(StartImageBuilderRequest, "You must provide a StartImageBuilderRequest")
 	local headers = {
@@ -7637,12 +7680,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartImageBuilderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartImageBuilderSync(StartImageBuilderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartImageBuilderAsync(StartImageBuilderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartImageBuilderAsync(StartImageBuilderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/appsync.lua
+++ b/aws-sdk/appsync.lua
@@ -3653,7 +3653,7 @@ end
 --
 --- Call UpdateResolver asynchronously, invoking a callback when done
 -- @param UpdateResolverRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateResolverAsync(UpdateResolverRequest, cb)
 	assert(UpdateResolverRequest, "You must provide a UpdateResolverRequest")
 	local headers = {
@@ -3676,19 +3676,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateResolverRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateResolverSync(UpdateResolverRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateResolverAsync(UpdateResolverRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateResolverAsync(UpdateResolverRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGraphqlApi asynchronously, invoking a callback when done
 -- @param GetGraphqlApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGraphqlApiAsync(GetGraphqlApiRequest, cb)
 	assert(GetGraphqlApiRequest, "You must provide a GetGraphqlApiRequest")
 	local headers = {
@@ -3711,19 +3712,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGraphqlApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGraphqlApiSync(GetGraphqlApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGraphqlApiAsync(GetGraphqlApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGraphqlApiAsync(GetGraphqlApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResolver asynchronously, invoking a callback when done
 -- @param CreateResolverRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResolverAsync(CreateResolverRequest, cb)
 	assert(CreateResolverRequest, "You must provide a CreateResolverRequest")
 	local headers = {
@@ -3746,19 +3748,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResolverRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResolverSync(CreateResolverRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResolverAsync(CreateResolverRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResolverAsync(CreateResolverRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTypes asynchronously, invoking a callback when done
 -- @param ListTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTypesAsync(ListTypesRequest, cb)
 	assert(ListTypesRequest, "You must provide a ListTypesRequest")
 	local headers = {
@@ -3781,19 +3784,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTypesSync(ListTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTypesAsync(ListTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTypesAsync(ListTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListApiKeys asynchronously, invoking a callback when done
 -- @param ListApiKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListApiKeysAsync(ListApiKeysRequest, cb)
 	assert(ListApiKeysRequest, "You must provide a ListApiKeysRequest")
 	local headers = {
@@ -3816,19 +3820,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListApiKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListApiKeysSync(ListApiKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListApiKeysAsync(ListApiKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListApiKeysAsync(ListApiKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGraphqlApis asynchronously, invoking a callback when done
 -- @param ListGraphqlApisRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGraphqlApisAsync(ListGraphqlApisRequest, cb)
 	assert(ListGraphqlApisRequest, "You must provide a ListGraphqlApisRequest")
 	local headers = {
@@ -3851,19 +3856,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGraphqlApisRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGraphqlApisSync(ListGraphqlApisRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGraphqlApisAsync(ListGraphqlApisRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGraphqlApisAsync(ListGraphqlApisRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGraphqlApi asynchronously, invoking a callback when done
 -- @param DeleteGraphqlApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGraphqlApiAsync(DeleteGraphqlApiRequest, cb)
 	assert(DeleteGraphqlApiRequest, "You must provide a DeleteGraphqlApiRequest")
 	local headers = {
@@ -3886,19 +3892,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGraphqlApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGraphqlApiSync(DeleteGraphqlApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGraphqlApiAsync(DeleteGraphqlApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGraphqlApiAsync(DeleteGraphqlApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIntrospectionSchema asynchronously, invoking a callback when done
 -- @param GetIntrospectionSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIntrospectionSchemaAsync(GetIntrospectionSchemaRequest, cb)
 	assert(GetIntrospectionSchemaRequest, "You must provide a GetIntrospectionSchemaRequest")
 	local headers = {
@@ -3921,19 +3928,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIntrospectionSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIntrospectionSchemaSync(GetIntrospectionSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIntrospectionSchemaAsync(GetIntrospectionSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIntrospectionSchemaAsync(GetIntrospectionSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResolvers asynchronously, invoking a callback when done
 -- @param ListResolversRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResolversAsync(ListResolversRequest, cb)
 	assert(ListResolversRequest, "You must provide a ListResolversRequest")
 	local headers = {
@@ -3956,19 +3964,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResolversRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResolversSync(ListResolversRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResolversAsync(ListResolversRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResolversAsync(ListResolversRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResolver asynchronously, invoking a callback when done
 -- @param GetResolverRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResolverAsync(GetResolverRequest, cb)
 	assert(GetResolverRequest, "You must provide a GetResolverRequest")
 	local headers = {
@@ -3991,19 +4000,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResolverRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResolverSync(GetResolverRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResolverAsync(GetResolverRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResolverAsync(GetResolverRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDataSource asynchronously, invoking a callback when done
 -- @param UpdateDataSourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDataSourceAsync(UpdateDataSourceRequest, cb)
 	assert(UpdateDataSourceRequest, "You must provide a UpdateDataSourceRequest")
 	local headers = {
@@ -4026,19 +4036,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDataSourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDataSourceSync(UpdateDataSourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDataSourceAsync(UpdateDataSourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDataSourceAsync(UpdateDataSourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResolver asynchronously, invoking a callback when done
 -- @param DeleteResolverRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResolverAsync(DeleteResolverRequest, cb)
 	assert(DeleteResolverRequest, "You must provide a DeleteResolverRequest")
 	local headers = {
@@ -4061,19 +4072,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResolverRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResolverSync(DeleteResolverRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResolverAsync(DeleteResolverRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResolverAsync(DeleteResolverRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApiKey asynchronously, invoking a callback when done
 -- @param UpdateApiKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApiKeyAsync(UpdateApiKeyRequest, cb)
 	assert(UpdateApiKeyRequest, "You must provide a UpdateApiKeyRequest")
 	local headers = {
@@ -4096,19 +4108,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApiKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApiKeySync(UpdateApiKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApiKeyAsync(UpdateApiKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApiKeyAsync(UpdateApiKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSchemaCreationStatus asynchronously, invoking a callback when done
 -- @param GetSchemaCreationStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSchemaCreationStatusAsync(GetSchemaCreationStatusRequest, cb)
 	assert(GetSchemaCreationStatusRequest, "You must provide a GetSchemaCreationStatusRequest")
 	local headers = {
@@ -4131,19 +4144,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSchemaCreationStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSchemaCreationStatusSync(GetSchemaCreationStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSchemaCreationStatusAsync(GetSchemaCreationStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSchemaCreationStatusAsync(GetSchemaCreationStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateType asynchronously, invoking a callback when done
 -- @param UpdateTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTypeAsync(UpdateTypeRequest, cb)
 	assert(UpdateTypeRequest, "You must provide a UpdateTypeRequest")
 	local headers = {
@@ -4166,19 +4180,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTypeSync(UpdateTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTypeAsync(UpdateTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTypeAsync(UpdateTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGraphqlApi asynchronously, invoking a callback when done
 -- @param CreateGraphqlApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGraphqlApiAsync(CreateGraphqlApiRequest, cb)
 	assert(CreateGraphqlApiRequest, "You must provide a CreateGraphqlApiRequest")
 	local headers = {
@@ -4201,19 +4216,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGraphqlApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGraphqlApiSync(CreateGraphqlApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGraphqlApiAsync(CreateGraphqlApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGraphqlApiAsync(CreateGraphqlApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateType asynchronously, invoking a callback when done
 -- @param CreateTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTypeAsync(CreateTypeRequest, cb)
 	assert(CreateTypeRequest, "You must provide a CreateTypeRequest")
 	local headers = {
@@ -4236,19 +4252,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTypeSync(CreateTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTypeAsync(CreateTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTypeAsync(CreateTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDataSource asynchronously, invoking a callback when done
 -- @param DeleteDataSourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDataSourceAsync(DeleteDataSourceRequest, cb)
 	assert(DeleteDataSourceRequest, "You must provide a DeleteDataSourceRequest")
 	local headers = {
@@ -4271,19 +4288,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDataSourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDataSourceSync(DeleteDataSourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDataSourceAsync(DeleteDataSourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDataSourceAsync(DeleteDataSourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApiKey asynchronously, invoking a callback when done
 -- @param CreateApiKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApiKeyAsync(CreateApiKeyRequest, cb)
 	assert(CreateApiKeyRequest, "You must provide a CreateApiKeyRequest")
 	local headers = {
@@ -4306,19 +4324,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApiKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApiKeySync(CreateApiKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApiKeyAsync(CreateApiKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApiKeyAsync(CreateApiKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDataSources asynchronously, invoking a callback when done
 -- @param ListDataSourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDataSourcesAsync(ListDataSourcesRequest, cb)
 	assert(ListDataSourcesRequest, "You must provide a ListDataSourcesRequest")
 	local headers = {
@@ -4341,19 +4360,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDataSourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDataSourcesSync(ListDataSourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDataSourcesAsync(ListDataSourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDataSourcesAsync(ListDataSourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSchemaCreation asynchronously, invoking a callback when done
 -- @param StartSchemaCreationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSchemaCreationAsync(StartSchemaCreationRequest, cb)
 	assert(StartSchemaCreationRequest, "You must provide a StartSchemaCreationRequest")
 	local headers = {
@@ -4376,19 +4396,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSchemaCreationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSchemaCreationSync(StartSchemaCreationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSchemaCreationAsync(StartSchemaCreationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSchemaCreationAsync(StartSchemaCreationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDataSource asynchronously, invoking a callback when done
 -- @param CreateDataSourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDataSourceAsync(CreateDataSourceRequest, cb)
 	assert(CreateDataSourceRequest, "You must provide a CreateDataSourceRequest")
 	local headers = {
@@ -4411,19 +4432,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDataSourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDataSourceSync(CreateDataSourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDataSourceAsync(CreateDataSourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDataSourceAsync(CreateDataSourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetType asynchronously, invoking a callback when done
 -- @param GetTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTypeAsync(GetTypeRequest, cb)
 	assert(GetTypeRequest, "You must provide a GetTypeRequest")
 	local headers = {
@@ -4446,19 +4468,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTypeSync(GetTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTypeAsync(GetTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTypeAsync(GetTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDataSource asynchronously, invoking a callback when done
 -- @param GetDataSourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDataSourceAsync(GetDataSourceRequest, cb)
 	assert(GetDataSourceRequest, "You must provide a GetDataSourceRequest")
 	local headers = {
@@ -4481,19 +4504,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDataSourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDataSourceSync(GetDataSourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDataSourceAsync(GetDataSourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDataSourceAsync(GetDataSourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteType asynchronously, invoking a callback when done
 -- @param DeleteTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTypeAsync(DeleteTypeRequest, cb)
 	assert(DeleteTypeRequest, "You must provide a DeleteTypeRequest")
 	local headers = {
@@ -4516,19 +4540,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTypeSync(DeleteTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTypeAsync(DeleteTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTypeAsync(DeleteTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApiKey asynchronously, invoking a callback when done
 -- @param DeleteApiKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApiKeyAsync(DeleteApiKeyRequest, cb)
 	assert(DeleteApiKeyRequest, "You must provide a DeleteApiKeyRequest")
 	local headers = {
@@ -4551,19 +4576,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApiKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApiKeySync(DeleteApiKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApiKeyAsync(DeleteApiKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApiKeyAsync(DeleteApiKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGraphqlApi asynchronously, invoking a callback when done
 -- @param UpdateGraphqlApiRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGraphqlApiAsync(UpdateGraphqlApiRequest, cb)
 	assert(UpdateGraphqlApiRequest, "You must provide a UpdateGraphqlApiRequest")
 	local headers = {
@@ -4586,12 +4612,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGraphqlApiRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGraphqlApiSync(UpdateGraphqlApiRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGraphqlApiAsync(UpdateGraphqlApiRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGraphqlApiAsync(UpdateGraphqlApiRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/athena.lua
+++ b/aws-sdk/athena.lua
@@ -1976,7 +1976,7 @@ end
 --
 --- Call BatchGetQueryExecution asynchronously, invoking a callback when done
 -- @param BatchGetQueryExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetQueryExecutionAsync(BatchGetQueryExecutionInput, cb)
 	assert(BatchGetQueryExecutionInput, "You must provide a BatchGetQueryExecutionInput")
 	local headers = {
@@ -1999,19 +1999,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetQueryExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetQueryExecutionSync(BatchGetQueryExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetQueryExecutionAsync(BatchGetQueryExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetQueryExecutionAsync(BatchGetQueryExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNamedQuery asynchronously, invoking a callback when done
 -- @param DeleteNamedQueryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNamedQueryAsync(DeleteNamedQueryInput, cb)
 	assert(DeleteNamedQueryInput, "You must provide a DeleteNamedQueryInput")
 	local headers = {
@@ -2034,19 +2035,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNamedQueryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNamedQuerySync(DeleteNamedQueryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNamedQueryAsync(DeleteNamedQueryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNamedQueryAsync(DeleteNamedQueryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListNamedQueries asynchronously, invoking a callback when done
 -- @param ListNamedQueriesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListNamedQueriesAsync(ListNamedQueriesInput, cb)
 	assert(ListNamedQueriesInput, "You must provide a ListNamedQueriesInput")
 	local headers = {
@@ -2069,19 +2071,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListNamedQueriesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListNamedQueriesSync(ListNamedQueriesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListNamedQueriesAsync(ListNamedQueriesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListNamedQueriesAsync(ListNamedQueriesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopQueryExecution asynchronously, invoking a callback when done
 -- @param StopQueryExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopQueryExecutionAsync(StopQueryExecutionInput, cb)
 	assert(StopQueryExecutionInput, "You must provide a StopQueryExecutionInput")
 	local headers = {
@@ -2104,19 +2107,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopQueryExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopQueryExecutionSync(StopQueryExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopQueryExecutionAsync(StopQueryExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopQueryExecutionAsync(StopQueryExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetNamedQuery asynchronously, invoking a callback when done
 -- @param BatchGetNamedQueryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetNamedQueryAsync(BatchGetNamedQueryInput, cb)
 	assert(BatchGetNamedQueryInput, "You must provide a BatchGetNamedQueryInput")
 	local headers = {
@@ -2139,19 +2143,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetNamedQueryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetNamedQuerySync(BatchGetNamedQueryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetNamedQueryAsync(BatchGetNamedQueryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetNamedQueryAsync(BatchGetNamedQueryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartQueryExecution asynchronously, invoking a callback when done
 -- @param StartQueryExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartQueryExecutionAsync(StartQueryExecutionInput, cb)
 	assert(StartQueryExecutionInput, "You must provide a StartQueryExecutionInput")
 	local headers = {
@@ -2174,19 +2179,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartQueryExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartQueryExecutionSync(StartQueryExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartQueryExecutionAsync(StartQueryExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartQueryExecutionAsync(StartQueryExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetNamedQuery asynchronously, invoking a callback when done
 -- @param GetNamedQueryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetNamedQueryAsync(GetNamedQueryInput, cb)
 	assert(GetNamedQueryInput, "You must provide a GetNamedQueryInput")
 	local headers = {
@@ -2209,19 +2215,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetNamedQueryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetNamedQuerySync(GetNamedQueryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetNamedQueryAsync(GetNamedQueryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetNamedQueryAsync(GetNamedQueryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListQueryExecutions asynchronously, invoking a callback when done
 -- @param ListQueryExecutionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListQueryExecutionsAsync(ListQueryExecutionsInput, cb)
 	assert(ListQueryExecutionsInput, "You must provide a ListQueryExecutionsInput")
 	local headers = {
@@ -2244,19 +2251,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListQueryExecutionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListQueryExecutionsSync(ListQueryExecutionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListQueryExecutionsAsync(ListQueryExecutionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListQueryExecutionsAsync(ListQueryExecutionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQueryExecution asynchronously, invoking a callback when done
 -- @param GetQueryExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQueryExecutionAsync(GetQueryExecutionInput, cb)
 	assert(GetQueryExecutionInput, "You must provide a GetQueryExecutionInput")
 	local headers = {
@@ -2279,19 +2287,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQueryExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQueryExecutionSync(GetQueryExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQueryExecutionAsync(GetQueryExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQueryExecutionAsync(GetQueryExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQueryResults asynchronously, invoking a callback when done
 -- @param GetQueryResultsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQueryResultsAsync(GetQueryResultsInput, cb)
 	assert(GetQueryResultsInput, "You must provide a GetQueryResultsInput")
 	local headers = {
@@ -2314,19 +2323,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQueryResultsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQueryResultsSync(GetQueryResultsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQueryResultsAsync(GetQueryResultsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQueryResultsAsync(GetQueryResultsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNamedQuery asynchronously, invoking a callback when done
 -- @param CreateNamedQueryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNamedQueryAsync(CreateNamedQueryInput, cb)
 	assert(CreateNamedQueryInput, "You must provide a CreateNamedQueryInput")
 	local headers = {
@@ -2349,12 +2359,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNamedQueryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNamedQuerySync(CreateNamedQueryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNamedQueryAsync(CreateNamedQueryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNamedQueryAsync(CreateNamedQueryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/autoscaling.lua
+++ b/aws-sdk/autoscaling.lua
@@ -1711,7 +1711,7 @@ end
 --
 --- Call DescribeScalingPlanResources asynchronously, invoking a callback when done
 -- @param DescribeScalingPlanResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScalingPlanResourcesAsync(DescribeScalingPlanResourcesRequest, cb)
 	assert(DescribeScalingPlanResourcesRequest, "You must provide a DescribeScalingPlanResourcesRequest")
 	local headers = {
@@ -1734,19 +1734,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScalingPlanResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScalingPlanResourcesSync(DescribeScalingPlanResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScalingPlanResourcesAsync(DescribeScalingPlanResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScalingPlanResourcesAsync(DescribeScalingPlanResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateScalingPlan asynchronously, invoking a callback when done
 -- @param CreateScalingPlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateScalingPlanAsync(CreateScalingPlanRequest, cb)
 	assert(CreateScalingPlanRequest, "You must provide a CreateScalingPlanRequest")
 	local headers = {
@@ -1769,19 +1770,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateScalingPlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateScalingPlanSync(CreateScalingPlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateScalingPlanAsync(CreateScalingPlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateScalingPlanAsync(CreateScalingPlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteScalingPlan asynchronously, invoking a callback when done
 -- @param DeleteScalingPlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteScalingPlanAsync(DeleteScalingPlanRequest, cb)
 	assert(DeleteScalingPlanRequest, "You must provide a DeleteScalingPlanRequest")
 	local headers = {
@@ -1804,19 +1806,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteScalingPlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteScalingPlanSync(DeleteScalingPlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteScalingPlanAsync(DeleteScalingPlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteScalingPlanAsync(DeleteScalingPlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeScalingPlans asynchronously, invoking a callback when done
 -- @param DescribeScalingPlansRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScalingPlansAsync(DescribeScalingPlansRequest, cb)
 	assert(DescribeScalingPlansRequest, "You must provide a DescribeScalingPlansRequest")
 	local headers = {
@@ -1839,19 +1842,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScalingPlansRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScalingPlansSync(DescribeScalingPlansRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScalingPlansAsync(DescribeScalingPlansRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScalingPlansAsync(DescribeScalingPlansRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateScalingPlan asynchronously, invoking a callback when done
 -- @param UpdateScalingPlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateScalingPlanAsync(UpdateScalingPlanRequest, cb)
 	assert(UpdateScalingPlanRequest, "You must provide a UpdateScalingPlanRequest")
 	local headers = {
@@ -1874,12 +1878,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateScalingPlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateScalingPlanSync(UpdateScalingPlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateScalingPlanAsync(UpdateScalingPlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateScalingPlanAsync(UpdateScalingPlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/batch.lua
+++ b/aws-sdk/batch.lua
@@ -3218,7 +3218,7 @@ end
 --
 --- Call ListJobs asynchronously, invoking a callback when done
 -- @param ListJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsAsync(ListJobsRequest, cb)
 	assert(ListJobsRequest, "You must provide a ListJobsRequest")
 	local headers = {
@@ -3241,19 +3241,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsSync(ListJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsAsync(ListJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsAsync(ListJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SubmitJob asynchronously, invoking a callback when done
 -- @param SubmitJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SubmitJobAsync(SubmitJobRequest, cb)
 	assert(SubmitJobRequest, "You must provide a SubmitJobRequest")
 	local headers = {
@@ -3276,19 +3277,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SubmitJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SubmitJobSync(SubmitJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SubmitJobAsync(SubmitJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SubmitJobAsync(SubmitJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateJobQueue asynchronously, invoking a callback when done
 -- @param UpdateJobQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateJobQueueAsync(UpdateJobQueueRequest, cb)
 	assert(UpdateJobQueueRequest, "You must provide a UpdateJobQueueRequest")
 	local headers = {
@@ -3311,19 +3313,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateJobQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateJobQueueSync(UpdateJobQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateJobQueueAsync(UpdateJobQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateJobQueueAsync(UpdateJobQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateComputeEnvironment asynchronously, invoking a callback when done
 -- @param UpdateComputeEnvironmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateComputeEnvironmentAsync(UpdateComputeEnvironmentRequest, cb)
 	assert(UpdateComputeEnvironmentRequest, "You must provide a UpdateComputeEnvironmentRequest")
 	local headers = {
@@ -3346,19 +3349,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateComputeEnvironmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateComputeEnvironmentSync(UpdateComputeEnvironmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateComputeEnvironmentAsync(UpdateComputeEnvironmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateComputeEnvironmentAsync(UpdateComputeEnvironmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterJobDefinition asynchronously, invoking a callback when done
 -- @param DeregisterJobDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterJobDefinitionAsync(DeregisterJobDefinitionRequest, cb)
 	assert(DeregisterJobDefinitionRequest, "You must provide a DeregisterJobDefinitionRequest")
 	local headers = {
@@ -3381,19 +3385,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterJobDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterJobDefinitionSync(DeregisterJobDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterJobDefinitionAsync(DeregisterJobDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterJobDefinitionAsync(DeregisterJobDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJobQueues asynchronously, invoking a callback when done
 -- @param DescribeJobQueuesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobQueuesAsync(DescribeJobQueuesRequest, cb)
 	assert(DescribeJobQueuesRequest, "You must provide a DescribeJobQueuesRequest")
 	local headers = {
@@ -3416,19 +3421,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobQueuesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobQueuesSync(DescribeJobQueuesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobQueuesAsync(DescribeJobQueuesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobQueuesAsync(DescribeJobQueuesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateComputeEnvironment asynchronously, invoking a callback when done
 -- @param CreateComputeEnvironmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateComputeEnvironmentAsync(CreateComputeEnvironmentRequest, cb)
 	assert(CreateComputeEnvironmentRequest, "You must provide a CreateComputeEnvironmentRequest")
 	local headers = {
@@ -3451,19 +3457,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateComputeEnvironmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateComputeEnvironmentSync(CreateComputeEnvironmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateComputeEnvironmentAsync(CreateComputeEnvironmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateComputeEnvironmentAsync(CreateComputeEnvironmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteComputeEnvironment asynchronously, invoking a callback when done
 -- @param DeleteComputeEnvironmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteComputeEnvironmentAsync(DeleteComputeEnvironmentRequest, cb)
 	assert(DeleteComputeEnvironmentRequest, "You must provide a DeleteComputeEnvironmentRequest")
 	local headers = {
@@ -3486,19 +3493,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteComputeEnvironmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteComputeEnvironmentSync(DeleteComputeEnvironmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteComputeEnvironmentAsync(DeleteComputeEnvironmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteComputeEnvironmentAsync(DeleteComputeEnvironmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeComputeEnvironments asynchronously, invoking a callback when done
 -- @param DescribeComputeEnvironmentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeComputeEnvironmentsAsync(DescribeComputeEnvironmentsRequest, cb)
 	assert(DescribeComputeEnvironmentsRequest, "You must provide a DescribeComputeEnvironmentsRequest")
 	local headers = {
@@ -3521,19 +3529,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeComputeEnvironmentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeComputeEnvironmentsSync(DescribeComputeEnvironmentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeComputeEnvironmentsAsync(DescribeComputeEnvironmentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeComputeEnvironmentsAsync(DescribeComputeEnvironmentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJobQueue asynchronously, invoking a callback when done
 -- @param CreateJobQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobQueueAsync(CreateJobQueueRequest, cb)
 	assert(CreateJobQueueRequest, "You must provide a CreateJobQueueRequest")
 	local headers = {
@@ -3556,19 +3565,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobQueueSync(CreateJobQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobQueueAsync(CreateJobQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobQueueAsync(CreateJobQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterJobDefinition asynchronously, invoking a callback when done
 -- @param RegisterJobDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterJobDefinitionAsync(RegisterJobDefinitionRequest, cb)
 	assert(RegisterJobDefinitionRequest, "You must provide a RegisterJobDefinitionRequest")
 	local headers = {
@@ -3591,19 +3601,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterJobDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterJobDefinitionSync(RegisterJobDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterJobDefinitionAsync(RegisterJobDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterJobDefinitionAsync(RegisterJobDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelJob asynchronously, invoking a callback when done
 -- @param CancelJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelJobAsync(CancelJobRequest, cb)
 	assert(CancelJobRequest, "You must provide a CancelJobRequest")
 	local headers = {
@@ -3626,19 +3637,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelJobSync(CancelJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelJobAsync(CancelJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelJobAsync(CancelJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJobDefinitions asynchronously, invoking a callback when done
 -- @param DescribeJobDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobDefinitionsAsync(DescribeJobDefinitionsRequest, cb)
 	assert(DescribeJobDefinitionsRequest, "You must provide a DescribeJobDefinitionsRequest")
 	local headers = {
@@ -3661,19 +3673,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobDefinitionsSync(DescribeJobDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobDefinitionsAsync(DescribeJobDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobDefinitionsAsync(DescribeJobDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteJobQueue asynchronously, invoking a callback when done
 -- @param DeleteJobQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteJobQueueAsync(DeleteJobQueueRequest, cb)
 	assert(DeleteJobQueueRequest, "You must provide a DeleteJobQueueRequest")
 	local headers = {
@@ -3696,19 +3709,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteJobQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteJobQueueSync(DeleteJobQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteJobQueueAsync(DeleteJobQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteJobQueueAsync(DeleteJobQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJobs asynchronously, invoking a callback when done
 -- @param DescribeJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobsAsync(DescribeJobsRequest, cb)
 	assert(DescribeJobsRequest, "You must provide a DescribeJobsRequest")
 	local headers = {
@@ -3731,19 +3745,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobsSync(DescribeJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobsAsync(DescribeJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobsAsync(DescribeJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateJob asynchronously, invoking a callback when done
 -- @param TerminateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateJobAsync(TerminateJobRequest, cb)
 	assert(TerminateJobRequest, "You must provide a TerminateJobRequest")
 	local headers = {
@@ -3766,12 +3781,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateJobSync(TerminateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateJobAsync(TerminateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateJobAsync(TerminateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/budgets.lua
+++ b/aws-sdk/budgets.lua
@@ -2121,7 +2121,7 @@ end
 --
 --- Call DescribeBudget asynchronously, invoking a callback when done
 -- @param DescribeBudgetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBudgetAsync(DescribeBudgetRequest, cb)
 	assert(DescribeBudgetRequest, "You must provide a DescribeBudgetRequest")
 	local headers = {
@@ -2144,19 +2144,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBudgetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBudgetSync(DescribeBudgetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBudgetAsync(DescribeBudgetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBudgetAsync(DescribeBudgetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNotificationsForBudget asynchronously, invoking a callback when done
 -- @param DescribeNotificationsForBudgetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNotificationsForBudgetAsync(DescribeNotificationsForBudgetRequest, cb)
 	assert(DescribeNotificationsForBudgetRequest, "You must provide a DescribeNotificationsForBudgetRequest")
 	local headers = {
@@ -2179,19 +2180,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNotificationsForBudgetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNotificationsForBudgetSync(DescribeNotificationsForBudgetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNotificationsForBudgetAsync(DescribeNotificationsForBudgetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNotificationsForBudgetAsync(DescribeNotificationsForBudgetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSubscriber asynchronously, invoking a callback when done
 -- @param CreateSubscriberRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSubscriberAsync(CreateSubscriberRequest, cb)
 	assert(CreateSubscriberRequest, "You must provide a CreateSubscriberRequest")
 	local headers = {
@@ -2214,19 +2216,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSubscriberRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSubscriberSync(CreateSubscriberRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSubscriberAsync(CreateSubscriberRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSubscriberAsync(CreateSubscriberRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNotification asynchronously, invoking a callback when done
 -- @param CreateNotificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNotificationAsync(CreateNotificationRequest, cb)
 	assert(CreateNotificationRequest, "You must provide a CreateNotificationRequest")
 	local headers = {
@@ -2249,19 +2252,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNotificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNotificationSync(CreateNotificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNotificationAsync(CreateNotificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNotificationAsync(CreateNotificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateNotification asynchronously, invoking a callback when done
 -- @param UpdateNotificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateNotificationAsync(UpdateNotificationRequest, cb)
 	assert(UpdateNotificationRequest, "You must provide a UpdateNotificationRequest")
 	local headers = {
@@ -2284,19 +2288,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateNotificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateNotificationSync(UpdateNotificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateNotificationAsync(UpdateNotificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateNotificationAsync(UpdateNotificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateBudget asynchronously, invoking a callback when done
 -- @param UpdateBudgetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateBudgetAsync(UpdateBudgetRequest, cb)
 	assert(UpdateBudgetRequest, "You must provide a UpdateBudgetRequest")
 	local headers = {
@@ -2319,19 +2324,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateBudgetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateBudgetSync(UpdateBudgetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateBudgetAsync(UpdateBudgetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateBudgetAsync(UpdateBudgetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBudget asynchronously, invoking a callback when done
 -- @param CreateBudgetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBudgetAsync(CreateBudgetRequest, cb)
 	assert(CreateBudgetRequest, "You must provide a CreateBudgetRequest")
 	local headers = {
@@ -2354,19 +2360,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBudgetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBudgetSync(CreateBudgetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBudgetAsync(CreateBudgetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBudgetAsync(CreateBudgetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNotification asynchronously, invoking a callback when done
 -- @param DeleteNotificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNotificationAsync(DeleteNotificationRequest, cb)
 	assert(DeleteNotificationRequest, "You must provide a DeleteNotificationRequest")
 	local headers = {
@@ -2389,19 +2396,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNotificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNotificationSync(DeleteNotificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNotificationAsync(DeleteNotificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNotificationAsync(DeleteNotificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSubscribersForNotification asynchronously, invoking a callback when done
 -- @param DescribeSubscribersForNotificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSubscribersForNotificationAsync(DescribeSubscribersForNotificationRequest, cb)
 	assert(DescribeSubscribersForNotificationRequest, "You must provide a DescribeSubscribersForNotificationRequest")
 	local headers = {
@@ -2424,19 +2432,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSubscribersForNotificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSubscribersForNotificationSync(DescribeSubscribersForNotificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSubscribersForNotificationAsync(DescribeSubscribersForNotificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSubscribersForNotificationAsync(DescribeSubscribersForNotificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSubscriber asynchronously, invoking a callback when done
 -- @param DeleteSubscriberRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSubscriberAsync(DeleteSubscriberRequest, cb)
 	assert(DeleteSubscriberRequest, "You must provide a DeleteSubscriberRequest")
 	local headers = {
@@ -2459,19 +2468,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSubscriberRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSubscriberSync(DeleteSubscriberRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSubscriberAsync(DeleteSubscriberRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSubscriberAsync(DeleteSubscriberRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBudgets asynchronously, invoking a callback when done
 -- @param DescribeBudgetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBudgetsAsync(DescribeBudgetsRequest, cb)
 	assert(DescribeBudgetsRequest, "You must provide a DescribeBudgetsRequest")
 	local headers = {
@@ -2494,19 +2504,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBudgetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBudgetsSync(DescribeBudgetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBudgetsAsync(DescribeBudgetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBudgetsAsync(DescribeBudgetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBudget asynchronously, invoking a callback when done
 -- @param DeleteBudgetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBudgetAsync(DeleteBudgetRequest, cb)
 	assert(DeleteBudgetRequest, "You must provide a DeleteBudgetRequest")
 	local headers = {
@@ -2529,19 +2540,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBudgetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBudgetSync(DeleteBudgetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBudgetAsync(DeleteBudgetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBudgetAsync(DeleteBudgetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSubscriber asynchronously, invoking a callback when done
 -- @param UpdateSubscriberRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSubscriberAsync(UpdateSubscriberRequest, cb)
 	assert(UpdateSubscriberRequest, "You must provide a UpdateSubscriberRequest")
 	local headers = {
@@ -2564,12 +2576,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSubscriberRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSubscriberSync(UpdateSubscriberRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSubscriberAsync(UpdateSubscriberRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSubscriberAsync(UpdateSubscriberRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/ce.lua
+++ b/aws-sdk/ce.lua
@@ -2900,7 +2900,7 @@ end
 --
 --- Call GetTags asynchronously, invoking a callback when done
 -- @param GetTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTagsAsync(GetTagsRequest, cb)
 	assert(GetTagsRequest, "You must provide a GetTagsRequest")
 	local headers = {
@@ -2923,19 +2923,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTagsSync(GetTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTagsAsync(GetTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTagsAsync(GetTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReservationPurchaseRecommendation asynchronously, invoking a callback when done
 -- @param GetReservationPurchaseRecommendationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReservationPurchaseRecommendationAsync(GetReservationPurchaseRecommendationRequest, cb)
 	assert(GetReservationPurchaseRecommendationRequest, "You must provide a GetReservationPurchaseRecommendationRequest")
 	local headers = {
@@ -2958,19 +2959,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReservationPurchaseRecommendationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReservationPurchaseRecommendationSync(GetReservationPurchaseRecommendationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReservationPurchaseRecommendationAsync(GetReservationPurchaseRecommendationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReservationPurchaseRecommendationAsync(GetReservationPurchaseRecommendationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReservationUtilization asynchronously, invoking a callback when done
 -- @param GetReservationUtilizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReservationUtilizationAsync(GetReservationUtilizationRequest, cb)
 	assert(GetReservationUtilizationRequest, "You must provide a GetReservationUtilizationRequest")
 	local headers = {
@@ -2993,19 +2995,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReservationUtilizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReservationUtilizationSync(GetReservationUtilizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReservationUtilizationAsync(GetReservationUtilizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReservationUtilizationAsync(GetReservationUtilizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDimensionValues asynchronously, invoking a callback when done
 -- @param GetDimensionValuesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDimensionValuesAsync(GetDimensionValuesRequest, cb)
 	assert(GetDimensionValuesRequest, "You must provide a GetDimensionValuesRequest")
 	local headers = {
@@ -3028,19 +3031,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDimensionValuesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDimensionValuesSync(GetDimensionValuesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDimensionValuesAsync(GetDimensionValuesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDimensionValuesAsync(GetDimensionValuesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCostAndUsage asynchronously, invoking a callback when done
 -- @param GetCostAndUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCostAndUsageAsync(GetCostAndUsageRequest, cb)
 	assert(GetCostAndUsageRequest, "You must provide a GetCostAndUsageRequest")
 	local headers = {
@@ -3063,19 +3067,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCostAndUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCostAndUsageSync(GetCostAndUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCostAndUsageAsync(GetCostAndUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCostAndUsageAsync(GetCostAndUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReservationCoverage asynchronously, invoking a callback when done
 -- @param GetReservationCoverageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReservationCoverageAsync(GetReservationCoverageRequest, cb)
 	assert(GetReservationCoverageRequest, "You must provide a GetReservationCoverageRequest")
 	local headers = {
@@ -3098,12 +3103,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReservationCoverageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReservationCoverageSync(GetReservationCoverageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReservationCoverageAsync(GetReservationCoverageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReservationCoverageAsync(GetReservationCoverageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/chime.lua
+++ b/aws-sdk/chime.lua
@@ -1944,7 +1944,7 @@ end
 --
 --- Call UpdateUser asynchronously, invoking a callback when done
 -- @param UpdateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserAsync(UpdateUserRequest, cb)
 	assert(UpdateUserRequest, "You must provide a UpdateUserRequest")
 	local headers = {
@@ -1967,19 +1967,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserSync(UpdateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserAsync(UpdateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserAsync(UpdateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAccount asynchronously, invoking a callback when done
 -- @param CreateAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAccountAsync(CreateAccountRequest, cb)
 	assert(CreateAccountRequest, "You must provide a CreateAccountRequest")
 	local headers = {
@@ -2002,19 +2003,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAccountSync(CreateAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAccountAsync(CreateAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAccountAsync(CreateAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAccount asynchronously, invoking a callback when done
 -- @param DeleteAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAccountAsync(DeleteAccountRequest, cb)
 	assert(DeleteAccountRequest, "You must provide a DeleteAccountRequest")
 	local headers = {
@@ -2037,19 +2039,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAccountSync(DeleteAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAccountAsync(DeleteAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAccountAsync(DeleteAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAccounts asynchronously, invoking a callback when done
 -- @param ListAccountsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAccountsAsync(ListAccountsRequest, cb)
 	assert(ListAccountsRequest, "You must provide a ListAccountsRequest")
 	local headers = {
@@ -2072,19 +2075,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAccountsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAccountsSync(ListAccountsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAccountsAsync(ListAccountsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAccountsAsync(ListAccountsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchSuspendUser asynchronously, invoking a callback when done
 -- @param BatchSuspendUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchSuspendUserAsync(BatchSuspendUserRequest, cb)
 	assert(BatchSuspendUserRequest, "You must provide a BatchSuspendUserRequest")
 	local headers = {
@@ -2107,19 +2111,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchSuspendUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchSuspendUserSync(BatchSuspendUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchSuspendUserAsync(BatchSuspendUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchSuspendUserAsync(BatchSuspendUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetPersonalPIN asynchronously, invoking a callback when done
 -- @param ResetPersonalPINRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetPersonalPINAsync(ResetPersonalPINRequest, cb)
 	assert(ResetPersonalPINRequest, "You must provide a ResetPersonalPINRequest")
 	local headers = {
@@ -2142,19 +2147,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetPersonalPINRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetPersonalPINSync(ResetPersonalPINRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetPersonalPINAsync(ResetPersonalPINRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetPersonalPINAsync(ResetPersonalPINRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAccount asynchronously, invoking a callback when done
 -- @param UpdateAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAccountAsync(UpdateAccountRequest, cb)
 	assert(UpdateAccountRequest, "You must provide a UpdateAccountRequest")
 	local headers = {
@@ -2177,19 +2183,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAccountSync(UpdateAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAccountAsync(UpdateAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAccountAsync(UpdateAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchUnsuspendUser asynchronously, invoking a callback when done
 -- @param BatchUnsuspendUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchUnsuspendUserAsync(BatchUnsuspendUserRequest, cb)
 	assert(BatchUnsuspendUserRequest, "You must provide a BatchUnsuspendUserRequest")
 	local headers = {
@@ -2212,19 +2219,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchUnsuspendUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchUnsuspendUserSync(BatchUnsuspendUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchUnsuspendUserAsync(BatchUnsuspendUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchUnsuspendUserAsync(BatchUnsuspendUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUsers asynchronously, invoking a callback when done
 -- @param ListUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUsersAsync(ListUsersRequest, cb)
 	assert(ListUsersRequest, "You must provide a ListUsersRequest")
 	local headers = {
@@ -2247,19 +2255,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUsersSync(ListUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUsersAsync(ListUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUsersAsync(ListUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUser asynchronously, invoking a callback when done
 -- @param GetUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserAsync(GetUserRequest, cb)
 	assert(GetUserRequest, "You must provide a GetUserRequest")
 	local headers = {
@@ -2282,19 +2291,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserSync(GetUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserAsync(GetUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserAsync(GetUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountSettings asynchronously, invoking a callback when done
 -- @param GetAccountSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountSettingsAsync(GetAccountSettingsRequest, cb)
 	assert(GetAccountSettingsRequest, "You must provide a GetAccountSettingsRequest")
 	local headers = {
@@ -2317,19 +2327,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountSettingsSync(GetAccountSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountSettingsAsync(GetAccountSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountSettingsAsync(GetAccountSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call LogoutUser asynchronously, invoking a callback when done
 -- @param LogoutUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.LogoutUserAsync(LogoutUserRequest, cb)
 	assert(LogoutUserRequest, "You must provide a LogoutUserRequest")
 	local headers = {
@@ -2352,19 +2363,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param LogoutUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.LogoutUserSync(LogoutUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.LogoutUserAsync(LogoutUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.LogoutUserAsync(LogoutUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAccountSettings asynchronously, invoking a callback when done
 -- @param UpdateAccountSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAccountSettingsAsync(UpdateAccountSettingsRequest, cb)
 	assert(UpdateAccountSettingsRequest, "You must provide a UpdateAccountSettingsRequest")
 	local headers = {
@@ -2387,19 +2399,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAccountSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAccountSettingsSync(UpdateAccountSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAccountSettingsAsync(UpdateAccountSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAccountSettingsAsync(UpdateAccountSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccount asynchronously, invoking a callback when done
 -- @param GetAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountAsync(GetAccountRequest, cb)
 	assert(GetAccountRequest, "You must provide a GetAccountRequest")
 	local headers = {
@@ -2422,19 +2435,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountSync(GetAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountAsync(GetAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountAsync(GetAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchUpdateUser asynchronously, invoking a callback when done
 -- @param BatchUpdateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchUpdateUserAsync(BatchUpdateUserRequest, cb)
 	assert(BatchUpdateUserRequest, "You must provide a BatchUpdateUserRequest")
 	local headers = {
@@ -2457,19 +2471,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchUpdateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchUpdateUserSync(BatchUpdateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchUpdateUserAsync(BatchUpdateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchUpdateUserAsync(BatchUpdateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InviteUsers asynchronously, invoking a callback when done
 -- @param InviteUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InviteUsersAsync(InviteUsersRequest, cb)
 	assert(InviteUsersRequest, "You must provide a InviteUsersRequest")
 	local headers = {
@@ -2492,12 +2507,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InviteUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InviteUsersSync(InviteUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InviteUsersAsync(InviteUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InviteUsersAsync(InviteUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloud9.lua
+++ b/aws-sdk/cloud9.lua
@@ -1477,7 +1477,7 @@ end
 --
 --- Call UpdateEnvironment asynchronously, invoking a callback when done
 -- @param UpdateEnvironmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEnvironmentAsync(UpdateEnvironmentRequest, cb)
 	assert(UpdateEnvironmentRequest, "You must provide a UpdateEnvironmentRequest")
 	local headers = {
@@ -1500,19 +1500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEnvironmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEnvironmentSync(UpdateEnvironmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEnvironmentAsync(UpdateEnvironmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEnvironmentAsync(UpdateEnvironmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEnvironmentMembership asynchronously, invoking a callback when done
 -- @param CreateEnvironmentMembershipRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEnvironmentMembershipAsync(CreateEnvironmentMembershipRequest, cb)
 	assert(CreateEnvironmentMembershipRequest, "You must provide a CreateEnvironmentMembershipRequest")
 	local headers = {
@@ -1535,19 +1536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEnvironmentMembershipRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEnvironmentMembershipSync(CreateEnvironmentMembershipRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEnvironmentMembershipAsync(CreateEnvironmentMembershipRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEnvironmentMembershipAsync(CreateEnvironmentMembershipRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironments asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentsAsync(DescribeEnvironmentsRequest, cb)
 	assert(DescribeEnvironmentsRequest, "You must provide a DescribeEnvironmentsRequest")
 	local headers = {
@@ -1570,19 +1572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentsSync(DescribeEnvironmentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentsAsync(DescribeEnvironmentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentsAsync(DescribeEnvironmentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEnvironmentMembership asynchronously, invoking a callback when done
 -- @param DeleteEnvironmentMembershipRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEnvironmentMembershipAsync(DeleteEnvironmentMembershipRequest, cb)
 	assert(DeleteEnvironmentMembershipRequest, "You must provide a DeleteEnvironmentMembershipRequest")
 	local headers = {
@@ -1605,19 +1608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEnvironmentMembershipRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEnvironmentMembershipSync(DeleteEnvironmentMembershipRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEnvironmentMembershipAsync(DeleteEnvironmentMembershipRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEnvironmentMembershipAsync(DeleteEnvironmentMembershipRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEnvironmentMembership asynchronously, invoking a callback when done
 -- @param UpdateEnvironmentMembershipRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEnvironmentMembershipAsync(UpdateEnvironmentMembershipRequest, cb)
 	assert(UpdateEnvironmentMembershipRequest, "You must provide a UpdateEnvironmentMembershipRequest")
 	local headers = {
@@ -1640,19 +1644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEnvironmentMembershipRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEnvironmentMembershipSync(UpdateEnvironmentMembershipRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEnvironmentMembershipAsync(UpdateEnvironmentMembershipRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEnvironmentMembershipAsync(UpdateEnvironmentMembershipRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironmentStatus asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentStatusAsync(DescribeEnvironmentStatusRequest, cb)
 	assert(DescribeEnvironmentStatusRequest, "You must provide a DescribeEnvironmentStatusRequest")
 	local headers = {
@@ -1675,19 +1680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentStatusSync(DescribeEnvironmentStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentStatusAsync(DescribeEnvironmentStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentStatusAsync(DescribeEnvironmentStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListEnvironments asynchronously, invoking a callback when done
 -- @param ListEnvironmentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEnvironmentsAsync(ListEnvironmentsRequest, cb)
 	assert(ListEnvironmentsRequest, "You must provide a ListEnvironmentsRequest")
 	local headers = {
@@ -1710,19 +1716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEnvironmentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEnvironmentsSync(ListEnvironmentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEnvironmentsAsync(ListEnvironmentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEnvironmentsAsync(ListEnvironmentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironmentMemberships asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentMembershipsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentMembershipsAsync(DescribeEnvironmentMembershipsRequest, cb)
 	assert(DescribeEnvironmentMembershipsRequest, "You must provide a DescribeEnvironmentMembershipsRequest")
 	local headers = {
@@ -1745,19 +1752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentMembershipsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentMembershipsSync(DescribeEnvironmentMembershipsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentMembershipsAsync(DescribeEnvironmentMembershipsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentMembershipsAsync(DescribeEnvironmentMembershipsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEnvironment asynchronously, invoking a callback when done
 -- @param DeleteEnvironmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEnvironmentAsync(DeleteEnvironmentRequest, cb)
 	assert(DeleteEnvironmentRequest, "You must provide a DeleteEnvironmentRequest")
 	local headers = {
@@ -1780,19 +1788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEnvironmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEnvironmentSync(DeleteEnvironmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEnvironmentAsync(DeleteEnvironmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEnvironmentAsync(DeleteEnvironmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEnvironmentEC2 asynchronously, invoking a callback when done
 -- @param CreateEnvironmentEC2Request
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEnvironmentEC2Async(CreateEnvironmentEC2Request, cb)
 	assert(CreateEnvironmentEC2Request, "You must provide a CreateEnvironmentEC2Request")
 	local headers = {
@@ -1815,12 +1824,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEnvironmentEC2Request
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEnvironmentEC2Sync(CreateEnvironmentEC2Request, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEnvironmentEC2Async(CreateEnvironmentEC2Request, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEnvironmentEC2Async(CreateEnvironmentEC2Request, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/clouddirectory.lua
+++ b/aws-sdk/clouddirectory.lua
@@ -10888,7 +10888,7 @@ end
 --
 --- Call ListTypedLinkFacetNames asynchronously, invoking a callback when done
 -- @param ListTypedLinkFacetNamesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTypedLinkFacetNamesAsync(ListTypedLinkFacetNamesRequest, cb)
 	assert(ListTypedLinkFacetNamesRequest, "You must provide a ListTypedLinkFacetNamesRequest")
 	local headers = {
@@ -10911,19 +10911,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTypedLinkFacetNamesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTypedLinkFacetNamesSync(ListTypedLinkFacetNamesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTypedLinkFacetNamesAsync(ListTypedLinkFacetNamesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTypedLinkFacetNamesAsync(ListTypedLinkFacetNamesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIncomingTypedLinks asynchronously, invoking a callback when done
 -- @param ListIncomingTypedLinksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIncomingTypedLinksAsync(ListIncomingTypedLinksRequest, cb)
 	assert(ListIncomingTypedLinksRequest, "You must provide a ListIncomingTypedLinksRequest")
 	local headers = {
@@ -10946,19 +10947,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIncomingTypedLinksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIncomingTypedLinksSync(ListIncomingTypedLinksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIncomingTypedLinksAsync(ListIncomingTypedLinksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIncomingTypedLinksAsync(ListIncomingTypedLinksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDirectories asynchronously, invoking a callback when done
 -- @param ListDirectoriesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDirectoriesAsync(ListDirectoriesRequest, cb)
 	assert(ListDirectoriesRequest, "You must provide a ListDirectoriesRequest")
 	local headers = {
@@ -10981,19 +10983,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDirectoriesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDirectoriesSync(ListDirectoriesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDirectoriesAsync(ListDirectoriesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDirectoriesAsync(ListDirectoriesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSchema asynchronously, invoking a callback when done
 -- @param CreateSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSchemaAsync(CreateSchemaRequest, cb)
 	assert(CreateSchemaRequest, "You must provide a CreateSchemaRequest")
 	local headers = {
@@ -11016,19 +11019,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSchemaSync(CreateSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSchemaAsync(CreateSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSchemaAsync(CreateSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSchema asynchronously, invoking a callback when done
 -- @param UpdateSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSchemaAsync(UpdateSchemaRequest, cb)
 	assert(UpdateSchemaRequest, "You must provide a UpdateSchemaRequest")
 	local headers = {
@@ -11051,19 +11055,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSchemaSync(UpdateSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSchemaAsync(UpdateSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSchemaAsync(UpdateSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateObject asynchronously, invoking a callback when done
 -- @param CreateObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateObjectAsync(CreateObjectRequest, cb)
 	assert(CreateObjectRequest, "You must provide a CreateObjectRequest")
 	local headers = {
@@ -11086,19 +11091,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateObjectSync(CreateObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateObjectAsync(CreateObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateObjectAsync(CreateObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableDirectory asynchronously, invoking a callback when done
 -- @param EnableDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableDirectoryAsync(EnableDirectoryRequest, cb)
 	assert(EnableDirectoryRequest, "You must provide a EnableDirectoryRequest")
 	local headers = {
@@ -11121,19 +11127,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableDirectorySync(EnableDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableDirectoryAsync(EnableDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableDirectoryAsync(EnableDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetObjectInformation asynchronously, invoking a callback when done
 -- @param GetObjectInformationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetObjectInformationAsync(GetObjectInformationRequest, cb)
 	assert(GetObjectInformationRequest, "You must provide a GetObjectInformationRequest")
 	local headers = {
@@ -11156,19 +11163,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetObjectInformationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetObjectInformationSync(GetObjectInformationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetObjectInformationAsync(GetObjectInformationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetObjectInformationAsync(GetObjectInformationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -11191,19 +11199,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSchemaAsJson asynchronously, invoking a callback when done
 -- @param GetSchemaAsJsonRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSchemaAsJsonAsync(GetSchemaAsJsonRequest, cb)
 	assert(GetSchemaAsJsonRequest, "You must provide a GetSchemaAsJsonRequest")
 	local headers = {
@@ -11226,19 +11235,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSchemaAsJsonRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSchemaAsJsonSync(GetSchemaAsJsonRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSchemaAsJsonAsync(GetSchemaAsJsonRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSchemaAsJsonAsync(GetSchemaAsJsonRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchWrite asynchronously, invoking a callback when done
 -- @param BatchWriteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchWriteAsync(BatchWriteRequest, cb)
 	assert(BatchWriteRequest, "You must provide a BatchWriteRequest")
 	local headers = {
@@ -11261,19 +11271,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchWriteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchWriteSync(BatchWriteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchWriteAsync(BatchWriteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchWriteAsync(BatchWriteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFacetNames asynchronously, invoking a callback when done
 -- @param ListFacetNamesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFacetNamesAsync(ListFacetNamesRequest, cb)
 	assert(ListFacetNamesRequest, "You must provide a ListFacetNamesRequest")
 	local headers = {
@@ -11296,19 +11307,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFacetNamesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFacetNamesSync(ListFacetNamesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFacetNamesAsync(ListFacetNamesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFacetNamesAsync(ListFacetNamesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDirectory asynchronously, invoking a callback when done
 -- @param CreateDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDirectoryAsync(CreateDirectoryRequest, cb)
 	assert(CreateDirectoryRequest, "You must provide a CreateDirectoryRequest")
 	local headers = {
@@ -11331,19 +11343,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDirectorySync(CreateDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDirectoryAsync(CreateDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDirectoryAsync(CreateDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIndex asynchronously, invoking a callback when done
 -- @param CreateIndexRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIndexAsync(CreateIndexRequest, cb)
 	assert(CreateIndexRequest, "You must provide a CreateIndexRequest")
 	local headers = {
@@ -11366,19 +11379,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIndexRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIndexSync(CreateIndexRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIndexAsync(CreateIndexRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIndexAsync(CreateIndexRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFacet asynchronously, invoking a callback when done
 -- @param DeleteFacetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFacetAsync(DeleteFacetRequest, cb)
 	assert(DeleteFacetRequest, "You must provide a DeleteFacetRequest")
 	local headers = {
@@ -11401,19 +11415,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFacetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFacetSync(DeleteFacetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFacetAsync(DeleteFacetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFacetAsync(DeleteFacetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachPolicy asynchronously, invoking a callback when done
 -- @param DetachPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachPolicyAsync(DetachPolicyRequest, cb)
 	assert(DetachPolicyRequest, "You must provide a DetachPolicyRequest")
 	local headers = {
@@ -11436,19 +11451,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachPolicySync(DetachPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachPolicyAsync(DetachPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachPolicyAsync(DetachPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachObject asynchronously, invoking a callback when done
 -- @param DetachObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachObjectAsync(DetachObjectRequest, cb)
 	assert(DetachObjectRequest, "You must provide a DetachObjectRequest")
 	local headers = {
@@ -11471,19 +11487,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachObjectSync(DetachObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachObjectAsync(DetachObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachObjectAsync(DetachObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListObjectChildren asynchronously, invoking a callback when done
 -- @param ListObjectChildrenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectChildrenAsync(ListObjectChildrenRequest, cb)
 	assert(ListObjectChildrenRequest, "You must provide a ListObjectChildrenRequest")
 	local headers = {
@@ -11506,19 +11523,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectChildrenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectChildrenSync(ListObjectChildrenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectChildrenAsync(ListObjectChildrenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectChildrenAsync(ListObjectChildrenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListObjectAttributes asynchronously, invoking a callback when done
 -- @param ListObjectAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectAttributesAsync(ListObjectAttributesRequest, cb)
 	assert(ListObjectAttributesRequest, "You must provide a ListObjectAttributesRequest")
 	local headers = {
@@ -11541,19 +11559,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectAttributesSync(ListObjectAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectAttributesAsync(ListObjectAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectAttributesAsync(ListObjectAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddFacetToObject asynchronously, invoking a callback when done
 -- @param AddFacetToObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddFacetToObjectAsync(AddFacetToObjectRequest, cb)
 	assert(AddFacetToObjectRequest, "You must provide a AddFacetToObjectRequest")
 	local headers = {
@@ -11576,19 +11595,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddFacetToObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddFacetToObjectSync(AddFacetToObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddFacetToObjectAsync(AddFacetToObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddFacetToObjectAsync(AddFacetToObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutSchemaFromJson asynchronously, invoking a callback when done
 -- @param PutSchemaFromJsonRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutSchemaFromJsonAsync(PutSchemaFromJsonRequest, cb)
 	assert(PutSchemaFromJsonRequest, "You must provide a PutSchemaFromJsonRequest")
 	local headers = {
@@ -11611,19 +11631,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutSchemaFromJsonRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutSchemaFromJsonSync(PutSchemaFromJsonRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutSchemaFromJsonAsync(PutSchemaFromJsonRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutSchemaFromJsonAsync(PutSchemaFromJsonRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateLinkAttributes asynchronously, invoking a callback when done
 -- @param UpdateLinkAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateLinkAttributesAsync(UpdateLinkAttributesRequest, cb)
 	assert(UpdateLinkAttributesRequest, "You must provide a UpdateLinkAttributesRequest")
 	local headers = {
@@ -11646,19 +11667,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateLinkAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateLinkAttributesSync(UpdateLinkAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateLinkAttributesAsync(UpdateLinkAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateLinkAttributesAsync(UpdateLinkAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPolicyAttachments asynchronously, invoking a callback when done
 -- @param ListPolicyAttachmentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPolicyAttachmentsAsync(ListPolicyAttachmentsRequest, cb)
 	assert(ListPolicyAttachmentsRequest, "You must provide a ListPolicyAttachmentsRequest")
 	local headers = {
@@ -11681,19 +11703,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPolicyAttachmentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPolicyAttachmentsSync(ListPolicyAttachmentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPolicyAttachmentsAsync(ListPolicyAttachmentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPolicyAttachmentsAsync(ListPolicyAttachmentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFacet asynchronously, invoking a callback when done
 -- @param CreateFacetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFacetAsync(CreateFacetRequest, cb)
 	assert(CreateFacetRequest, "You must provide a CreateFacetRequest")
 	local headers = {
@@ -11716,19 +11739,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFacetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFacetSync(CreateFacetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFacetAsync(CreateFacetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFacetAsync(CreateFacetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListObjectParents asynchronously, invoking a callback when done
 -- @param ListObjectParentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectParentsAsync(ListObjectParentsRequest, cb)
 	assert(ListObjectParentsRequest, "You must provide a ListObjectParentsRequest")
 	local headers = {
@@ -11751,19 +11775,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectParentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectParentsSync(ListObjectParentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectParentsAsync(ListObjectParentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectParentsAsync(ListObjectParentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchRead asynchronously, invoking a callback when done
 -- @param BatchReadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchReadAsync(BatchReadRequest, cb)
 	assert(BatchReadRequest, "You must provide a BatchReadRequest")
 	local headers = {
@@ -11786,19 +11811,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchReadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchReadSync(BatchReadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchReadAsync(BatchReadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchReadAsync(BatchReadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachTypedLink asynchronously, invoking a callback when done
 -- @param DetachTypedLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachTypedLinkAsync(DetachTypedLinkRequest, cb)
 	assert(DetachTypedLinkRequest, "You must provide a DetachTypedLinkRequest")
 	local headers = {
@@ -11821,19 +11847,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachTypedLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachTypedLinkSync(DetachTypedLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachTypedLinkAsync(DetachTypedLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachTypedLinkAsync(DetachTypedLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveFacetFromObject asynchronously, invoking a callback when done
 -- @param RemoveFacetFromObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveFacetFromObjectAsync(RemoveFacetFromObjectRequest, cb)
 	assert(RemoveFacetFromObjectRequest, "You must provide a RemoveFacetFromObjectRequest")
 	local headers = {
@@ -11856,19 +11883,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveFacetFromObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveFacetFromObjectSync(RemoveFacetFromObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveFacetFromObjectAsync(RemoveFacetFromObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveFacetFromObjectAsync(RemoveFacetFromObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpgradeAppliedSchema asynchronously, invoking a callback when done
 -- @param UpgradeAppliedSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpgradeAppliedSchemaAsync(UpgradeAppliedSchemaRequest, cb)
 	assert(UpgradeAppliedSchemaRequest, "You must provide a UpgradeAppliedSchemaRequest")
 	local headers = {
@@ -11891,19 +11919,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpgradeAppliedSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpgradeAppliedSchemaSync(UpgradeAppliedSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpgradeAppliedSchemaAsync(UpgradeAppliedSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpgradeAppliedSchemaAsync(UpgradeAppliedSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call LookupPolicy asynchronously, invoking a callback when done
 -- @param LookupPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.LookupPolicyAsync(LookupPolicyRequest, cb)
 	assert(LookupPolicyRequest, "You must provide a LookupPolicyRequest")
 	local headers = {
@@ -11926,19 +11955,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param LookupPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.LookupPolicySync(LookupPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.LookupPolicyAsync(LookupPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.LookupPolicyAsync(LookupPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListObjectParentPaths asynchronously, invoking a callback when done
 -- @param ListObjectParentPathsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectParentPathsAsync(ListObjectParentPathsRequest, cb)
 	assert(ListObjectParentPathsRequest, "You must provide a ListObjectParentPathsRequest")
 	local headers = {
@@ -11961,19 +11991,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectParentPathsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectParentPathsSync(ListObjectParentPathsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectParentPathsAsync(ListObjectParentPathsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectParentPathsAsync(ListObjectParentPathsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -11996,19 +12027,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAttachedIndices asynchronously, invoking a callback when done
 -- @param ListAttachedIndicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAttachedIndicesAsync(ListAttachedIndicesRequest, cb)
 	assert(ListAttachedIndicesRequest, "You must provide a ListAttachedIndicesRequest")
 	local headers = {
@@ -12031,19 +12063,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAttachedIndicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAttachedIndicesSync(ListAttachedIndicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAttachedIndicesAsync(ListAttachedIndicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAttachedIndicesAsync(ListAttachedIndicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachTypedLink asynchronously, invoking a callback when done
 -- @param AttachTypedLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachTypedLinkAsync(AttachTypedLinkRequest, cb)
 	assert(AttachTypedLinkRequest, "You must provide a AttachTypedLinkRequest")
 	local headers = {
@@ -12066,19 +12099,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachTypedLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachTypedLinkSync(AttachTypedLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachTypedLinkAsync(AttachTypedLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachTypedLinkAsync(AttachTypedLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetObjectAttributes asynchronously, invoking a callback when done
 -- @param GetObjectAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetObjectAttributesAsync(GetObjectAttributesRequest, cb)
 	assert(GetObjectAttributesRequest, "You must provide a GetObjectAttributesRequest")
 	local headers = {
@@ -12101,19 +12135,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetObjectAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetObjectAttributesSync(GetObjectAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetObjectAttributesAsync(GetObjectAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetObjectAttributesAsync(GetObjectAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLinkAttributes asynchronously, invoking a callback when done
 -- @param GetLinkAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLinkAttributesAsync(GetLinkAttributesRequest, cb)
 	assert(GetLinkAttributesRequest, "You must provide a GetLinkAttributesRequest")
 	local headers = {
@@ -12136,19 +12171,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLinkAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLinkAttributesSync(GetLinkAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLinkAttributesAsync(GetLinkAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLinkAttributesAsync(GetLinkAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPublishedSchemaArns asynchronously, invoking a callback when done
 -- @param ListPublishedSchemaArnsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPublishedSchemaArnsAsync(ListPublishedSchemaArnsRequest, cb)
 	assert(ListPublishedSchemaArnsRequest, "You must provide a ListPublishedSchemaArnsRequest")
 	local headers = {
@@ -12171,19 +12207,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPublishedSchemaArnsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPublishedSchemaArnsSync(ListPublishedSchemaArnsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPublishedSchemaArnsAsync(ListPublishedSchemaArnsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPublishedSchemaArnsAsync(ListPublishedSchemaArnsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDirectory asynchronously, invoking a callback when done
 -- @param DeleteDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDirectoryAsync(DeleteDirectoryRequest, cb)
 	assert(DeleteDirectoryRequest, "You must provide a DeleteDirectoryRequest")
 	local headers = {
@@ -12206,19 +12243,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDirectorySync(DeleteDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDirectoryAsync(DeleteDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDirectoryAsync(DeleteDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PublishSchema asynchronously, invoking a callback when done
 -- @param PublishSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PublishSchemaAsync(PublishSchemaRequest, cb)
 	assert(PublishSchemaRequest, "You must provide a PublishSchemaRequest")
 	local headers = {
@@ -12241,19 +12279,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PublishSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PublishSchemaSync(PublishSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PublishSchemaAsync(PublishSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PublishSchemaAsync(PublishSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFacet asynchronously, invoking a callback when done
 -- @param GetFacetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFacetAsync(GetFacetRequest, cb)
 	assert(GetFacetRequest, "You must provide a GetFacetRequest")
 	local headers = {
@@ -12276,19 +12315,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFacetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFacetSync(GetFacetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFacetAsync(GetFacetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFacetAsync(GetFacetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSchema asynchronously, invoking a callback when done
 -- @param DeleteSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSchemaAsync(DeleteSchemaRequest, cb)
 	assert(DeleteSchemaRequest, "You must provide a DeleteSchemaRequest")
 	local headers = {
@@ -12311,19 +12351,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSchemaSync(DeleteSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSchemaAsync(DeleteSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSchemaAsync(DeleteSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachPolicy asynchronously, invoking a callback when done
 -- @param AttachPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachPolicyAsync(AttachPolicyRequest, cb)
 	assert(AttachPolicyRequest, "You must provide a AttachPolicyRequest")
 	local headers = {
@@ -12346,19 +12387,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachPolicySync(AttachPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachPolicyAsync(AttachPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachPolicyAsync(AttachPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableDirectory asynchronously, invoking a callback when done
 -- @param DisableDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableDirectoryAsync(DisableDirectoryRequest, cb)
 	assert(DisableDirectoryRequest, "You must provide a DisableDirectoryRequest")
 	local headers = {
@@ -12381,19 +12423,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableDirectorySync(DisableDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableDirectoryAsync(DisableDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableDirectoryAsync(DisableDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFacetAttributes asynchronously, invoking a callback when done
 -- @param ListFacetAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFacetAttributesAsync(ListFacetAttributesRequest, cb)
 	assert(ListFacetAttributesRequest, "You must provide a ListFacetAttributesRequest")
 	local headers = {
@@ -12416,19 +12459,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFacetAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFacetAttributesSync(ListFacetAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFacetAttributesAsync(ListFacetAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFacetAttributesAsync(ListFacetAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTypedLinkFacet asynchronously, invoking a callback when done
 -- @param DeleteTypedLinkFacetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTypedLinkFacetAsync(DeleteTypedLinkFacetRequest, cb)
 	assert(DeleteTypedLinkFacetRequest, "You must provide a DeleteTypedLinkFacetRequest")
 	local headers = {
@@ -12451,19 +12495,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTypedLinkFacetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTypedLinkFacetSync(DeleteTypedLinkFacetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTypedLinkFacetAsync(DeleteTypedLinkFacetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTypedLinkFacetAsync(DeleteTypedLinkFacetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListObjectPolicies asynchronously, invoking a callback when done
 -- @param ListObjectPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectPoliciesAsync(ListObjectPoliciesRequest, cb)
 	assert(ListObjectPoliciesRequest, "You must provide a ListObjectPoliciesRequest")
 	local headers = {
@@ -12486,19 +12531,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectPoliciesSync(ListObjectPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectPoliciesAsync(ListObjectPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectPoliciesAsync(ListObjectPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachFromIndex asynchronously, invoking a callback when done
 -- @param DetachFromIndexRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachFromIndexAsync(DetachFromIndexRequest, cb)
 	assert(DetachFromIndexRequest, "You must provide a DetachFromIndexRequest")
 	local headers = {
@@ -12521,19 +12567,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachFromIndexRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachFromIndexSync(DetachFromIndexRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachFromIndexAsync(DetachFromIndexRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachFromIndexAsync(DetachFromIndexRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpgradePublishedSchema asynchronously, invoking a callback when done
 -- @param UpgradePublishedSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpgradePublishedSchemaAsync(UpgradePublishedSchemaRequest, cb)
 	assert(UpgradePublishedSchemaRequest, "You must provide a UpgradePublishedSchemaRequest")
 	local headers = {
@@ -12556,19 +12603,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpgradePublishedSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpgradePublishedSchemaSync(UpgradePublishedSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpgradePublishedSchemaAsync(UpgradePublishedSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpgradePublishedSchemaAsync(UpgradePublishedSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAppliedSchemaArns asynchronously, invoking a callback when done
 -- @param ListAppliedSchemaArnsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAppliedSchemaArnsAsync(ListAppliedSchemaArnsRequest, cb)
 	assert(ListAppliedSchemaArnsRequest, "You must provide a ListAppliedSchemaArnsRequest")
 	local headers = {
@@ -12591,19 +12639,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAppliedSchemaArnsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAppliedSchemaArnsSync(ListAppliedSchemaArnsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAppliedSchemaArnsAsync(ListAppliedSchemaArnsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAppliedSchemaArnsAsync(ListAppliedSchemaArnsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAppliedSchemaVersion asynchronously, invoking a callback when done
 -- @param GetAppliedSchemaVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAppliedSchemaVersionAsync(GetAppliedSchemaVersionRequest, cb)
 	assert(GetAppliedSchemaVersionRequest, "You must provide a GetAppliedSchemaVersionRequest")
 	local headers = {
@@ -12626,19 +12675,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAppliedSchemaVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAppliedSchemaVersionSync(GetAppliedSchemaVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAppliedSchemaVersionAsync(GetAppliedSchemaVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAppliedSchemaVersionAsync(GetAppliedSchemaVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ApplySchema asynchronously, invoking a callback when done
 -- @param ApplySchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ApplySchemaAsync(ApplySchemaRequest, cb)
 	assert(ApplySchemaRequest, "You must provide a ApplySchemaRequest")
 	local headers = {
@@ -12661,19 +12711,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ApplySchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ApplySchemaSync(ApplySchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ApplySchemaAsync(ApplySchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ApplySchemaAsync(ApplySchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDevelopmentSchemaArns asynchronously, invoking a callback when done
 -- @param ListDevelopmentSchemaArnsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDevelopmentSchemaArnsAsync(ListDevelopmentSchemaArnsRequest, cb)
 	assert(ListDevelopmentSchemaArnsRequest, "You must provide a ListDevelopmentSchemaArnsRequest")
 	local headers = {
@@ -12696,19 +12747,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDevelopmentSchemaArnsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDevelopmentSchemaArnsSync(ListDevelopmentSchemaArnsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDevelopmentSchemaArnsAsync(ListDevelopmentSchemaArnsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDevelopmentSchemaArnsAsync(ListDevelopmentSchemaArnsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDirectory asynchronously, invoking a callback when done
 -- @param GetDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDirectoryAsync(GetDirectoryRequest, cb)
 	assert(GetDirectoryRequest, "You must provide a GetDirectoryRequest")
 	local headers = {
@@ -12731,19 +12783,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDirectorySync(GetDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDirectoryAsync(GetDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDirectoryAsync(GetDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachObject asynchronously, invoking a callback when done
 -- @param AttachObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachObjectAsync(AttachObjectRequest, cb)
 	assert(AttachObjectRequest, "You must provide a AttachObjectRequest")
 	local headers = {
@@ -12766,19 +12819,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachObjectSync(AttachObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachObjectAsync(AttachObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachObjectAsync(AttachObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOutgoingTypedLinks asynchronously, invoking a callback when done
 -- @param ListOutgoingTypedLinksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOutgoingTypedLinksAsync(ListOutgoingTypedLinksRequest, cb)
 	assert(ListOutgoingTypedLinksRequest, "You must provide a ListOutgoingTypedLinksRequest")
 	local headers = {
@@ -12801,19 +12855,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOutgoingTypedLinksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOutgoingTypedLinksSync(ListOutgoingTypedLinksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOutgoingTypedLinksAsync(ListOutgoingTypedLinksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOutgoingTypedLinksAsync(ListOutgoingTypedLinksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateObjectAttributes asynchronously, invoking a callback when done
 -- @param UpdateObjectAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateObjectAttributesAsync(UpdateObjectAttributesRequest, cb)
 	assert(UpdateObjectAttributesRequest, "You must provide a UpdateObjectAttributesRequest")
 	local headers = {
@@ -12836,19 +12891,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateObjectAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateObjectAttributesSync(UpdateObjectAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateObjectAttributesAsync(UpdateObjectAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateObjectAttributesAsync(UpdateObjectAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -12871,19 +12927,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTypedLinkFacet asynchronously, invoking a callback when done
 -- @param CreateTypedLinkFacetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTypedLinkFacetAsync(CreateTypedLinkFacetRequest, cb)
 	assert(CreateTypedLinkFacetRequest, "You must provide a CreateTypedLinkFacetRequest")
 	local headers = {
@@ -12906,19 +12963,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTypedLinkFacetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTypedLinkFacetSync(CreateTypedLinkFacetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTypedLinkFacetAsync(CreateTypedLinkFacetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTypedLinkFacetAsync(CreateTypedLinkFacetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachToIndex asynchronously, invoking a callback when done
 -- @param AttachToIndexRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachToIndexAsync(AttachToIndexRequest, cb)
 	assert(AttachToIndexRequest, "You must provide a AttachToIndexRequest")
 	local headers = {
@@ -12941,19 +12999,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachToIndexRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachToIndexSync(AttachToIndexRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachToIndexAsync(AttachToIndexRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachToIndexAsync(AttachToIndexRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIndex asynchronously, invoking a callback when done
 -- @param ListIndexRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIndexAsync(ListIndexRequest, cb)
 	assert(ListIndexRequest, "You must provide a ListIndexRequest")
 	local headers = {
@@ -12976,19 +13035,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIndexRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIndexSync(ListIndexRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIndexAsync(ListIndexRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIndexAsync(ListIndexRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTypedLinkFacetAttributes asynchronously, invoking a callback when done
 -- @param ListTypedLinkFacetAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTypedLinkFacetAttributesAsync(ListTypedLinkFacetAttributesRequest, cb)
 	assert(ListTypedLinkFacetAttributesRequest, "You must provide a ListTypedLinkFacetAttributesRequest")
 	local headers = {
@@ -13011,19 +13071,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTypedLinkFacetAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTypedLinkFacetAttributesSync(ListTypedLinkFacetAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTypedLinkFacetAttributesAsync(ListTypedLinkFacetAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTypedLinkFacetAttributesAsync(ListTypedLinkFacetAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFacet asynchronously, invoking a callback when done
 -- @param UpdateFacetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFacetAsync(UpdateFacetRequest, cb)
 	assert(UpdateFacetRequest, "You must provide a UpdateFacetRequest")
 	local headers = {
@@ -13046,19 +13107,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFacetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFacetSync(UpdateFacetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFacetAsync(UpdateFacetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFacetAsync(UpdateFacetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTypedLinkFacet asynchronously, invoking a callback when done
 -- @param UpdateTypedLinkFacetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTypedLinkFacetAsync(UpdateTypedLinkFacetRequest, cb)
 	assert(UpdateTypedLinkFacetRequest, "You must provide a UpdateTypedLinkFacetRequest")
 	local headers = {
@@ -13081,19 +13143,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTypedLinkFacetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTypedLinkFacetSync(UpdateTypedLinkFacetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTypedLinkFacetAsync(UpdateTypedLinkFacetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTypedLinkFacetAsync(UpdateTypedLinkFacetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListManagedSchemaArns asynchronously, invoking a callback when done
 -- @param ListManagedSchemaArnsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListManagedSchemaArnsAsync(ListManagedSchemaArnsRequest, cb)
 	assert(ListManagedSchemaArnsRequest, "You must provide a ListManagedSchemaArnsRequest")
 	local headers = {
@@ -13116,19 +13179,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListManagedSchemaArnsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListManagedSchemaArnsSync(ListManagedSchemaArnsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListManagedSchemaArnsAsync(ListManagedSchemaArnsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListManagedSchemaArnsAsync(ListManagedSchemaArnsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteObject asynchronously, invoking a callback when done
 -- @param DeleteObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteObjectAsync(DeleteObjectRequest, cb)
 	assert(DeleteObjectRequest, "You must provide a DeleteObjectRequest")
 	local headers = {
@@ -13151,19 +13215,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteObjectSync(DeleteObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteObjectAsync(DeleteObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteObjectAsync(DeleteObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTypedLinkFacetInformation asynchronously, invoking a callback when done
 -- @param GetTypedLinkFacetInformationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTypedLinkFacetInformationAsync(GetTypedLinkFacetInformationRequest, cb)
 	assert(GetTypedLinkFacetInformationRequest, "You must provide a GetTypedLinkFacetInformationRequest")
 	local headers = {
@@ -13186,12 +13251,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTypedLinkFacetInformationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTypedLinkFacetInformationSync(GetTypedLinkFacetInformationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTypedLinkFacetInformationAsync(GetTypedLinkFacetInformationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTypedLinkFacetInformationAsync(GetTypedLinkFacetInformationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloudformation.lua
+++ b/aws-sdk/cloudformation.lua
@@ -7317,7 +7317,7 @@ end
 --
 --- Call DescribeStackResource asynchronously, invoking a callback when done
 -- @param DescribeStackResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackResourceAsync(DescribeStackResourceInput, cb)
 	assert(DescribeStackResourceInput, "You must provide a DescribeStackResourceInput")
 	local headers = {
@@ -7340,19 +7340,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackResourceSync(DescribeStackResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackResourceAsync(DescribeStackResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackResourceAsync(DescribeStackResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStackInstance asynchronously, invoking a callback when done
 -- @param DescribeStackInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackInstanceAsync(DescribeStackInstanceInput, cb)
 	assert(DescribeStackInstanceInput, "You must provide a DescribeStackInstanceInput")
 	local headers = {
@@ -7375,19 +7376,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackInstanceSync(DescribeStackInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackInstanceAsync(DescribeStackInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackInstanceAsync(DescribeStackInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStackSet asynchronously, invoking a callback when done
 -- @param UpdateStackSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStackSetAsync(UpdateStackSetInput, cb)
 	assert(UpdateStackSetInput, "You must provide a UpdateStackSetInput")
 	local headers = {
@@ -7410,19 +7412,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStackSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStackSetSync(UpdateStackSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStackSetAsync(UpdateStackSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStackSetAsync(UpdateStackSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStackInstances asynchronously, invoking a callback when done
 -- @param CreateStackInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStackInstancesAsync(CreateStackInstancesInput, cb)
 	assert(CreateStackInstancesInput, "You must provide a CreateStackInstancesInput")
 	local headers = {
@@ -7445,19 +7448,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStackInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStackInstancesSync(CreateStackInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStackInstancesAsync(CreateStackInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStackInstancesAsync(CreateStackInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTerminationProtection asynchronously, invoking a callback when done
 -- @param UpdateTerminationProtectionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTerminationProtectionAsync(UpdateTerminationProtectionInput, cb)
 	assert(UpdateTerminationProtectionInput, "You must provide a UpdateTerminationProtectionInput")
 	local headers = {
@@ -7480,19 +7484,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTerminationProtectionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTerminationProtectionSync(UpdateTerminationProtectionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTerminationProtectionAsync(UpdateTerminationProtectionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTerminationProtectionAsync(UpdateTerminationProtectionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ValidateTemplate asynchronously, invoking a callback when done
 -- @param ValidateTemplateInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ValidateTemplateAsync(ValidateTemplateInput, cb)
 	assert(ValidateTemplateInput, "You must provide a ValidateTemplateInput")
 	local headers = {
@@ -7515,19 +7520,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ValidateTemplateInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ValidateTemplateSync(ValidateTemplateInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ValidateTemplateAsync(ValidateTemplateInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ValidateTemplateAsync(ValidateTemplateInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStackResources asynchronously, invoking a callback when done
 -- @param DescribeStackResourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackResourcesAsync(DescribeStackResourcesInput, cb)
 	assert(DescribeStackResourcesInput, "You must provide a DescribeStackResourcesInput")
 	local headers = {
@@ -7550,19 +7556,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackResourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackResourcesSync(DescribeStackResourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackResourcesAsync(DescribeStackResourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackResourcesAsync(DescribeStackResourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStackSetOperations asynchronously, invoking a callback when done
 -- @param ListStackSetOperationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStackSetOperationsAsync(ListStackSetOperationsInput, cb)
 	assert(ListStackSetOperationsInput, "You must provide a ListStackSetOperationsInput")
 	local headers = {
@@ -7585,19 +7592,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStackSetOperationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStackSetOperationsSync(ListStackSetOperationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStackSetOperationsAsync(ListStackSetOperationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStackSetOperationsAsync(ListStackSetOperationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListChangeSets asynchronously, invoking a callback when done
 -- @param ListChangeSetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListChangeSetsAsync(ListChangeSetsInput, cb)
 	assert(ListChangeSetsInput, "You must provide a ListChangeSetsInput")
 	local headers = {
@@ -7620,19 +7628,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListChangeSetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListChangeSetsSync(ListChangeSetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListChangeSetsAsync(ListChangeSetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListChangeSetsAsync(ListChangeSetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStack asynchronously, invoking a callback when done
 -- @param CreateStackInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStackAsync(CreateStackInput, cb)
 	assert(CreateStackInput, "You must provide a CreateStackInput")
 	local headers = {
@@ -7655,19 +7664,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStackInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStackSync(CreateStackInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStackAsync(CreateStackInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStackAsync(CreateStackInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTemplateSummary asynchronously, invoking a callback when done
 -- @param GetTemplateSummaryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTemplateSummaryAsync(GetTemplateSummaryInput, cb)
 	assert(GetTemplateSummaryInput, "You must provide a GetTemplateSummaryInput")
 	local headers = {
@@ -7690,19 +7700,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTemplateSummaryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTemplateSummarySync(GetTemplateSummaryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTemplateSummaryAsync(GetTemplateSummaryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTemplateSummaryAsync(GetTemplateSummaryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelUpdateStack asynchronously, invoking a callback when done
 -- @param CancelUpdateStackInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelUpdateStackAsync(CancelUpdateStackInput, cb)
 	assert(CancelUpdateStackInput, "You must provide a CancelUpdateStackInput")
 	local headers = {
@@ -7725,19 +7736,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelUpdateStackInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelUpdateStackSync(CancelUpdateStackInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelUpdateStackAsync(CancelUpdateStackInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelUpdateStackAsync(CancelUpdateStackInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStackInstances asynchronously, invoking a callback when done
 -- @param UpdateStackInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStackInstancesAsync(UpdateStackInstancesInput, cb)
 	assert(UpdateStackInstancesInput, "You must provide a UpdateStackInstancesInput")
 	local headers = {
@@ -7760,19 +7772,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStackInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStackInstancesSync(UpdateStackInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStackInstancesAsync(UpdateStackInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStackInstancesAsync(UpdateStackInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ContinueUpdateRollback asynchronously, invoking a callback when done
 -- @param ContinueUpdateRollbackInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ContinueUpdateRollbackAsync(ContinueUpdateRollbackInput, cb)
 	assert(ContinueUpdateRollbackInput, "You must provide a ContinueUpdateRollbackInput")
 	local headers = {
@@ -7795,19 +7808,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ContinueUpdateRollbackInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ContinueUpdateRollbackSync(ContinueUpdateRollbackInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ContinueUpdateRollbackAsync(ContinueUpdateRollbackInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ContinueUpdateRollbackAsync(ContinueUpdateRollbackInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListImports asynchronously, invoking a callback when done
 -- @param ListImportsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListImportsAsync(ListImportsInput, cb)
 	assert(ListImportsInput, "You must provide a ListImportsInput")
 	local headers = {
@@ -7830,19 +7844,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListImportsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListImportsSync(ListImportsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListImportsAsync(ListImportsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListImportsAsync(ListImportsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStackPolicy asynchronously, invoking a callback when done
 -- @param GetStackPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStackPolicyAsync(GetStackPolicyInput, cb)
 	assert(GetStackPolicyInput, "You must provide a GetStackPolicyInput")
 	local headers = {
@@ -7865,19 +7880,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStackPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStackPolicySync(GetStackPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStackPolicyAsync(GetStackPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStackPolicyAsync(GetStackPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStackSets asynchronously, invoking a callback when done
 -- @param ListStackSetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStackSetsAsync(ListStackSetsInput, cb)
 	assert(ListStackSetsInput, "You must provide a ListStackSetsInput")
 	local headers = {
@@ -7900,19 +7916,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStackSetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStackSetsSync(ListStackSetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStackSetsAsync(ListStackSetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStackSetsAsync(ListStackSetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListExports asynchronously, invoking a callback when done
 -- @param ListExportsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListExportsAsync(ListExportsInput, cb)
 	assert(ListExportsInput, "You must provide a ListExportsInput")
 	local headers = {
@@ -7935,19 +7952,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListExportsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListExportsSync(ListExportsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListExportsAsync(ListExportsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListExportsAsync(ListExportsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStackSet asynchronously, invoking a callback when done
 -- @param DeleteStackSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStackSetAsync(DeleteStackSetInput, cb)
 	assert(DeleteStackSetInput, "You must provide a DeleteStackSetInput")
 	local headers = {
@@ -7970,19 +7988,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStackSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStackSetSync(DeleteStackSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStackSetAsync(DeleteStackSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStackSetAsync(DeleteStackSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStackSet asynchronously, invoking a callback when done
 -- @param DescribeStackSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackSetAsync(DescribeStackSetInput, cb)
 	assert(DescribeStackSetInput, "You must provide a DescribeStackSetInput")
 	local headers = {
@@ -8005,19 +8024,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackSetSync(DescribeStackSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackSetAsync(DescribeStackSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackSetAsync(DescribeStackSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStackSetOperation asynchronously, invoking a callback when done
 -- @param DescribeStackSetOperationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackSetOperationAsync(DescribeStackSetOperationInput, cb)
 	assert(DescribeStackSetOperationInput, "You must provide a DescribeStackSetOperationInput")
 	local headers = {
@@ -8040,19 +8060,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackSetOperationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackSetOperationSync(DescribeStackSetOperationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackSetOperationAsync(DescribeStackSetOperationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackSetOperationAsync(DescribeStackSetOperationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStackResources asynchronously, invoking a callback when done
 -- @param ListStackResourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStackResourcesAsync(ListStackResourcesInput, cb)
 	assert(ListStackResourcesInput, "You must provide a ListStackResourcesInput")
 	local headers = {
@@ -8075,19 +8096,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStackResourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStackResourcesSync(ListStackResourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStackResourcesAsync(ListStackResourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStackResourcesAsync(ListStackResourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStackEvents asynchronously, invoking a callback when done
 -- @param DescribeStackEventsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackEventsAsync(DescribeStackEventsInput, cb)
 	assert(DescribeStackEventsInput, "You must provide a DescribeStackEventsInput")
 	local headers = {
@@ -8110,19 +8132,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackEventsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackEventsSync(DescribeStackEventsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackEventsAsync(DescribeStackEventsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackEventsAsync(DescribeStackEventsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStackSet asynchronously, invoking a callback when done
 -- @param CreateStackSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStackSetAsync(CreateStackSetInput, cb)
 	assert(CreateStackSetInput, "You must provide a CreateStackSetInput")
 	local headers = {
@@ -8145,19 +8168,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStackSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStackSetSync(CreateStackSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStackSetAsync(CreateStackSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStackSetAsync(CreateStackSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SignalResource asynchronously, invoking a callback when done
 -- @param SignalResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SignalResourceAsync(SignalResourceInput, cb)
 	assert(SignalResourceInput, "You must provide a SignalResourceInput")
 	local headers = {
@@ -8180,19 +8204,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SignalResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SignalResourceSync(SignalResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SignalResourceAsync(SignalResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SignalResourceAsync(SignalResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTemplate asynchronously, invoking a callback when done
 -- @param GetTemplateInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTemplateAsync(GetTemplateInput, cb)
 	assert(GetTemplateInput, "You must provide a GetTemplateInput")
 	local headers = {
@@ -8215,19 +8240,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTemplateInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTemplateSync(GetTemplateInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTemplateAsync(GetTemplateInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTemplateAsync(GetTemplateInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeChangeSet asynchronously, invoking a callback when done
 -- @param DescribeChangeSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeChangeSetAsync(DescribeChangeSetInput, cb)
 	assert(DescribeChangeSetInput, "You must provide a DescribeChangeSetInput")
 	local headers = {
@@ -8250,19 +8276,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeChangeSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeChangeSetSync(DescribeChangeSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeChangeSetAsync(DescribeChangeSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeChangeSetAsync(DescribeChangeSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteChangeSet asynchronously, invoking a callback when done
 -- @param DeleteChangeSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteChangeSetAsync(DeleteChangeSetInput, cb)
 	assert(DeleteChangeSetInput, "You must provide a DeleteChangeSetInput")
 	local headers = {
@@ -8285,19 +8312,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteChangeSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteChangeSetSync(DeleteChangeSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteChangeSetAsync(DeleteChangeSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteChangeSetAsync(DeleteChangeSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateChangeSet asynchronously, invoking a callback when done
 -- @param CreateChangeSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateChangeSetAsync(CreateChangeSetInput, cb)
 	assert(CreateChangeSetInput, "You must provide a CreateChangeSetInput")
 	local headers = {
@@ -8320,19 +8348,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateChangeSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateChangeSetSync(CreateChangeSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateChangeSetAsync(CreateChangeSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateChangeSetAsync(CreateChangeSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStacks asynchronously, invoking a callback when done
 -- @param DescribeStacksInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStacksAsync(DescribeStacksInput, cb)
 	assert(DescribeStacksInput, "You must provide a DescribeStacksInput")
 	local headers = {
@@ -8355,19 +8384,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStacksInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStacksSync(DescribeStacksInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStacksAsync(DescribeStacksInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStacksAsync(DescribeStacksInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStack asynchronously, invoking a callback when done
 -- @param UpdateStackInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStackAsync(UpdateStackInput, cb)
 	assert(UpdateStackInput, "You must provide a UpdateStackInput")
 	local headers = {
@@ -8390,19 +8420,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStackInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStackSync(UpdateStackInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStackAsync(UpdateStackInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStackAsync(UpdateStackInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopStackSetOperation asynchronously, invoking a callback when done
 -- @param StopStackSetOperationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopStackSetOperationAsync(StopStackSetOperationInput, cb)
 	assert(StopStackSetOperationInput, "You must provide a StopStackSetOperationInput")
 	local headers = {
@@ -8425,19 +8456,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopStackSetOperationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopStackSetOperationSync(StopStackSetOperationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopStackSetOperationAsync(StopStackSetOperationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopStackSetOperationAsync(StopStackSetOperationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStackInstances asynchronously, invoking a callback when done
 -- @param ListStackInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStackInstancesAsync(ListStackInstancesInput, cb)
 	assert(ListStackInstancesInput, "You must provide a ListStackInstancesInput")
 	local headers = {
@@ -8460,19 +8492,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStackInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStackInstancesSync(ListStackInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStackInstancesAsync(ListStackInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStackInstancesAsync(ListStackInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStackInstances asynchronously, invoking a callback when done
 -- @param DeleteStackInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStackInstancesAsync(DeleteStackInstancesInput, cb)
 	assert(DeleteStackInstancesInput, "You must provide a DeleteStackInstancesInput")
 	local headers = {
@@ -8495,19 +8528,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStackInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStackInstancesSync(DeleteStackInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStackInstancesAsync(DeleteStackInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStackInstancesAsync(DeleteStackInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ExecuteChangeSet asynchronously, invoking a callback when done
 -- @param ExecuteChangeSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExecuteChangeSetAsync(ExecuteChangeSetInput, cb)
 	assert(ExecuteChangeSetInput, "You must provide a ExecuteChangeSetInput")
 	local headers = {
@@ -8530,19 +8564,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExecuteChangeSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExecuteChangeSetSync(ExecuteChangeSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExecuteChangeSetAsync(ExecuteChangeSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExecuteChangeSetAsync(ExecuteChangeSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStack asynchronously, invoking a callback when done
 -- @param DeleteStackInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStackAsync(DeleteStackInput, cb)
 	assert(DeleteStackInput, "You must provide a DeleteStackInput")
 	local headers = {
@@ -8565,19 +8600,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStackInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStackSync(DeleteStackInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStackAsync(DeleteStackInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStackAsync(DeleteStackInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStackSetOperationResults asynchronously, invoking a callback when done
 -- @param ListStackSetOperationResultsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStackSetOperationResultsAsync(ListStackSetOperationResultsInput, cb)
 	assert(ListStackSetOperationResultsInput, "You must provide a ListStackSetOperationResultsInput")
 	local headers = {
@@ -8600,19 +8636,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStackSetOperationResultsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStackSetOperationResultsSync(ListStackSetOperationResultsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStackSetOperationResultsAsync(ListStackSetOperationResultsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStackSetOperationResultsAsync(ListStackSetOperationResultsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetStackPolicy asynchronously, invoking a callback when done
 -- @param SetStackPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetStackPolicyAsync(SetStackPolicyInput, cb)
 	assert(SetStackPolicyInput, "You must provide a SetStackPolicyInput")
 	local headers = {
@@ -8635,19 +8672,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetStackPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetStackPolicySync(SetStackPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetStackPolicyAsync(SetStackPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetStackPolicyAsync(SetStackPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStacks asynchronously, invoking a callback when done
 -- @param ListStacksInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStacksAsync(ListStacksInput, cb)
 	assert(ListStacksInput, "You must provide a ListStacksInput")
 	local headers = {
@@ -8670,19 +8708,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStacksInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStacksSync(ListStacksInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStacksAsync(ListStacksInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStacksAsync(ListStacksInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EstimateTemplateCost asynchronously, invoking a callback when done
 -- @param EstimateTemplateCostInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EstimateTemplateCostAsync(EstimateTemplateCostInput, cb)
 	assert(EstimateTemplateCostInput, "You must provide a EstimateTemplateCostInput")
 	local headers = {
@@ -8705,19 +8744,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EstimateTemplateCostInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EstimateTemplateCostSync(EstimateTemplateCostInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EstimateTemplateCostAsync(EstimateTemplateCostInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EstimateTemplateCostAsync(EstimateTemplateCostInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountLimits asynchronously, invoking a callback when done
 -- @param DescribeAccountLimitsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountLimitsAsync(DescribeAccountLimitsInput, cb)
 	assert(DescribeAccountLimitsInput, "You must provide a DescribeAccountLimitsInput")
 	local headers = {
@@ -8740,12 +8780,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountLimitsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountLimitsSync(DescribeAccountLimitsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountLimitsAsync(DescribeAccountLimitsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountLimitsAsync(DescribeAccountLimitsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloudfront.lua
+++ b/aws-sdk/cloudfront.lua
@@ -7996,7 +7996,7 @@ end
 --
 --- Call UpdateStreamingDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param UpdateStreamingDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStreamingDistribution2018_06_18Async(UpdateStreamingDistributionRequest, cb)
 	assert(UpdateStreamingDistributionRequest, "You must provide a UpdateStreamingDistributionRequest")
 	local headers = {
@@ -8019,19 +8019,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStreamingDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStreamingDistribution2018_06_18Sync(UpdateStreamingDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStreamingDistribution2018_06_18Async(UpdateStreamingDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStreamingDistribution2018_06_18Async(UpdateStreamingDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFieldLevelEncryptionConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param DeleteFieldLevelEncryptionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFieldLevelEncryptionConfig2018_06_18Async(DeleteFieldLevelEncryptionConfigRequest, cb)
 	assert(DeleteFieldLevelEncryptionConfigRequest, "You must provide a DeleteFieldLevelEncryptionConfigRequest")
 	local headers = {
@@ -8054,19 +8055,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFieldLevelEncryptionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFieldLevelEncryptionConfig2018_06_18Sync(DeleteFieldLevelEncryptionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFieldLevelEncryptionConfig2018_06_18Async(DeleteFieldLevelEncryptionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFieldLevelEncryptionConfig2018_06_18Async(DeleteFieldLevelEncryptionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDistributions2018_06_18 asynchronously, invoking a callback when done
 -- @param ListDistributionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDistributions2018_06_18Async(ListDistributionsRequest, cb)
 	assert(ListDistributionsRequest, "You must provide a ListDistributionsRequest")
 	local headers = {
@@ -8089,19 +8091,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDistributionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDistributions2018_06_18Sync(ListDistributionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDistributions2018_06_18Async(ListDistributionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDistributions2018_06_18Async(ListDistributionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStreamingDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param GetStreamingDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStreamingDistribution2018_06_18Async(GetStreamingDistributionRequest, cb)
 	assert(GetStreamingDistributionRequest, "You must provide a GetStreamingDistributionRequest")
 	local headers = {
@@ -8124,19 +8127,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStreamingDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStreamingDistribution2018_06_18Sync(GetStreamingDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStreamingDistribution2018_06_18Async(GetStreamingDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStreamingDistribution2018_06_18Async(GetStreamingDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPublicKey2018_06_18 asynchronously, invoking a callback when done
 -- @param GetPublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPublicKey2018_06_18Async(GetPublicKeyRequest, cb)
 	assert(GetPublicKeyRequest, "You must provide a GetPublicKeyRequest")
 	local headers = {
@@ -8159,19 +8163,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPublicKey2018_06_18Sync(GetPublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPublicKey2018_06_18Async(GetPublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPublicKey2018_06_18Async(GetPublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStreamingDistributionWithTags2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateStreamingDistributionWithTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStreamingDistributionWithTags2018_06_18Async(CreateStreamingDistributionWithTagsRequest, cb)
 	assert(CreateStreamingDistributionWithTagsRequest, "You must provide a CreateStreamingDistributionWithTagsRequest")
 	local headers = {
@@ -8194,19 +8199,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStreamingDistributionWithTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStreamingDistributionWithTags2018_06_18Sync(CreateStreamingDistributionWithTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStreamingDistributionWithTags2018_06_18Async(CreateStreamingDistributionWithTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStreamingDistributionWithTags2018_06_18Async(CreateStreamingDistributionWithTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePublicKey2018_06_18 asynchronously, invoking a callback when done
 -- @param UpdatePublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePublicKey2018_06_18Async(UpdatePublicKeyRequest, cb)
 	assert(UpdatePublicKeyRequest, "You must provide a UpdatePublicKeyRequest")
 	local headers = {
@@ -8229,19 +8235,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePublicKey2018_06_18Sync(UpdatePublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePublicKey2018_06_18Async(UpdatePublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePublicKey2018_06_18Async(UpdatePublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFieldLevelEncryptionProfile2018_06_18 asynchronously, invoking a callback when done
 -- @param DeleteFieldLevelEncryptionProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFieldLevelEncryptionProfile2018_06_18Async(DeleteFieldLevelEncryptionProfileRequest, cb)
 	assert(DeleteFieldLevelEncryptionProfileRequest, "You must provide a DeleteFieldLevelEncryptionProfileRequest")
 	local headers = {
@@ -8264,19 +8271,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFieldLevelEncryptionProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFieldLevelEncryptionProfile2018_06_18Sync(DeleteFieldLevelEncryptionProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFieldLevelEncryptionProfile2018_06_18Async(DeleteFieldLevelEncryptionProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFieldLevelEncryptionProfile2018_06_18Async(DeleteFieldLevelEncryptionProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDistribution2018_06_18Async(CreateDistributionRequest, cb)
 	assert(CreateDistributionRequest, "You must provide a CreateDistributionRequest")
 	local headers = {
@@ -8299,19 +8307,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDistribution2018_06_18Sync(CreateDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDistribution2018_06_18Async(CreateDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDistribution2018_06_18Async(CreateDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFieldLevelEncryptionProfile2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateFieldLevelEncryptionProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFieldLevelEncryptionProfile2018_06_18Async(CreateFieldLevelEncryptionProfileRequest, cb)
 	assert(CreateFieldLevelEncryptionProfileRequest, "You must provide a CreateFieldLevelEncryptionProfileRequest")
 	local headers = {
@@ -8334,19 +8343,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFieldLevelEncryptionProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFieldLevelEncryptionProfile2018_06_18Sync(CreateFieldLevelEncryptionProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFieldLevelEncryptionProfile2018_06_18Async(CreateFieldLevelEncryptionProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFieldLevelEncryptionProfile2018_06_18Async(CreateFieldLevelEncryptionProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInvalidations2018_06_18 asynchronously, invoking a callback when done
 -- @param ListInvalidationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInvalidations2018_06_18Async(ListInvalidationsRequest, cb)
 	assert(ListInvalidationsRequest, "You must provide a ListInvalidationsRequest")
 	local headers = {
@@ -8369,19 +8379,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInvalidationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInvalidations2018_06_18Sync(ListInvalidationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInvalidations2018_06_18Async(ListInvalidationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInvalidations2018_06_18Async(ListInvalidationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStreamingDistributions2018_06_18 asynchronously, invoking a callback when done
 -- @param ListStreamingDistributionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStreamingDistributions2018_06_18Async(ListStreamingDistributionsRequest, cb)
 	assert(ListStreamingDistributionsRequest, "You must provide a ListStreamingDistributionsRequest")
 	local headers = {
@@ -8404,19 +8415,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStreamingDistributionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStreamingDistributions2018_06_18Sync(ListStreamingDistributionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStreamingDistributions2018_06_18Async(ListStreamingDistributionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStreamingDistributions2018_06_18Async(ListStreamingDistributionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param UpdateDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDistribution2018_06_18Async(UpdateDistributionRequest, cb)
 	assert(UpdateDistributionRequest, "You must provide a UpdateDistributionRequest")
 	local headers = {
@@ -8439,19 +8451,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDistribution2018_06_18Sync(UpdateDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDistribution2018_06_18Async(UpdateDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDistribution2018_06_18Async(UpdateDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStreamingDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateStreamingDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStreamingDistribution2018_06_18Async(CreateStreamingDistributionRequest, cb)
 	assert(CreateStreamingDistributionRequest, "You must provide a CreateStreamingDistributionRequest")
 	local headers = {
@@ -8474,19 +8487,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStreamingDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStreamingDistribution2018_06_18Sync(CreateStreamingDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStreamingDistribution2018_06_18Async(CreateStreamingDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStreamingDistribution2018_06_18Async(CreateStreamingDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPublicKeyConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param GetPublicKeyConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPublicKeyConfig2018_06_18Async(GetPublicKeyConfigRequest, cb)
 	assert(GetPublicKeyConfigRequest, "You must provide a GetPublicKeyConfigRequest")
 	local headers = {
@@ -8509,19 +8523,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPublicKeyConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPublicKeyConfig2018_06_18Sync(GetPublicKeyConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPublicKeyConfig2018_06_18Async(GetPublicKeyConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPublicKeyConfig2018_06_18Async(GetPublicKeyConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param DeleteDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDistribution2018_06_18Async(DeleteDistributionRequest, cb)
 	assert(DeleteDistributionRequest, "You must provide a DeleteDistributionRequest")
 	local headers = {
@@ -8544,19 +8559,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDistribution2018_06_18Sync(DeleteDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDistribution2018_06_18Async(DeleteDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDistribution2018_06_18Async(DeleteDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource2018_06_18 asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResource2018_06_18Async(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -8579,19 +8595,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResource2018_06_18Sync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResource2018_06_18Async(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResource2018_06_18Async(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePublicKey2018_06_18 asynchronously, invoking a callback when done
 -- @param CreatePublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePublicKey2018_06_18Async(CreatePublicKeyRequest, cb)
 	assert(CreatePublicKeyRequest, "You must provide a CreatePublicKeyRequest")
 	local headers = {
@@ -8614,19 +8631,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePublicKey2018_06_18Sync(CreatePublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePublicKey2018_06_18Async(CreatePublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePublicKey2018_06_18Async(CreatePublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePublicKey2018_06_18 asynchronously, invoking a callback when done
 -- @param DeletePublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePublicKey2018_06_18Async(DeletePublicKeyRequest, cb)
 	assert(DeletePublicKeyRequest, "You must provide a DeletePublicKeyRequest")
 	local headers = {
@@ -8649,19 +8667,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePublicKey2018_06_18Sync(DeletePublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePublicKey2018_06_18Async(DeletePublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePublicKey2018_06_18Async(DeletePublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInvalidation2018_06_18 asynchronously, invoking a callback when done
 -- @param GetInvalidationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInvalidation2018_06_18Async(GetInvalidationRequest, cb)
 	assert(GetInvalidationRequest, "You must provide a GetInvalidationRequest")
 	local headers = {
@@ -8684,19 +8703,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInvalidationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInvalidation2018_06_18Sync(GetInvalidationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInvalidation2018_06_18Async(GetInvalidationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInvalidation2018_06_18Async(GetInvalidationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCloudFrontOriginAccessIdentity2018_06_18 asynchronously, invoking a callback when done
 -- @param DeleteCloudFrontOriginAccessIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCloudFrontOriginAccessIdentity2018_06_18Async(DeleteCloudFrontOriginAccessIdentityRequest, cb)
 	assert(DeleteCloudFrontOriginAccessIdentityRequest, "You must provide a DeleteCloudFrontOriginAccessIdentityRequest")
 	local headers = {
@@ -8719,19 +8739,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCloudFrontOriginAccessIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCloudFrontOriginAccessIdentity2018_06_18Sync(DeleteCloudFrontOriginAccessIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCloudFrontOriginAccessIdentity2018_06_18Async(DeleteCloudFrontOriginAccessIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCloudFrontOriginAccessIdentity2018_06_18Async(DeleteCloudFrontOriginAccessIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFieldLevelEncryptionProfile2018_06_18 asynchronously, invoking a callback when done
 -- @param UpdateFieldLevelEncryptionProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFieldLevelEncryptionProfile2018_06_18Async(UpdateFieldLevelEncryptionProfileRequest, cb)
 	assert(UpdateFieldLevelEncryptionProfileRequest, "You must provide a UpdateFieldLevelEncryptionProfileRequest")
 	local headers = {
@@ -8754,19 +8775,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFieldLevelEncryptionProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFieldLevelEncryptionProfile2018_06_18Sync(UpdateFieldLevelEncryptionProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFieldLevelEncryptionProfile2018_06_18Async(UpdateFieldLevelEncryptionProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFieldLevelEncryptionProfile2018_06_18Async(UpdateFieldLevelEncryptionProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCloudFrontOriginAccessIdentities2018_06_18 asynchronously, invoking a callback when done
 -- @param ListCloudFrontOriginAccessIdentitiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCloudFrontOriginAccessIdentities2018_06_18Async(ListCloudFrontOriginAccessIdentitiesRequest, cb)
 	assert(ListCloudFrontOriginAccessIdentitiesRequest, "You must provide a ListCloudFrontOriginAccessIdentitiesRequest")
 	local headers = {
@@ -8789,19 +8811,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCloudFrontOriginAccessIdentitiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCloudFrontOriginAccessIdentities2018_06_18Sync(ListCloudFrontOriginAccessIdentitiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCloudFrontOriginAccessIdentities2018_06_18Async(ListCloudFrontOriginAccessIdentitiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCloudFrontOriginAccessIdentities2018_06_18Async(ListCloudFrontOriginAccessIdentitiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFieldLevelEncryptionConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateFieldLevelEncryptionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFieldLevelEncryptionConfig2018_06_18Async(CreateFieldLevelEncryptionConfigRequest, cb)
 	assert(CreateFieldLevelEncryptionConfigRequest, "You must provide a CreateFieldLevelEncryptionConfigRequest")
 	local headers = {
@@ -8824,19 +8847,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFieldLevelEncryptionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFieldLevelEncryptionConfig2018_06_18Sync(CreateFieldLevelEncryptionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFieldLevelEncryptionConfig2018_06_18Async(CreateFieldLevelEncryptionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFieldLevelEncryptionConfig2018_06_18Async(CreateFieldLevelEncryptionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPublicKeys2018_06_18 asynchronously, invoking a callback when done
 -- @param ListPublicKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPublicKeys2018_06_18Async(ListPublicKeysRequest, cb)
 	assert(ListPublicKeysRequest, "You must provide a ListPublicKeysRequest")
 	local headers = {
@@ -8859,19 +8883,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPublicKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPublicKeys2018_06_18Sync(ListPublicKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPublicKeys2018_06_18Async(ListPublicKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPublicKeys2018_06_18Async(ListPublicKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStreamingDistributionConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param GetStreamingDistributionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStreamingDistributionConfig2018_06_18Async(GetStreamingDistributionConfigRequest, cb)
 	assert(GetStreamingDistributionConfigRequest, "You must provide a GetStreamingDistributionConfigRequest")
 	local headers = {
@@ -8894,19 +8919,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStreamingDistributionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStreamingDistributionConfig2018_06_18Sync(GetStreamingDistributionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStreamingDistributionConfig2018_06_18Async(GetStreamingDistributionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStreamingDistributionConfig2018_06_18Async(GetStreamingDistributionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFieldLevelEncryptionProfileConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param GetFieldLevelEncryptionProfileConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFieldLevelEncryptionProfileConfig2018_06_18Async(GetFieldLevelEncryptionProfileConfigRequest, cb)
 	assert(GetFieldLevelEncryptionProfileConfigRequest, "You must provide a GetFieldLevelEncryptionProfileConfigRequest")
 	local headers = {
@@ -8929,19 +8955,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFieldLevelEncryptionProfileConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFieldLevelEncryptionProfileConfig2018_06_18Sync(GetFieldLevelEncryptionProfileConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFieldLevelEncryptionProfileConfig2018_06_18Async(GetFieldLevelEncryptionProfileConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFieldLevelEncryptionProfileConfig2018_06_18Async(GetFieldLevelEncryptionProfileConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCloudFrontOriginAccessIdentity2018_06_18 asynchronously, invoking a callback when done
 -- @param GetCloudFrontOriginAccessIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCloudFrontOriginAccessIdentity2018_06_18Async(GetCloudFrontOriginAccessIdentityRequest, cb)
 	assert(GetCloudFrontOriginAccessIdentityRequest, "You must provide a GetCloudFrontOriginAccessIdentityRequest")
 	local headers = {
@@ -8964,19 +8991,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCloudFrontOriginAccessIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCloudFrontOriginAccessIdentity2018_06_18Sync(GetCloudFrontOriginAccessIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCloudFrontOriginAccessIdentity2018_06_18Async(GetCloudFrontOriginAccessIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCloudFrontOriginAccessIdentity2018_06_18Async(GetCloudFrontOriginAccessIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param GetDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDistribution2018_06_18Async(GetDistributionRequest, cb)
 	assert(GetDistributionRequest, "You must provide a GetDistributionRequest")
 	local headers = {
@@ -8999,19 +9027,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDistribution2018_06_18Sync(GetDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDistribution2018_06_18Async(GetDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDistribution2018_06_18Async(GetDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCloudFrontOriginAccessIdentityConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param GetCloudFrontOriginAccessIdentityConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCloudFrontOriginAccessIdentityConfig2018_06_18Async(GetCloudFrontOriginAccessIdentityConfigRequest, cb)
 	assert(GetCloudFrontOriginAccessIdentityConfigRequest, "You must provide a GetCloudFrontOriginAccessIdentityConfigRequest")
 	local headers = {
@@ -9034,19 +9063,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCloudFrontOriginAccessIdentityConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCloudFrontOriginAccessIdentityConfig2018_06_18Sync(GetCloudFrontOriginAccessIdentityConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCloudFrontOriginAccessIdentityConfig2018_06_18Async(GetCloudFrontOriginAccessIdentityConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCloudFrontOriginAccessIdentityConfig2018_06_18Async(GetCloudFrontOriginAccessIdentityConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFieldLevelEncryptionProfiles2018_06_18 asynchronously, invoking a callback when done
 -- @param ListFieldLevelEncryptionProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFieldLevelEncryptionProfiles2018_06_18Async(ListFieldLevelEncryptionProfilesRequest, cb)
 	assert(ListFieldLevelEncryptionProfilesRequest, "You must provide a ListFieldLevelEncryptionProfilesRequest")
 	local headers = {
@@ -9069,19 +9099,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFieldLevelEncryptionProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFieldLevelEncryptionProfiles2018_06_18Sync(ListFieldLevelEncryptionProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFieldLevelEncryptionProfiles2018_06_18Async(ListFieldLevelEncryptionProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFieldLevelEncryptionProfiles2018_06_18Async(ListFieldLevelEncryptionProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDistributionConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param GetDistributionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDistributionConfig2018_06_18Async(GetDistributionConfigRequest, cb)
 	assert(GetDistributionConfigRequest, "You must provide a GetDistributionConfigRequest")
 	local headers = {
@@ -9104,19 +9135,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDistributionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDistributionConfig2018_06_18Sync(GetDistributionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDistributionConfig2018_06_18Async(GetDistributionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDistributionConfig2018_06_18Async(GetDistributionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCloudFrontOriginAccessIdentity2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateCloudFrontOriginAccessIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCloudFrontOriginAccessIdentity2018_06_18Async(CreateCloudFrontOriginAccessIdentityRequest, cb)
 	assert(CreateCloudFrontOriginAccessIdentityRequest, "You must provide a CreateCloudFrontOriginAccessIdentityRequest")
 	local headers = {
@@ -9139,19 +9171,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCloudFrontOriginAccessIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCloudFrontOriginAccessIdentity2018_06_18Sync(CreateCloudFrontOriginAccessIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCloudFrontOriginAccessIdentity2018_06_18Async(CreateCloudFrontOriginAccessIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCloudFrontOriginAccessIdentity2018_06_18Async(CreateCloudFrontOriginAccessIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFieldLevelEncryptionConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param UpdateFieldLevelEncryptionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFieldLevelEncryptionConfig2018_06_18Async(UpdateFieldLevelEncryptionConfigRequest, cb)
 	assert(UpdateFieldLevelEncryptionConfigRequest, "You must provide a UpdateFieldLevelEncryptionConfigRequest")
 	local headers = {
@@ -9174,19 +9207,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFieldLevelEncryptionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFieldLevelEncryptionConfig2018_06_18Sync(UpdateFieldLevelEncryptionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFieldLevelEncryptionConfig2018_06_18Async(UpdateFieldLevelEncryptionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFieldLevelEncryptionConfig2018_06_18Async(UpdateFieldLevelEncryptionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStreamingDistribution2018_06_18 asynchronously, invoking a callback when done
 -- @param DeleteStreamingDistributionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStreamingDistribution2018_06_18Async(DeleteStreamingDistributionRequest, cb)
 	assert(DeleteStreamingDistributionRequest, "You must provide a DeleteStreamingDistributionRequest")
 	local headers = {
@@ -9209,19 +9243,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStreamingDistributionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStreamingDistribution2018_06_18Sync(DeleteStreamingDistributionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStreamingDistribution2018_06_18Async(DeleteStreamingDistributionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStreamingDistribution2018_06_18Async(DeleteStreamingDistributionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDistributionWithTags2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateDistributionWithTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDistributionWithTags2018_06_18Async(CreateDistributionWithTagsRequest, cb)
 	assert(CreateDistributionWithTagsRequest, "You must provide a CreateDistributionWithTagsRequest")
 	local headers = {
@@ -9244,19 +9279,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDistributionWithTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDistributionWithTags2018_06_18Sync(CreateDistributionWithTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDistributionWithTags2018_06_18Async(CreateDistributionWithTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDistributionWithTags2018_06_18Async(CreateDistributionWithTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCloudFrontOriginAccessIdentity2018_06_18 asynchronously, invoking a callback when done
 -- @param UpdateCloudFrontOriginAccessIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCloudFrontOriginAccessIdentity2018_06_18Async(UpdateCloudFrontOriginAccessIdentityRequest, cb)
 	assert(UpdateCloudFrontOriginAccessIdentityRequest, "You must provide a UpdateCloudFrontOriginAccessIdentityRequest")
 	local headers = {
@@ -9279,19 +9315,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCloudFrontOriginAccessIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCloudFrontOriginAccessIdentity2018_06_18Sync(UpdateCloudFrontOriginAccessIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCloudFrontOriginAccessIdentity2018_06_18Async(UpdateCloudFrontOriginAccessIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCloudFrontOriginAccessIdentity2018_06_18Async(UpdateCloudFrontOriginAccessIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource2018_06_18 asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResource2018_06_18Async(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -9314,19 +9351,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResource2018_06_18Sync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResource2018_06_18Async(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResource2018_06_18Async(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFieldLevelEncryptionConfigs2018_06_18 asynchronously, invoking a callback when done
 -- @param ListFieldLevelEncryptionConfigsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFieldLevelEncryptionConfigs2018_06_18Async(ListFieldLevelEncryptionConfigsRequest, cb)
 	assert(ListFieldLevelEncryptionConfigsRequest, "You must provide a ListFieldLevelEncryptionConfigsRequest")
 	local headers = {
@@ -9349,19 +9387,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFieldLevelEncryptionConfigsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFieldLevelEncryptionConfigs2018_06_18Sync(ListFieldLevelEncryptionConfigsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFieldLevelEncryptionConfigs2018_06_18Async(ListFieldLevelEncryptionConfigsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFieldLevelEncryptionConfigs2018_06_18Async(ListFieldLevelEncryptionConfigsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFieldLevelEncryptionProfile2018_06_18 asynchronously, invoking a callback when done
 -- @param GetFieldLevelEncryptionProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFieldLevelEncryptionProfile2018_06_18Async(GetFieldLevelEncryptionProfileRequest, cb)
 	assert(GetFieldLevelEncryptionProfileRequest, "You must provide a GetFieldLevelEncryptionProfileRequest")
 	local headers = {
@@ -9384,19 +9423,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFieldLevelEncryptionProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFieldLevelEncryptionProfile2018_06_18Sync(GetFieldLevelEncryptionProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFieldLevelEncryptionProfile2018_06_18Async(GetFieldLevelEncryptionProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFieldLevelEncryptionProfile2018_06_18Async(GetFieldLevelEncryptionProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFieldLevelEncryption2018_06_18 asynchronously, invoking a callback when done
 -- @param GetFieldLevelEncryptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFieldLevelEncryption2018_06_18Async(GetFieldLevelEncryptionRequest, cb)
 	assert(GetFieldLevelEncryptionRequest, "You must provide a GetFieldLevelEncryptionRequest")
 	local headers = {
@@ -9419,19 +9459,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFieldLevelEncryptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFieldLevelEncryption2018_06_18Sync(GetFieldLevelEncryptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFieldLevelEncryption2018_06_18Async(GetFieldLevelEncryptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFieldLevelEncryption2018_06_18Async(GetFieldLevelEncryptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInvalidation2018_06_18 asynchronously, invoking a callback when done
 -- @param CreateInvalidationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInvalidation2018_06_18Async(CreateInvalidationRequest, cb)
 	assert(CreateInvalidationRequest, "You must provide a CreateInvalidationRequest")
 	local headers = {
@@ -9454,19 +9495,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInvalidationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInvalidation2018_06_18Sync(CreateInvalidationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInvalidation2018_06_18Async(CreateInvalidationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInvalidation2018_06_18Async(CreateInvalidationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDistributionsByWebACLId2018_06_18 asynchronously, invoking a callback when done
 -- @param ListDistributionsByWebACLIdRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDistributionsByWebACLId2018_06_18Async(ListDistributionsByWebACLIdRequest, cb)
 	assert(ListDistributionsByWebACLIdRequest, "You must provide a ListDistributionsByWebACLIdRequest")
 	local headers = {
@@ -9489,19 +9531,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDistributionsByWebACLIdRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDistributionsByWebACLId2018_06_18Sync(ListDistributionsByWebACLIdRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDistributionsByWebACLId2018_06_18Async(ListDistributionsByWebACLIdRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDistributionsByWebACLId2018_06_18Async(ListDistributionsByWebACLIdRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource2018_06_18 asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResource2018_06_18Async(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -9524,19 +9567,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResource2018_06_18Sync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResource2018_06_18Async(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResource2018_06_18Async(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFieldLevelEncryptionConfig2018_06_18 asynchronously, invoking a callback when done
 -- @param GetFieldLevelEncryptionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFieldLevelEncryptionConfig2018_06_18Async(GetFieldLevelEncryptionConfigRequest, cb)
 	assert(GetFieldLevelEncryptionConfigRequest, "You must provide a GetFieldLevelEncryptionConfigRequest")
 	local headers = {
@@ -9559,12 +9603,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFieldLevelEncryptionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFieldLevelEncryptionConfig2018_06_18Sync(GetFieldLevelEncryptionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFieldLevelEncryptionConfig2018_06_18Async(GetFieldLevelEncryptionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFieldLevelEncryptionConfig2018_06_18Async(GetFieldLevelEncryptionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloudhsm.lua
+++ b/aws-sdk/cloudhsm.lua
@@ -2375,7 +2375,7 @@ end
 --
 --- Call CreateHsm asynchronously, invoking a callback when done
 -- @param CreateHsmRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHsmAsync(CreateHsmRequest, cb)
 	assert(CreateHsmRequest, "You must provide a CreateHsmRequest")
 	local headers = {
@@ -2398,19 +2398,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHsmRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHsmSync(CreateHsmRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHsmAsync(CreateHsmRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHsmAsync(CreateHsmRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHapgs asynchronously, invoking a callback when done
 -- @param ListHapgsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHapgsAsync(ListHapgsRequest, cb)
 	assert(ListHapgsRequest, "You must provide a ListHapgsRequest")
 	local headers = {
@@ -2433,19 +2434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHapgsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHapgsSync(ListHapgsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHapgsAsync(ListHapgsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHapgsAsync(ListHapgsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyHapg asynchronously, invoking a callback when done
 -- @param ModifyHapgRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyHapgAsync(ModifyHapgRequest, cb)
 	assert(ModifyHapgRequest, "You must provide a ModifyHapgRequest")
 	local headers = {
@@ -2468,19 +2470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyHapgRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyHapgSync(ModifyHapgRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyHapgAsync(ModifyHapgRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyHapgAsync(ModifyHapgRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHapg asynchronously, invoking a callback when done
 -- @param DescribeHapgRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHapgAsync(DescribeHapgRequest, cb)
 	assert(DescribeHapgRequest, "You must provide a DescribeHapgRequest")
 	local headers = {
@@ -2503,19 +2506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHapgRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHapgSync(DescribeHapgRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHapgAsync(DescribeHapgRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHapgAsync(DescribeHapgRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHsm asynchronously, invoking a callback when done
 -- @param DeleteHsmRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHsmAsync(DeleteHsmRequest, cb)
 	assert(DeleteHsmRequest, "You must provide a DeleteHsmRequest")
 	local headers = {
@@ -2538,19 +2542,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHsmRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHsmSync(DeleteHsmRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHsmAsync(DeleteHsmRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHsmAsync(DeleteHsmRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHsms asynchronously, invoking a callback when done
 -- @param ListHsmsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHsmsAsync(ListHsmsRequest, cb)
 	assert(ListHsmsRequest, "You must provide a ListHsmsRequest")
 	local headers = {
@@ -2573,19 +2578,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHsmsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHsmsSync(ListHsmsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHsmsAsync(ListHsmsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHsmsAsync(ListHsmsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToResource asynchronously, invoking a callback when done
 -- @param AddTagsToResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToResourceAsync(AddTagsToResourceRequest, cb)
 	assert(AddTagsToResourceRequest, "You must provide a AddTagsToResourceRequest")
 	local headers = {
@@ -2608,19 +2614,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToResourceSync(AddTagsToResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToResourceAsync(AddTagsToResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToResourceAsync(AddTagsToResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLunaClient asynchronously, invoking a callback when done
 -- @param DeleteLunaClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLunaClientAsync(DeleteLunaClientRequest, cb)
 	assert(DeleteLunaClientRequest, "You must provide a DeleteLunaClientRequest")
 	local headers = {
@@ -2643,19 +2650,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLunaClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLunaClientSync(DeleteLunaClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLunaClientAsync(DeleteLunaClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLunaClientAsync(DeleteLunaClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLunaClient asynchronously, invoking a callback when done
 -- @param CreateLunaClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLunaClientAsync(CreateLunaClientRequest, cb)
 	assert(CreateLunaClientRequest, "You must provide a CreateLunaClientRequest")
 	local headers = {
@@ -2678,19 +2686,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLunaClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLunaClientSync(CreateLunaClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLunaClientAsync(CreateLunaClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLunaClientAsync(CreateLunaClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHapg asynchronously, invoking a callback when done
 -- @param CreateHapgRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHapgAsync(CreateHapgRequest, cb)
 	assert(CreateHapgRequest, "You must provide a CreateHapgRequest")
 	local headers = {
@@ -2713,19 +2722,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHapgRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHapgSync(CreateHapgRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHapgAsync(CreateHapgRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHapgAsync(CreateHapgRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromResource asynchronously, invoking a callback when done
 -- @param RemoveTagsFromResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, cb)
 	assert(RemoveTagsFromResourceRequest, "You must provide a RemoveTagsFromResourceRequest")
 	local headers = {
@@ -2748,19 +2758,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromResourceSync(RemoveTagsFromResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHapg asynchronously, invoking a callback when done
 -- @param DeleteHapgRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHapgAsync(DeleteHapgRequest, cb)
 	assert(DeleteHapgRequest, "You must provide a DeleteHapgRequest")
 	local headers = {
@@ -2783,19 +2794,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHapgRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHapgSync(DeleteHapgRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHapgAsync(DeleteHapgRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHapgAsync(DeleteHapgRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHsm asynchronously, invoking a callback when done
 -- @param DescribeHsmRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHsmAsync(DescribeHsmRequest, cb)
 	assert(DescribeHsmRequest, "You must provide a DescribeHsmRequest")
 	local headers = {
@@ -2818,19 +2830,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHsmRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHsmSync(DescribeHsmRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHsmAsync(DescribeHsmRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHsmAsync(DescribeHsmRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConfig asynchronously, invoking a callback when done
 -- @param GetConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConfigAsync(GetConfigRequest, cb)
 	assert(GetConfigRequest, "You must provide a GetConfigRequest")
 	local headers = {
@@ -2853,19 +2866,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConfigSync(GetConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConfigAsync(GetConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConfigAsync(GetConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAvailableZones asynchronously, invoking a callback when done
 -- @param ListAvailableZonesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAvailableZonesAsync(ListAvailableZonesRequest, cb)
 	assert(ListAvailableZonesRequest, "You must provide a ListAvailableZonesRequest")
 	local headers = {
@@ -2888,19 +2902,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAvailableZonesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAvailableZonesSync(ListAvailableZonesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAvailableZonesAsync(ListAvailableZonesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAvailableZonesAsync(ListAvailableZonesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyHsm asynchronously, invoking a callback when done
 -- @param ModifyHsmRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyHsmAsync(ModifyHsmRequest, cb)
 	assert(ModifyHsmRequest, "You must provide a ModifyHsmRequest")
 	local headers = {
@@ -2923,19 +2938,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyHsmRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyHsmSync(ModifyHsmRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyHsmAsync(ModifyHsmRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyHsmAsync(ModifyHsmRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -2958,19 +2974,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyLunaClient asynchronously, invoking a callback when done
 -- @param ModifyLunaClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyLunaClientAsync(ModifyLunaClientRequest, cb)
 	assert(ModifyLunaClientRequest, "You must provide a ModifyLunaClientRequest")
 	local headers = {
@@ -2993,19 +3010,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyLunaClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyLunaClientSync(ModifyLunaClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyLunaClientAsync(ModifyLunaClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyLunaClientAsync(ModifyLunaClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLunaClient asynchronously, invoking a callback when done
 -- @param DescribeLunaClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLunaClientAsync(DescribeLunaClientRequest, cb)
 	assert(DescribeLunaClientRequest, "You must provide a DescribeLunaClientRequest")
 	local headers = {
@@ -3028,19 +3046,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLunaClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLunaClientSync(DescribeLunaClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLunaClientAsync(DescribeLunaClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLunaClientAsync(DescribeLunaClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLunaClients asynchronously, invoking a callback when done
 -- @param ListLunaClientsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLunaClientsAsync(ListLunaClientsRequest, cb)
 	assert(ListLunaClientsRequest, "You must provide a ListLunaClientsRequest")
 	local headers = {
@@ -3063,12 +3082,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLunaClientsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLunaClientsSync(ListLunaClientsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLunaClientsAsync(ListLunaClientsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLunaClientsAsync(ListLunaClientsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloudhsmv2.lua
+++ b/aws-sdk/cloudhsmv2.lua
@@ -1897,7 +1897,7 @@ end
 --
 --- Call CreateHsm asynchronously, invoking a callback when done
 -- @param CreateHsmRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHsmAsync(CreateHsmRequest, cb)
 	assert(CreateHsmRequest, "You must provide a CreateHsmRequest")
 	local headers = {
@@ -1920,19 +1920,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHsmRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHsmSync(CreateHsmRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHsmAsync(CreateHsmRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHsmAsync(CreateHsmRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -1955,19 +1956,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -1990,19 +1992,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCluster asynchronously, invoking a callback when done
 -- @param CreateClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterAsync(CreateClusterRequest, cb)
 	assert(CreateClusterRequest, "You must provide a CreateClusterRequest")
 	local headers = {
@@ -2025,19 +2028,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSync(CreateClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterAsync(CreateClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterAsync(CreateClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHsm asynchronously, invoking a callback when done
 -- @param DeleteHsmRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHsmAsync(DeleteHsmRequest, cb)
 	assert(DeleteHsmRequest, "You must provide a DeleteHsmRequest")
 	local headers = {
@@ -2060,19 +2064,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHsmRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHsmSync(DeleteHsmRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHsmAsync(DeleteHsmRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHsmAsync(DeleteHsmRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBackups asynchronously, invoking a callback when done
 -- @param DescribeBackupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBackupsAsync(DescribeBackupsRequest, cb)
 	assert(DescribeBackupsRequest, "You must provide a DescribeBackupsRequest")
 	local headers = {
@@ -2095,19 +2100,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBackupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBackupsSync(DescribeBackupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBackupsAsync(DescribeBackupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBackupsAsync(DescribeBackupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBackup asynchronously, invoking a callback when done
 -- @param DeleteBackupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBackupAsync(DeleteBackupRequest, cb)
 	assert(DeleteBackupRequest, "You must provide a DeleteBackupRequest")
 	local headers = {
@@ -2130,19 +2136,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBackupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBackupSync(DeleteBackupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBackupAsync(DeleteBackupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBackupAsync(DeleteBackupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreBackup asynchronously, invoking a callback when done
 -- @param RestoreBackupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreBackupAsync(RestoreBackupRequest, cb)
 	assert(RestoreBackupRequest, "You must provide a RestoreBackupRequest")
 	local headers = {
@@ -2165,19 +2172,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreBackupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreBackupSync(RestoreBackupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreBackupAsync(RestoreBackupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreBackupAsync(RestoreBackupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitializeCluster asynchronously, invoking a callback when done
 -- @param InitializeClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitializeClusterAsync(InitializeClusterRequest, cb)
 	assert(InitializeClusterRequest, "You must provide a InitializeClusterRequest")
 	local headers = {
@@ -2200,19 +2208,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitializeClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitializeClusterSync(InitializeClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitializeClusterAsync(InitializeClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitializeClusterAsync(InitializeClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -2235,19 +2244,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyBackupToRegion asynchronously, invoking a callback when done
 -- @param CopyBackupToRegionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyBackupToRegionAsync(CopyBackupToRegionRequest, cb)
 	assert(CopyBackupToRegionRequest, "You must provide a CopyBackupToRegionRequest")
 	local headers = {
@@ -2270,19 +2280,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyBackupToRegionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyBackupToRegionSync(CopyBackupToRegionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyBackupToRegionAsync(CopyBackupToRegionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyBackupToRegionAsync(CopyBackupToRegionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusters asynchronously, invoking a callback when done
 -- @param DescribeClustersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClustersAsync(DescribeClustersRequest, cb)
 	assert(DescribeClustersRequest, "You must provide a DescribeClustersRequest")
 	local headers = {
@@ -2305,19 +2316,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClustersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClustersSync(DescribeClustersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClustersAsync(DescribeClustersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClustersAsync(DescribeClustersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCluster asynchronously, invoking a callback when done
 -- @param DeleteClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterAsync(DeleteClusterRequest, cb)
 	assert(DeleteClusterRequest, "You must provide a DeleteClusterRequest")
 	local headers = {
@@ -2340,12 +2352,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSync(DeleteClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloudsearch.lua
+++ b/aws-sdk/cloudsearch.lua
@@ -4132,7 +4132,7 @@ end
 --
 --- Call DescribeServiceAccessPolicies asynchronously, invoking a callback when done
 -- @param DescribeServiceAccessPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeServiceAccessPoliciesAsync(DescribeServiceAccessPoliciesRequest, cb)
 	assert(DescribeServiceAccessPoliciesRequest, "You must provide a DescribeServiceAccessPoliciesRequest")
 	local headers = {
@@ -4155,19 +4155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeServiceAccessPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeServiceAccessPoliciesSync(DescribeServiceAccessPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeServiceAccessPoliciesAsync(DescribeServiceAccessPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeServiceAccessPoliciesAsync(DescribeServiceAccessPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateScalingParameters asynchronously, invoking a callback when done
 -- @param UpdateScalingParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateScalingParametersAsync(UpdateScalingParametersRequest, cb)
 	assert(UpdateScalingParametersRequest, "You must provide a UpdateScalingParametersRequest")
 	local headers = {
@@ -4190,19 +4191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateScalingParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateScalingParametersSync(UpdateScalingParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateScalingParametersAsync(UpdateScalingParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateScalingParametersAsync(UpdateScalingParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDomains asynchronously, invoking a callback when done
 -- @param DescribeDomainsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDomainsAsync(DescribeDomainsRequest, cb)
 	assert(DescribeDomainsRequest, "You must provide a DescribeDomainsRequest")
 	local headers = {
@@ -4225,19 +4227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDomainsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDomainsSync(DescribeDomainsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDomainsAsync(DescribeDomainsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDomainsAsync(DescribeDomainsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeScalingParameters asynchronously, invoking a callback when done
 -- @param DescribeScalingParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScalingParametersAsync(DescribeScalingParametersRequest, cb)
 	assert(DescribeScalingParametersRequest, "You must provide a DescribeScalingParametersRequest")
 	local headers = {
@@ -4260,19 +4263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScalingParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScalingParametersSync(DescribeScalingParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScalingParametersAsync(DescribeScalingParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScalingParametersAsync(DescribeScalingParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeExpressions asynchronously, invoking a callback when done
 -- @param DescribeExpressionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeExpressionsAsync(DescribeExpressionsRequest, cb)
 	assert(DescribeExpressionsRequest, "You must provide a DescribeExpressionsRequest")
 	local headers = {
@@ -4295,19 +4299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeExpressionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeExpressionsSync(DescribeExpressionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeExpressionsAsync(DescribeExpressionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeExpressionsAsync(DescribeExpressionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIndexFields asynchronously, invoking a callback when done
 -- @param DescribeIndexFieldsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIndexFieldsAsync(DescribeIndexFieldsRequest, cb)
 	assert(DescribeIndexFieldsRequest, "You must provide a DescribeIndexFieldsRequest")
 	local headers = {
@@ -4330,18 +4335,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIndexFieldsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIndexFieldsSync(DescribeIndexFieldsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIndexFieldsAsync(DescribeIndexFieldsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIndexFieldsAsync(DescribeIndexFieldsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDomainNames asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDomainNamesAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -4360,19 +4366,20 @@ end
 --- Call ListDomainNames synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDomainNamesSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDomainNamesAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDomainNamesAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAvailabilityOptions asynchronously, invoking a callback when done
 -- @param DescribeAvailabilityOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAvailabilityOptionsAsync(DescribeAvailabilityOptionsRequest, cb)
 	assert(DescribeAvailabilityOptionsRequest, "You must provide a DescribeAvailabilityOptionsRequest")
 	local headers = {
@@ -4395,19 +4402,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAvailabilityOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAvailabilityOptionsSync(DescribeAvailabilityOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAvailabilityOptionsAsync(DescribeAvailabilityOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAvailabilityOptionsAsync(DescribeAvailabilityOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DefineIndexField asynchronously, invoking a callback when done
 -- @param DefineIndexFieldRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DefineIndexFieldAsync(DefineIndexFieldRequest, cb)
 	assert(DefineIndexFieldRequest, "You must provide a DefineIndexFieldRequest")
 	local headers = {
@@ -4430,19 +4438,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DefineIndexFieldRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DefineIndexFieldSync(DefineIndexFieldRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DefineIndexFieldAsync(DefineIndexFieldRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DefineIndexFieldAsync(DefineIndexFieldRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAnalysisScheme asynchronously, invoking a callback when done
 -- @param DeleteAnalysisSchemeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAnalysisSchemeAsync(DeleteAnalysisSchemeRequest, cb)
 	assert(DeleteAnalysisSchemeRequest, "You must provide a DeleteAnalysisSchemeRequest")
 	local headers = {
@@ -4465,19 +4474,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAnalysisSchemeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAnalysisSchemeSync(DeleteAnalysisSchemeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAnalysisSchemeAsync(DeleteAnalysisSchemeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAnalysisSchemeAsync(DeleteAnalysisSchemeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAvailabilityOptions asynchronously, invoking a callback when done
 -- @param UpdateAvailabilityOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAvailabilityOptionsAsync(UpdateAvailabilityOptionsRequest, cb)
 	assert(UpdateAvailabilityOptionsRequest, "You must provide a UpdateAvailabilityOptionsRequest")
 	local headers = {
@@ -4500,19 +4510,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAvailabilityOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAvailabilityOptionsSync(UpdateAvailabilityOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAvailabilityOptionsAsync(UpdateAvailabilityOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAvailabilityOptionsAsync(UpdateAvailabilityOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteExpression asynchronously, invoking a callback when done
 -- @param DeleteExpressionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteExpressionAsync(DeleteExpressionRequest, cb)
 	assert(DeleteExpressionRequest, "You must provide a DeleteExpressionRequest")
 	local headers = {
@@ -4535,19 +4546,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteExpressionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteExpressionSync(DeleteExpressionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteExpressionAsync(DeleteExpressionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteExpressionAsync(DeleteExpressionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAnalysisSchemes asynchronously, invoking a callback when done
 -- @param DescribeAnalysisSchemesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAnalysisSchemesAsync(DescribeAnalysisSchemesRequest, cb)
 	assert(DescribeAnalysisSchemesRequest, "You must provide a DescribeAnalysisSchemesRequest")
 	local headers = {
@@ -4570,19 +4582,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAnalysisSchemesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAnalysisSchemesSync(DescribeAnalysisSchemesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAnalysisSchemesAsync(DescribeAnalysisSchemesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAnalysisSchemesAsync(DescribeAnalysisSchemesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DefineSuggester asynchronously, invoking a callback when done
 -- @param DefineSuggesterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DefineSuggesterAsync(DefineSuggesterRequest, cb)
 	assert(DefineSuggesterRequest, "You must provide a DefineSuggesterRequest")
 	local headers = {
@@ -4605,19 +4618,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DefineSuggesterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DefineSuggesterSync(DefineSuggesterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DefineSuggesterAsync(DefineSuggesterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DefineSuggesterAsync(DefineSuggesterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDomain asynchronously, invoking a callback when done
 -- @param CreateDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDomainAsync(CreateDomainRequest, cb)
 	assert(CreateDomainRequest, "You must provide a CreateDomainRequest")
 	local headers = {
@@ -4640,19 +4654,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDomainSync(CreateDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDomainAsync(CreateDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDomainAsync(CreateDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call IndexDocuments asynchronously, invoking a callback when done
 -- @param IndexDocumentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.IndexDocumentsAsync(IndexDocumentsRequest, cb)
 	assert(IndexDocumentsRequest, "You must provide a IndexDocumentsRequest")
 	local headers = {
@@ -4675,19 +4690,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IndexDocumentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.IndexDocumentsSync(IndexDocumentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.IndexDocumentsAsync(IndexDocumentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.IndexDocumentsAsync(IndexDocumentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSuggesters asynchronously, invoking a callback when done
 -- @param DescribeSuggestersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSuggestersAsync(DescribeSuggestersRequest, cb)
 	assert(DescribeSuggestersRequest, "You must provide a DescribeSuggestersRequest")
 	local headers = {
@@ -4710,19 +4726,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSuggestersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSuggestersSync(DescribeSuggestersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSuggestersAsync(DescribeSuggestersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSuggestersAsync(DescribeSuggestersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateServiceAccessPolicies asynchronously, invoking a callback when done
 -- @param UpdateServiceAccessPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServiceAccessPoliciesAsync(UpdateServiceAccessPoliciesRequest, cb)
 	assert(UpdateServiceAccessPoliciesRequest, "You must provide a UpdateServiceAccessPoliciesRequest")
 	local headers = {
@@ -4745,19 +4762,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServiceAccessPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServiceAccessPoliciesSync(UpdateServiceAccessPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServiceAccessPoliciesAsync(UpdateServiceAccessPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServiceAccessPoliciesAsync(UpdateServiceAccessPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIndexField asynchronously, invoking a callback when done
 -- @param DeleteIndexFieldRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIndexFieldAsync(DeleteIndexFieldRequest, cb)
 	assert(DeleteIndexFieldRequest, "You must provide a DeleteIndexFieldRequest")
 	local headers = {
@@ -4780,19 +4798,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIndexFieldRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIndexFieldSync(DeleteIndexFieldRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIndexFieldAsync(DeleteIndexFieldRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIndexFieldAsync(DeleteIndexFieldRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DefineAnalysisScheme asynchronously, invoking a callback when done
 -- @param DefineAnalysisSchemeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DefineAnalysisSchemeAsync(DefineAnalysisSchemeRequest, cb)
 	assert(DefineAnalysisSchemeRequest, "You must provide a DefineAnalysisSchemeRequest")
 	local headers = {
@@ -4815,19 +4834,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DefineAnalysisSchemeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DefineAnalysisSchemeSync(DefineAnalysisSchemeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DefineAnalysisSchemeAsync(DefineAnalysisSchemeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DefineAnalysisSchemeAsync(DefineAnalysisSchemeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DefineExpression asynchronously, invoking a callback when done
 -- @param DefineExpressionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DefineExpressionAsync(DefineExpressionRequest, cb)
 	assert(DefineExpressionRequest, "You must provide a DefineExpressionRequest")
 	local headers = {
@@ -4850,19 +4870,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DefineExpressionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DefineExpressionSync(DefineExpressionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DefineExpressionAsync(DefineExpressionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DefineExpressionAsync(DefineExpressionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BuildSuggesters asynchronously, invoking a callback when done
 -- @param BuildSuggestersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BuildSuggestersAsync(BuildSuggestersRequest, cb)
 	assert(BuildSuggestersRequest, "You must provide a BuildSuggestersRequest")
 	local headers = {
@@ -4885,19 +4906,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BuildSuggestersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BuildSuggestersSync(BuildSuggestersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BuildSuggestersAsync(BuildSuggestersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BuildSuggestersAsync(BuildSuggestersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDomain asynchronously, invoking a callback when done
 -- @param DeleteDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDomainAsync(DeleteDomainRequest, cb)
 	assert(DeleteDomainRequest, "You must provide a DeleteDomainRequest")
 	local headers = {
@@ -4920,19 +4942,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDomainSync(DeleteDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDomainAsync(DeleteDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDomainAsync(DeleteDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSuggester asynchronously, invoking a callback when done
 -- @param DeleteSuggesterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSuggesterAsync(DeleteSuggesterRequest, cb)
 	assert(DeleteSuggesterRequest, "You must provide a DeleteSuggesterRequest")
 	local headers = {
@@ -4955,12 +4978,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSuggesterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSuggesterSync(DeleteSuggesterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSuggesterAsync(DeleteSuggesterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSuggesterAsync(DeleteSuggesterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloudsearchdomain.lua
+++ b/aws-sdk/cloudsearchdomain.lua
@@ -1287,7 +1287,7 @@ end
 --
 --- Call Suggest asynchronously, invoking a callback when done
 -- @param SuggestRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SuggestAsync(SuggestRequest, cb)
 	assert(SuggestRequest, "You must provide a SuggestRequest")
 	local headers = {
@@ -1310,19 +1310,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SuggestRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SuggestSync(SuggestRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SuggestAsync(SuggestRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SuggestAsync(SuggestRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Search asynchronously, invoking a callback when done
 -- @param SearchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchAsync(SearchRequest, cb)
 	assert(SearchRequest, "You must provide a SearchRequest")
 	local headers = {
@@ -1345,19 +1346,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchSync(SearchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchAsync(SearchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchAsync(SearchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadDocuments asynchronously, invoking a callback when done
 -- @param UploadDocumentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadDocumentsAsync(UploadDocumentsRequest, cb)
 	assert(UploadDocumentsRequest, "You must provide a UploadDocumentsRequest")
 	local headers = {
@@ -1380,12 +1382,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadDocumentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadDocumentsSync(UploadDocumentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadDocumentsAsync(UploadDocumentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadDocumentsAsync(UploadDocumentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cloudtrail.lua
+++ b/aws-sdk/cloudtrail.lua
@@ -2028,7 +2028,7 @@ end
 --
 --- Call DeleteTrail asynchronously, invoking a callback when done
 -- @param DeleteTrailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTrailAsync(DeleteTrailRequest, cb)
 	assert(DeleteTrailRequest, "You must provide a DeleteTrailRequest")
 	local headers = {
@@ -2051,19 +2051,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTrailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTrailSync(DeleteTrailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTrailAsync(DeleteTrailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTrailAsync(DeleteTrailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTags asynchronously, invoking a callback when done
 -- @param RemoveTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsAsync(RemoveTagsRequest, cb)
 	assert(RemoveTagsRequest, "You must provide a RemoveTagsRequest")
 	local headers = {
@@ -2086,19 +2087,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsSync(RemoveTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsAsync(RemoveTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsAsync(RemoveTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEventSelectors asynchronously, invoking a callback when done
 -- @param GetEventSelectorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEventSelectorsAsync(GetEventSelectorsRequest, cb)
 	assert(GetEventSelectorsRequest, "You must provide a GetEventSelectorsRequest")
 	local headers = {
@@ -2121,19 +2123,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEventSelectorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEventSelectorsSync(GetEventSelectorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEventSelectorsAsync(GetEventSelectorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEventSelectorsAsync(GetEventSelectorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTags asynchronously, invoking a callback when done
 -- @param AddTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsAsync(AddTagsRequest, cb)
 	assert(AddTagsRequest, "You must provide a AddTagsRequest")
 	local headers = {
@@ -2156,19 +2159,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsSync(AddTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsAsync(AddTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsAsync(AddTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartLogging asynchronously, invoking a callback when done
 -- @param StartLoggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartLoggingAsync(StartLoggingRequest, cb)
 	assert(StartLoggingRequest, "You must provide a StartLoggingRequest")
 	local headers = {
@@ -2191,19 +2195,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartLoggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartLoggingSync(StartLoggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartLoggingAsync(StartLoggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartLoggingAsync(StartLoggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTrailStatus asynchronously, invoking a callback when done
 -- @param GetTrailStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTrailStatusAsync(GetTrailStatusRequest, cb)
 	assert(GetTrailStatusRequest, "You must provide a GetTrailStatusRequest")
 	local headers = {
@@ -2226,19 +2231,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTrailStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTrailStatusSync(GetTrailStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTrailStatusAsync(GetTrailStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTrailStatusAsync(GetTrailStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPublicKeys asynchronously, invoking a callback when done
 -- @param ListPublicKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPublicKeysAsync(ListPublicKeysRequest, cb)
 	assert(ListPublicKeysRequest, "You must provide a ListPublicKeysRequest")
 	local headers = {
@@ -2261,19 +2267,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPublicKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPublicKeysSync(ListPublicKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPublicKeysAsync(ListPublicKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPublicKeysAsync(ListPublicKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopLogging asynchronously, invoking a callback when done
 -- @param StopLoggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopLoggingAsync(StopLoggingRequest, cb)
 	assert(StopLoggingRequest, "You must provide a StopLoggingRequest")
 	local headers = {
@@ -2296,19 +2303,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopLoggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopLoggingSync(StopLoggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopLoggingAsync(StopLoggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopLoggingAsync(StopLoggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutEventSelectors asynchronously, invoking a callback when done
 -- @param PutEventSelectorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutEventSelectorsAsync(PutEventSelectorsRequest, cb)
 	assert(PutEventSelectorsRequest, "You must provide a PutEventSelectorsRequest")
 	local headers = {
@@ -2331,19 +2339,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutEventSelectorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutEventSelectorsSync(PutEventSelectorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutEventSelectorsAsync(PutEventSelectorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutEventSelectorsAsync(PutEventSelectorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTrails asynchronously, invoking a callback when done
 -- @param DescribeTrailsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTrailsAsync(DescribeTrailsRequest, cb)
 	assert(DescribeTrailsRequest, "You must provide a DescribeTrailsRequest")
 	local headers = {
@@ -2366,19 +2375,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTrailsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTrailsSync(DescribeTrailsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTrailsAsync(DescribeTrailsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTrailsAsync(DescribeTrailsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTrail asynchronously, invoking a callback when done
 -- @param CreateTrailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTrailAsync(CreateTrailRequest, cb)
 	assert(CreateTrailRequest, "You must provide a CreateTrailRequest")
 	local headers = {
@@ -2401,19 +2411,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTrailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTrailSync(CreateTrailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTrailAsync(CreateTrailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTrailAsync(CreateTrailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTrail asynchronously, invoking a callback when done
 -- @param UpdateTrailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTrailAsync(UpdateTrailRequest, cb)
 	assert(UpdateTrailRequest, "You must provide a UpdateTrailRequest")
 	local headers = {
@@ -2436,19 +2447,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTrailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTrailSync(UpdateTrailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTrailAsync(UpdateTrailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTrailAsync(UpdateTrailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -2471,19 +2483,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call LookupEvents asynchronously, invoking a callback when done
 -- @param LookupEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.LookupEventsAsync(LookupEventsRequest, cb)
 	assert(LookupEventsRequest, "You must provide a LookupEventsRequest")
 	local headers = {
@@ -2506,12 +2519,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param LookupEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.LookupEventsSync(LookupEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.LookupEventsAsync(LookupEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.LookupEventsAsync(LookupEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/codebuild.lua
+++ b/aws-sdk/codebuild.lua
@@ -3343,7 +3343,7 @@ end
 --
 --- Call ListBuilds asynchronously, invoking a callback when done
 -- @param ListBuildsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBuildsAsync(ListBuildsInput, cb)
 	assert(ListBuildsInput, "You must provide a ListBuildsInput")
 	local headers = {
@@ -3366,19 +3366,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBuildsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBuildsSync(ListBuildsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBuildsAsync(ListBuildsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBuildsAsync(ListBuildsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateWebhook asynchronously, invoking a callback when done
 -- @param UpdateWebhookInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateWebhookAsync(UpdateWebhookInput, cb)
 	assert(UpdateWebhookInput, "You must provide a UpdateWebhookInput")
 	local headers = {
@@ -3401,19 +3402,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateWebhookInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateWebhookSync(UpdateWebhookInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateWebhookAsync(UpdateWebhookInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateWebhookAsync(UpdateWebhookInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopBuild asynchronously, invoking a callback when done
 -- @param StopBuildInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopBuildAsync(StopBuildInput, cb)
 	assert(StopBuildInput, "You must provide a StopBuildInput")
 	local headers = {
@@ -3436,19 +3438,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopBuildInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopBuildSync(StopBuildInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopBuildAsync(StopBuildInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopBuildAsync(StopBuildInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBuildsForProject asynchronously, invoking a callback when done
 -- @param ListBuildsForProjectInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBuildsForProjectAsync(ListBuildsForProjectInput, cb)
 	assert(ListBuildsForProjectInput, "You must provide a ListBuildsForProjectInput")
 	local headers = {
@@ -3471,19 +3474,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBuildsForProjectInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBuildsForProjectSync(ListBuildsForProjectInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBuildsForProjectAsync(ListBuildsForProjectInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBuildsForProjectAsync(ListBuildsForProjectInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetBuilds asynchronously, invoking a callback when done
 -- @param BatchGetBuildsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetBuildsAsync(BatchGetBuildsInput, cb)
 	assert(BatchGetBuildsInput, "You must provide a BatchGetBuildsInput")
 	local headers = {
@@ -3506,19 +3510,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetBuildsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetBuildsSync(BatchGetBuildsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetBuildsAsync(BatchGetBuildsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetBuildsAsync(BatchGetBuildsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProjects asynchronously, invoking a callback when done
 -- @param ListProjectsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProjectsAsync(ListProjectsInput, cb)
 	assert(ListProjectsInput, "You must provide a ListProjectsInput")
 	local headers = {
@@ -3541,19 +3546,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProjectsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProjectsSync(ListProjectsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProjectsAsync(ListProjectsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProjectsAsync(ListProjectsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProject asynchronously, invoking a callback when done
 -- @param CreateProjectInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProjectAsync(CreateProjectInput, cb)
 	assert(CreateProjectInput, "You must provide a CreateProjectInput")
 	local headers = {
@@ -3576,19 +3582,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProjectInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProjectSync(CreateProjectInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProjectAsync(CreateProjectInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProjectAsync(CreateProjectInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCuratedEnvironmentImages asynchronously, invoking a callback when done
 -- @param ListCuratedEnvironmentImagesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCuratedEnvironmentImagesAsync(ListCuratedEnvironmentImagesInput, cb)
 	assert(ListCuratedEnvironmentImagesInput, "You must provide a ListCuratedEnvironmentImagesInput")
 	local headers = {
@@ -3611,19 +3618,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCuratedEnvironmentImagesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCuratedEnvironmentImagesSync(ListCuratedEnvironmentImagesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCuratedEnvironmentImagesAsync(ListCuratedEnvironmentImagesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCuratedEnvironmentImagesAsync(ListCuratedEnvironmentImagesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateWebhook asynchronously, invoking a callback when done
 -- @param CreateWebhookInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateWebhookAsync(CreateWebhookInput, cb)
 	assert(CreateWebhookInput, "You must provide a CreateWebhookInput")
 	local headers = {
@@ -3646,19 +3654,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateWebhookInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateWebhookSync(CreateWebhookInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateWebhookAsync(CreateWebhookInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateWebhookAsync(CreateWebhookInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InvalidateProjectCache asynchronously, invoking a callback when done
 -- @param InvalidateProjectCacheInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InvalidateProjectCacheAsync(InvalidateProjectCacheInput, cb)
 	assert(InvalidateProjectCacheInput, "You must provide a InvalidateProjectCacheInput")
 	local headers = {
@@ -3681,19 +3690,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InvalidateProjectCacheInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InvalidateProjectCacheSync(InvalidateProjectCacheInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InvalidateProjectCacheAsync(InvalidateProjectCacheInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InvalidateProjectCacheAsync(InvalidateProjectCacheInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartBuild asynchronously, invoking a callback when done
 -- @param StartBuildInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartBuildAsync(StartBuildInput, cb)
 	assert(StartBuildInput, "You must provide a StartBuildInput")
 	local headers = {
@@ -3716,19 +3726,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartBuildInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartBuildSync(StartBuildInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartBuildAsync(StartBuildInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartBuildAsync(StartBuildInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProject asynchronously, invoking a callback when done
 -- @param DeleteProjectInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProjectAsync(DeleteProjectInput, cb)
 	assert(DeleteProjectInput, "You must provide a DeleteProjectInput")
 	local headers = {
@@ -3751,19 +3762,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProjectInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProjectSync(DeleteProjectInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProjectAsync(DeleteProjectInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProjectAsync(DeleteProjectInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProject asynchronously, invoking a callback when done
 -- @param UpdateProjectInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProjectAsync(UpdateProjectInput, cb)
 	assert(UpdateProjectInput, "You must provide a UpdateProjectInput")
 	local headers = {
@@ -3786,19 +3798,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProjectInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProjectSync(UpdateProjectInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProjectAsync(UpdateProjectInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProjectAsync(UpdateProjectInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteWebhook asynchronously, invoking a callback when done
 -- @param DeleteWebhookInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteWebhookAsync(DeleteWebhookInput, cb)
 	assert(DeleteWebhookInput, "You must provide a DeleteWebhookInput")
 	local headers = {
@@ -3821,19 +3834,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteWebhookInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteWebhookSync(DeleteWebhookInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteWebhookAsync(DeleteWebhookInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteWebhookAsync(DeleteWebhookInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetProjects asynchronously, invoking a callback when done
 -- @param BatchGetProjectsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetProjectsAsync(BatchGetProjectsInput, cb)
 	assert(BatchGetProjectsInput, "You must provide a BatchGetProjectsInput")
 	local headers = {
@@ -3856,19 +3870,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetProjectsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetProjectsSync(BatchGetProjectsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetProjectsAsync(BatchGetProjectsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetProjectsAsync(BatchGetProjectsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDeleteBuilds asynchronously, invoking a callback when done
 -- @param BatchDeleteBuildsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDeleteBuildsAsync(BatchDeleteBuildsInput, cb)
 	assert(BatchDeleteBuildsInput, "You must provide a BatchDeleteBuildsInput")
 	local headers = {
@@ -3891,12 +3906,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDeleteBuildsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDeleteBuildsSync(BatchDeleteBuildsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDeleteBuildsAsync(BatchDeleteBuildsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDeleteBuildsAsync(BatchDeleteBuildsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/codecommit.lua
+++ b/aws-sdk/codecommit.lua
@@ -5520,7 +5520,7 @@ end
 --
 --- Call TestRepositoryTriggers asynchronously, invoking a callback when done
 -- @param TestRepositoryTriggersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestRepositoryTriggersAsync(TestRepositoryTriggersInput, cb)
 	assert(TestRepositoryTriggersInput, "You must provide a TestRepositoryTriggersInput")
 	local headers = {
@@ -5543,19 +5543,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestRepositoryTriggersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestRepositoryTriggersSync(TestRepositoryTriggersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestRepositoryTriggersAsync(TestRepositoryTriggersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestRepositoryTriggersAsync(TestRepositoryTriggersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRepository asynchronously, invoking a callback when done
 -- @param DeleteRepositoryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRepositoryAsync(DeleteRepositoryInput, cb)
 	assert(DeleteRepositoryInput, "You must provide a DeleteRepositoryInput")
 	local headers = {
@@ -5578,19 +5579,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRepositoryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRepositorySync(DeleteRepositoryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRepositoryAsync(DeleteRepositoryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRepositoryAsync(DeleteRepositoryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPullRequests asynchronously, invoking a callback when done
 -- @param ListPullRequestsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPullRequestsAsync(ListPullRequestsInput, cb)
 	assert(ListPullRequestsInput, "You must provide a ListPullRequestsInput")
 	local headers = {
@@ -5613,19 +5615,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPullRequestsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPullRequestsSync(ListPullRequestsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPullRequestsAsync(ListPullRequestsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPullRequestsAsync(ListPullRequestsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRepositoryDescription asynchronously, invoking a callback when done
 -- @param UpdateRepositoryDescriptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRepositoryDescriptionAsync(UpdateRepositoryDescriptionInput, cb)
 	assert(UpdateRepositoryDescriptionInput, "You must provide a UpdateRepositoryDescriptionInput")
 	local headers = {
@@ -5648,19 +5651,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRepositoryDescriptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRepositoryDescriptionSync(UpdateRepositoryDescriptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRepositoryDescriptionAsync(UpdateRepositoryDescriptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRepositoryDescriptionAsync(UpdateRepositoryDescriptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePullRequestDescription asynchronously, invoking a callback when done
 -- @param UpdatePullRequestDescriptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePullRequestDescriptionAsync(UpdatePullRequestDescriptionInput, cb)
 	assert(UpdatePullRequestDescriptionInput, "You must provide a UpdatePullRequestDescriptionInput")
 	local headers = {
@@ -5683,19 +5687,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePullRequestDescriptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePullRequestDescriptionSync(UpdatePullRequestDescriptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePullRequestDescriptionAsync(UpdatePullRequestDescriptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePullRequestDescriptionAsync(UpdatePullRequestDescriptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBranch asynchronously, invoking a callback when done
 -- @param DeleteBranchInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBranchAsync(DeleteBranchInput, cb)
 	assert(DeleteBranchInput, "You must provide a DeleteBranchInput")
 	local headers = {
@@ -5718,19 +5723,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBranchInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBranchSync(DeleteBranchInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBranchAsync(DeleteBranchInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBranchAsync(DeleteBranchInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMergeConflicts asynchronously, invoking a callback when done
 -- @param GetMergeConflictsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMergeConflictsAsync(GetMergeConflictsInput, cb)
 	assert(GetMergeConflictsInput, "You must provide a GetMergeConflictsInput")
 	local headers = {
@@ -5753,19 +5759,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMergeConflictsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMergeConflictsSync(GetMergeConflictsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMergeConflictsAsync(GetMergeConflictsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMergeConflictsAsync(GetMergeConflictsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFolder asynchronously, invoking a callback when done
 -- @param GetFolderInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFolderAsync(GetFolderInput, cb)
 	assert(GetFolderInput, "You must provide a GetFolderInput")
 	local headers = {
@@ -5788,19 +5795,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFolderInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFolderSync(GetFolderInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFolderAsync(GetFolderInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFolderAsync(GetFolderInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCommentContent asynchronously, invoking a callback when done
 -- @param DeleteCommentContentInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCommentContentAsync(DeleteCommentContentInput, cb)
 	assert(DeleteCommentContentInput, "You must provide a DeleteCommentContentInput")
 	local headers = {
@@ -5823,19 +5831,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCommentContentInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCommentContentSync(DeleteCommentContentInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCommentContentAsync(DeleteCommentContentInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCommentContentAsync(DeleteCommentContentInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFile asynchronously, invoking a callback when done
 -- @param GetFileInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFileAsync(GetFileInput, cb)
 	assert(GetFileInput, "You must provide a GetFileInput")
 	local headers = {
@@ -5858,19 +5867,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFileInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFileSync(GetFileInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFileAsync(GetFileInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFileAsync(GetFileInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDifferences asynchronously, invoking a callback when done
 -- @param GetDifferencesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDifferencesAsync(GetDifferencesInput, cb)
 	assert(GetDifferencesInput, "You must provide a GetDifferencesInput")
 	local headers = {
@@ -5893,19 +5903,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDifferencesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDifferencesSync(GetDifferencesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDifferencesAsync(GetDifferencesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDifferencesAsync(GetDifferencesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRepositoryName asynchronously, invoking a callback when done
 -- @param UpdateRepositoryNameInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRepositoryNameAsync(UpdateRepositoryNameInput, cb)
 	assert(UpdateRepositoryNameInput, "You must provide a UpdateRepositoryNameInput")
 	local headers = {
@@ -5928,19 +5939,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRepositoryNameInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRepositoryNameSync(UpdateRepositoryNameInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRepositoryNameAsync(UpdateRepositoryNameInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRepositoryNameAsync(UpdateRepositoryNameInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PostCommentForPullRequest asynchronously, invoking a callback when done
 -- @param PostCommentForPullRequestInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PostCommentForPullRequestAsync(PostCommentForPullRequestInput, cb)
 	assert(PostCommentForPullRequestInput, "You must provide a PostCommentForPullRequestInput")
 	local headers = {
@@ -5963,19 +5975,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PostCommentForPullRequestInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PostCommentForPullRequestSync(PostCommentForPullRequestInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PostCommentForPullRequestAsync(PostCommentForPullRequestInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PostCommentForPullRequestAsync(PostCommentForPullRequestInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBranch asynchronously, invoking a callback when done
 -- @param CreateBranchInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBranchAsync(CreateBranchInput, cb)
 	assert(CreateBranchInput, "You must provide a CreateBranchInput")
 	local headers = {
@@ -5998,19 +6011,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBranchInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBranchSync(CreateBranchInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBranchAsync(CreateBranchInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBranchAsync(CreateBranchInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRepository asynchronously, invoking a callback when done
 -- @param GetRepositoryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRepositoryAsync(GetRepositoryInput, cb)
 	assert(GetRepositoryInput, "You must provide a GetRepositoryInput")
 	local headers = {
@@ -6033,19 +6047,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRepositoryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRepositorySync(GetRepositoryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRepositoryAsync(GetRepositoryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRepositoryAsync(GetRepositoryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBlob asynchronously, invoking a callback when done
 -- @param GetBlobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBlobAsync(GetBlobInput, cb)
 	assert(GetBlobInput, "You must provide a GetBlobInput")
 	local headers = {
@@ -6068,19 +6083,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBlobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBlobSync(GetBlobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBlobAsync(GetBlobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBlobAsync(GetBlobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBranches asynchronously, invoking a callback when done
 -- @param ListBranchesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBranchesAsync(ListBranchesInput, cb)
 	assert(ListBranchesInput, "You must provide a ListBranchesInput")
 	local headers = {
@@ -6103,19 +6119,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBranchesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBranchesSync(ListBranchesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBranchesAsync(ListBranchesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBranchesAsync(ListBranchesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRepositoryTriggers asynchronously, invoking a callback when done
 -- @param GetRepositoryTriggersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRepositoryTriggersAsync(GetRepositoryTriggersInput, cb)
 	assert(GetRepositoryTriggersInput, "You must provide a GetRepositoryTriggersInput")
 	local headers = {
@@ -6138,19 +6155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRepositoryTriggersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRepositoryTriggersSync(GetRepositoryTriggersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRepositoryTriggersAsync(GetRepositoryTriggersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRepositoryTriggersAsync(GetRepositoryTriggersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateComment asynchronously, invoking a callback when done
 -- @param UpdateCommentInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCommentAsync(UpdateCommentInput, cb)
 	assert(UpdateCommentInput, "You must provide a UpdateCommentInput")
 	local headers = {
@@ -6173,19 +6191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCommentInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCommentSync(UpdateCommentInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCommentAsync(UpdateCommentInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCommentAsync(UpdateCommentInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFile asynchronously, invoking a callback when done
 -- @param DeleteFileInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFileAsync(DeleteFileInput, cb)
 	assert(DeleteFileInput, "You must provide a DeleteFileInput")
 	local headers = {
@@ -6208,19 +6227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFileInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFileSync(DeleteFileInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFileAsync(DeleteFileInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFileAsync(DeleteFileInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDefaultBranch asynchronously, invoking a callback when done
 -- @param UpdateDefaultBranchInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDefaultBranchAsync(UpdateDefaultBranchInput, cb)
 	assert(UpdateDefaultBranchInput, "You must provide a UpdateDefaultBranchInput")
 	local headers = {
@@ -6243,19 +6263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDefaultBranchInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDefaultBranchSync(UpdateDefaultBranchInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDefaultBranchAsync(UpdateDefaultBranchInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDefaultBranchAsync(UpdateDefaultBranchInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRepositoryTriggers asynchronously, invoking a callback when done
 -- @param PutRepositoryTriggersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRepositoryTriggersAsync(PutRepositoryTriggersInput, cb)
 	assert(PutRepositoryTriggersInput, "You must provide a PutRepositoryTriggersInput")
 	local headers = {
@@ -6278,19 +6299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRepositoryTriggersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRepositoryTriggersSync(PutRepositoryTriggersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRepositoryTriggersAsync(PutRepositoryTriggersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRepositoryTriggersAsync(PutRepositoryTriggersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCommentsForComparedCommit asynchronously, invoking a callback when done
 -- @param GetCommentsForComparedCommitInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCommentsForComparedCommitAsync(GetCommentsForComparedCommitInput, cb)
 	assert(GetCommentsForComparedCommitInput, "You must provide a GetCommentsForComparedCommitInput")
 	local headers = {
@@ -6313,19 +6335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCommentsForComparedCommitInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCommentsForComparedCommitSync(GetCommentsForComparedCommitInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCommentsForComparedCommitAsync(GetCommentsForComparedCommitInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCommentsForComparedCommitAsync(GetCommentsForComparedCommitInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBranch asynchronously, invoking a callback when done
 -- @param GetBranchInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBranchAsync(GetBranchInput, cb)
 	assert(GetBranchInput, "You must provide a GetBranchInput")
 	local headers = {
@@ -6348,19 +6371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBranchInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBranchSync(GetBranchInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBranchAsync(GetBranchInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBranchAsync(GetBranchInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRepository asynchronously, invoking a callback when done
 -- @param CreateRepositoryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRepositoryAsync(CreateRepositoryInput, cb)
 	assert(CreateRepositoryInput, "You must provide a CreateRepositoryInput")
 	local headers = {
@@ -6383,19 +6407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRepositoryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRepositorySync(CreateRepositoryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRepositoryAsync(CreateRepositoryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRepositoryAsync(CreateRepositoryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCommit asynchronously, invoking a callback when done
 -- @param GetCommitInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCommitAsync(GetCommitInput, cb)
 	assert(GetCommitInput, "You must provide a GetCommitInput")
 	local headers = {
@@ -6418,19 +6443,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCommitInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCommitSync(GetCommitInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCommitAsync(GetCommitInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCommitAsync(GetCommitInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PostCommentReply asynchronously, invoking a callback when done
 -- @param PostCommentReplyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PostCommentReplyAsync(PostCommentReplyInput, cb)
 	assert(PostCommentReplyInput, "You must provide a PostCommentReplyInput")
 	local headers = {
@@ -6453,19 +6479,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PostCommentReplyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PostCommentReplySync(PostCommentReplyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PostCommentReplyAsync(PostCommentReplyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PostCommentReplyAsync(PostCommentReplyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutFile asynchronously, invoking a callback when done
 -- @param PutFileInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutFileAsync(PutFileInput, cb)
 	assert(PutFileInput, "You must provide a PutFileInput")
 	local headers = {
@@ -6488,19 +6515,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutFileInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutFileSync(PutFileInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutFileAsync(PutFileInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutFileAsync(PutFileInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePullRequestEvents asynchronously, invoking a callback when done
 -- @param DescribePullRequestEventsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePullRequestEventsAsync(DescribePullRequestEventsInput, cb)
 	assert(DescribePullRequestEventsInput, "You must provide a DescribePullRequestEventsInput")
 	local headers = {
@@ -6523,19 +6551,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePullRequestEventsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePullRequestEventsSync(DescribePullRequestEventsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePullRequestEventsAsync(DescribePullRequestEventsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePullRequestEventsAsync(DescribePullRequestEventsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetRepositories asynchronously, invoking a callback when done
 -- @param BatchGetRepositoriesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetRepositoriesAsync(BatchGetRepositoriesInput, cb)
 	assert(BatchGetRepositoriesInput, "You must provide a BatchGetRepositoriesInput")
 	local headers = {
@@ -6558,19 +6587,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetRepositoriesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetRepositoriesSync(BatchGetRepositoriesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetRepositoriesAsync(BatchGetRepositoriesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetRepositoriesAsync(BatchGetRepositoriesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPullRequest asynchronously, invoking a callback when done
 -- @param GetPullRequestInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPullRequestAsync(GetPullRequestInput, cb)
 	assert(GetPullRequestInput, "You must provide a GetPullRequestInput")
 	local headers = {
@@ -6593,19 +6623,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPullRequestInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPullRequestSync(GetPullRequestInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPullRequestAsync(GetPullRequestInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPullRequestAsync(GetPullRequestInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePullRequest asynchronously, invoking a callback when done
 -- @param CreatePullRequestInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePullRequestAsync(CreatePullRequestInput, cb)
 	assert(CreatePullRequestInput, "You must provide a CreatePullRequestInput")
 	local headers = {
@@ -6628,19 +6659,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePullRequestInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePullRequestSync(CreatePullRequestInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePullRequestAsync(CreatePullRequestInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePullRequestAsync(CreatePullRequestInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCommentsForPullRequest asynchronously, invoking a callback when done
 -- @param GetCommentsForPullRequestInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCommentsForPullRequestAsync(GetCommentsForPullRequestInput, cb)
 	assert(GetCommentsForPullRequestInput, "You must provide a GetCommentsForPullRequestInput")
 	local headers = {
@@ -6663,19 +6695,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCommentsForPullRequestInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCommentsForPullRequestSync(GetCommentsForPullRequestInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCommentsForPullRequestAsync(GetCommentsForPullRequestInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCommentsForPullRequestAsync(GetCommentsForPullRequestInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePullRequestStatus asynchronously, invoking a callback when done
 -- @param UpdatePullRequestStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePullRequestStatusAsync(UpdatePullRequestStatusInput, cb)
 	assert(UpdatePullRequestStatusInput, "You must provide a UpdatePullRequestStatusInput")
 	local headers = {
@@ -6698,19 +6731,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePullRequestStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePullRequestStatusSync(UpdatePullRequestStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePullRequestStatusAsync(UpdatePullRequestStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePullRequestStatusAsync(UpdatePullRequestStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PostCommentForComparedCommit asynchronously, invoking a callback when done
 -- @param PostCommentForComparedCommitInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PostCommentForComparedCommitAsync(PostCommentForComparedCommitInput, cb)
 	assert(PostCommentForComparedCommitInput, "You must provide a PostCommentForComparedCommitInput")
 	local headers = {
@@ -6733,19 +6767,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PostCommentForComparedCommitInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PostCommentForComparedCommitSync(PostCommentForComparedCommitInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PostCommentForComparedCommitAsync(PostCommentForComparedCommitInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PostCommentForComparedCommitAsync(PostCommentForComparedCommitInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRepositories asynchronously, invoking a callback when done
 -- @param ListRepositoriesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRepositoriesAsync(ListRepositoriesInput, cb)
 	assert(ListRepositoriesInput, "You must provide a ListRepositoriesInput")
 	local headers = {
@@ -6768,19 +6803,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRepositoriesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRepositoriesSync(ListRepositoriesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRepositoriesAsync(ListRepositoriesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRepositoriesAsync(ListRepositoriesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetComment asynchronously, invoking a callback when done
 -- @param GetCommentInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCommentAsync(GetCommentInput, cb)
 	assert(GetCommentInput, "You must provide a GetCommentInput")
 	local headers = {
@@ -6803,19 +6839,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCommentInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCommentSync(GetCommentInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCommentAsync(GetCommentInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCommentAsync(GetCommentInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePullRequestTitle asynchronously, invoking a callback when done
 -- @param UpdatePullRequestTitleInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePullRequestTitleAsync(UpdatePullRequestTitleInput, cb)
 	assert(UpdatePullRequestTitleInput, "You must provide a UpdatePullRequestTitleInput")
 	local headers = {
@@ -6838,19 +6875,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePullRequestTitleInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePullRequestTitleSync(UpdatePullRequestTitleInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePullRequestTitleAsync(UpdatePullRequestTitleInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePullRequestTitleAsync(UpdatePullRequestTitleInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call MergePullRequestByFastForward asynchronously, invoking a callback when done
 -- @param MergePullRequestByFastForwardInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.MergePullRequestByFastForwardAsync(MergePullRequestByFastForwardInput, cb)
 	assert(MergePullRequestByFastForwardInput, "You must provide a MergePullRequestByFastForwardInput")
 	local headers = {
@@ -6873,12 +6911,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param MergePullRequestByFastForwardInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.MergePullRequestByFastForwardSync(MergePullRequestByFastForwardInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.MergePullRequestByFastForwardAsync(MergePullRequestByFastForwardInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.MergePullRequestByFastForwardAsync(MergePullRequestByFastForwardInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/codedeploy.lua
+++ b/aws-sdk/codedeploy.lua
@@ -9521,7 +9521,7 @@ end
 --
 --- Call DeleteGitHubAccountToken asynchronously, invoking a callback when done
 -- @param DeleteGitHubAccountTokenInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGitHubAccountTokenAsync(DeleteGitHubAccountTokenInput, cb)
 	assert(DeleteGitHubAccountTokenInput, "You must provide a DeleteGitHubAccountTokenInput")
 	local headers = {
@@ -9544,19 +9544,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGitHubAccountTokenInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGitHubAccountTokenSync(DeleteGitHubAccountTokenInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGitHubAccountTokenAsync(DeleteGitHubAccountTokenInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGitHubAccountTokenAsync(DeleteGitHubAccountTokenInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeploymentConfig asynchronously, invoking a callback when done
 -- @param GetDeploymentConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeploymentConfigAsync(GetDeploymentConfigInput, cb)
 	assert(GetDeploymentConfigInput, "You must provide a GetDeploymentConfigInput")
 	local headers = {
@@ -9579,19 +9580,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeploymentConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeploymentConfigSync(GetDeploymentConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeploymentConfigAsync(GetDeploymentConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeploymentConfigAsync(GetDeploymentConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDeploymentGroup asynchronously, invoking a callback when done
 -- @param UpdateDeploymentGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDeploymentGroupAsync(UpdateDeploymentGroupInput, cb)
 	assert(UpdateDeploymentGroupInput, "You must provide a UpdateDeploymentGroupInput")
 	local headers = {
@@ -9614,19 +9616,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDeploymentGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDeploymentGroupSync(UpdateDeploymentGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDeploymentGroupAsync(UpdateDeploymentGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDeploymentGroupAsync(UpdateDeploymentGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetDeployments asynchronously, invoking a callback when done
 -- @param BatchGetDeploymentsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetDeploymentsAsync(BatchGetDeploymentsInput, cb)
 	assert(BatchGetDeploymentsInput, "You must provide a BatchGetDeploymentsInput")
 	local headers = {
@@ -9649,19 +9652,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetDeploymentsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetDeploymentsSync(BatchGetDeploymentsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetDeploymentsAsync(BatchGetDeploymentsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetDeploymentsAsync(BatchGetDeploymentsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ContinueDeployment asynchronously, invoking a callback when done
 -- @param ContinueDeploymentInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ContinueDeploymentAsync(ContinueDeploymentInput, cb)
 	assert(ContinueDeploymentInput, "You must provide a ContinueDeploymentInput")
 	local headers = {
@@ -9684,19 +9688,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ContinueDeploymentInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ContinueDeploymentSync(ContinueDeploymentInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ContinueDeploymentAsync(ContinueDeploymentInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ContinueDeploymentAsync(ContinueDeploymentInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeploymentGroup asynchronously, invoking a callback when done
 -- @param GetDeploymentGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeploymentGroupAsync(GetDeploymentGroupInput, cb)
 	assert(GetDeploymentGroupInput, "You must provide a GetDeploymentGroupInput")
 	local headers = {
@@ -9719,19 +9724,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeploymentGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeploymentGroupSync(GetDeploymentGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeploymentGroupAsync(GetDeploymentGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeploymentGroupAsync(GetDeploymentGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeploymentGroups asynchronously, invoking a callback when done
 -- @param ListDeploymentGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeploymentGroupsAsync(ListDeploymentGroupsInput, cb)
 	assert(ListDeploymentGroupsInput, "You must provide a ListDeploymentGroupsInput")
 	local headers = {
@@ -9754,19 +9760,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeploymentGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeploymentGroupsSync(ListDeploymentGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeploymentGroupsAsync(ListDeploymentGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeploymentGroupsAsync(ListDeploymentGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplication asynchronously, invoking a callback when done
 -- @param DeleteApplicationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationAsync(DeleteApplicationInput, cb)
 	assert(DeleteApplicationInput, "You must provide a DeleteApplicationInput")
 	local headers = {
@@ -9789,19 +9796,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationSync(DeleteApplicationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationAsync(DeleteApplicationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationAsync(DeleteApplicationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeployment asynchronously, invoking a callback when done
 -- @param CreateDeploymentInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeploymentAsync(CreateDeploymentInput, cb)
 	assert(CreateDeploymentInput, "You must provide a CreateDeploymentInput")
 	local headers = {
@@ -9824,19 +9832,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeploymentInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeploymentSync(CreateDeploymentInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeploymentAsync(CreateDeploymentInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeploymentAsync(CreateDeploymentInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopDeployment asynchronously, invoking a callback when done
 -- @param StopDeploymentInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopDeploymentAsync(StopDeploymentInput, cb)
 	assert(StopDeploymentInput, "You must provide a StopDeploymentInput")
 	local headers = {
@@ -9859,19 +9868,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopDeploymentInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopDeploymentSync(StopDeploymentInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopDeploymentAsync(StopDeploymentInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopDeploymentAsync(StopDeploymentInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDeploymentConfig asynchronously, invoking a callback when done
 -- @param DeleteDeploymentConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDeploymentConfigAsync(DeleteDeploymentConfigInput, cb)
 	assert(DeleteDeploymentConfigInput, "You must provide a DeleteDeploymentConfigInput")
 	local headers = {
@@ -9894,19 +9904,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDeploymentConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDeploymentConfigSync(DeleteDeploymentConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDeploymentConfigAsync(DeleteDeploymentConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDeploymentConfigAsync(DeleteDeploymentConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromOnPremisesInstances asynchronously, invoking a callback when done
 -- @param RemoveTagsFromOnPremisesInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromOnPremisesInstancesAsync(RemoveTagsFromOnPremisesInstancesInput, cb)
 	assert(RemoveTagsFromOnPremisesInstancesInput, "You must provide a RemoveTagsFromOnPremisesInstancesInput")
 	local headers = {
@@ -9929,19 +9940,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromOnPremisesInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromOnPremisesInstancesSync(RemoveTagsFromOnPremisesInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromOnPremisesInstancesAsync(RemoveTagsFromOnPremisesInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromOnPremisesInstancesAsync(RemoveTagsFromOnPremisesInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterOnPremisesInstance asynchronously, invoking a callback when done
 -- @param RegisterOnPremisesInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterOnPremisesInstanceAsync(RegisterOnPremisesInstanceInput, cb)
 	assert(RegisterOnPremisesInstanceInput, "You must provide a RegisterOnPremisesInstanceInput")
 	local headers = {
@@ -9964,19 +9976,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterOnPremisesInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterOnPremisesInstanceSync(RegisterOnPremisesInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterOnPremisesInstanceAsync(RegisterOnPremisesInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterOnPremisesInstanceAsync(RegisterOnPremisesInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOnPremisesInstances asynchronously, invoking a callback when done
 -- @param ListOnPremisesInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOnPremisesInstancesAsync(ListOnPremisesInstancesInput, cb)
 	assert(ListOnPremisesInstancesInput, "You must provide a ListOnPremisesInstancesInput")
 	local headers = {
@@ -9999,19 +10012,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOnPremisesInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOnPremisesInstancesSync(ListOnPremisesInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOnPremisesInstancesAsync(ListOnPremisesInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOnPremisesInstancesAsync(ListOnPremisesInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeploymentConfigs asynchronously, invoking a callback when done
 -- @param ListDeploymentConfigsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeploymentConfigsAsync(ListDeploymentConfigsInput, cb)
 	assert(ListDeploymentConfigsInput, "You must provide a ListDeploymentConfigsInput")
 	local headers = {
@@ -10034,19 +10048,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeploymentConfigsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeploymentConfigsSync(ListDeploymentConfigsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeploymentConfigsAsync(ListDeploymentConfigsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeploymentConfigsAsync(ListDeploymentConfigsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApplication asynchronously, invoking a callback when done
 -- @param GetApplicationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApplicationAsync(GetApplicationInput, cb)
 	assert(GetApplicationInput, "You must provide a GetApplicationInput")
 	local headers = {
@@ -10069,19 +10084,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApplicationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApplicationSync(GetApplicationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApplicationAsync(GetApplicationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApplicationAsync(GetApplicationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeploymentInstance asynchronously, invoking a callback when done
 -- @param GetDeploymentInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeploymentInstanceAsync(GetDeploymentInstanceInput, cb)
 	assert(GetDeploymentInstanceInput, "You must provide a GetDeploymentInstanceInput")
 	local headers = {
@@ -10104,19 +10120,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeploymentInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeploymentInstanceSync(GetDeploymentInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeploymentInstanceAsync(GetDeploymentInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeploymentInstanceAsync(GetDeploymentInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SkipWaitTimeForInstanceTermination asynchronously, invoking a callback when done
 -- @param SkipWaitTimeForInstanceTerminationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SkipWaitTimeForInstanceTerminationAsync(SkipWaitTimeForInstanceTerminationInput, cb)
 	assert(SkipWaitTimeForInstanceTerminationInput, "You must provide a SkipWaitTimeForInstanceTerminationInput")
 	local headers = {
@@ -10139,19 +10156,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SkipWaitTimeForInstanceTerminationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SkipWaitTimeForInstanceTerminationSync(SkipWaitTimeForInstanceTerminationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SkipWaitTimeForInstanceTerminationAsync(SkipWaitTimeForInstanceTerminationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SkipWaitTimeForInstanceTerminationAsync(SkipWaitTimeForInstanceTerminationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetDeploymentGroups asynchronously, invoking a callback when done
 -- @param BatchGetDeploymentGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetDeploymentGroupsAsync(BatchGetDeploymentGroupsInput, cb)
 	assert(BatchGetDeploymentGroupsInput, "You must provide a BatchGetDeploymentGroupsInput")
 	local headers = {
@@ -10174,19 +10192,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetDeploymentGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetDeploymentGroupsSync(BatchGetDeploymentGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetDeploymentGroupsAsync(BatchGetDeploymentGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetDeploymentGroupsAsync(BatchGetDeploymentGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetOnPremisesInstances asynchronously, invoking a callback when done
 -- @param BatchGetOnPremisesInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetOnPremisesInstancesAsync(BatchGetOnPremisesInstancesInput, cb)
 	assert(BatchGetOnPremisesInstancesInput, "You must provide a BatchGetOnPremisesInstancesInput")
 	local headers = {
@@ -10209,19 +10228,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetOnPremisesInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetOnPremisesInstancesSync(BatchGetOnPremisesInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetOnPremisesInstancesAsync(BatchGetOnPremisesInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetOnPremisesInstancesAsync(BatchGetOnPremisesInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApplicationRevision asynchronously, invoking a callback when done
 -- @param GetApplicationRevisionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApplicationRevisionAsync(GetApplicationRevisionInput, cb)
 	assert(GetApplicationRevisionInput, "You must provide a GetApplicationRevisionInput")
 	local headers = {
@@ -10244,19 +10264,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApplicationRevisionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApplicationRevisionSync(GetApplicationRevisionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApplicationRevisionAsync(GetApplicationRevisionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApplicationRevisionAsync(GetApplicationRevisionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetDeploymentInstances asynchronously, invoking a callback when done
 -- @param BatchGetDeploymentInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetDeploymentInstancesAsync(BatchGetDeploymentInstancesInput, cb)
 	assert(BatchGetDeploymentInstancesInput, "You must provide a BatchGetDeploymentInstancesInput")
 	local headers = {
@@ -10279,19 +10300,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetDeploymentInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetDeploymentInstancesSync(BatchGetDeploymentInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetDeploymentInstancesAsync(BatchGetDeploymentInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetDeploymentInstancesAsync(BatchGetDeploymentInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApplication asynchronously, invoking a callback when done
 -- @param UpdateApplicationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationAsync(UpdateApplicationInput, cb)
 	assert(UpdateApplicationInput, "You must provide a UpdateApplicationInput")
 	local headers = {
@@ -10314,19 +10336,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationSync(UpdateApplicationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationAsync(UpdateApplicationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationAsync(UpdateApplicationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeploymentGroup asynchronously, invoking a callback when done
 -- @param CreateDeploymentGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeploymentGroupAsync(CreateDeploymentGroupInput, cb)
 	assert(CreateDeploymentGroupInput, "You must provide a CreateDeploymentGroupInput")
 	local headers = {
@@ -10349,19 +10372,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeploymentGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeploymentGroupSync(CreateDeploymentGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeploymentGroupAsync(CreateDeploymentGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeploymentGroupAsync(CreateDeploymentGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListApplicationRevisions asynchronously, invoking a callback when done
 -- @param ListApplicationRevisionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListApplicationRevisionsAsync(ListApplicationRevisionsInput, cb)
 	assert(ListApplicationRevisionsInput, "You must provide a ListApplicationRevisionsInput")
 	local headers = {
@@ -10384,19 +10408,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListApplicationRevisionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListApplicationRevisionsSync(ListApplicationRevisionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListApplicationRevisionsAsync(ListApplicationRevisionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListApplicationRevisionsAsync(ListApplicationRevisionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeploymentInstances asynchronously, invoking a callback when done
 -- @param ListDeploymentInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeploymentInstancesAsync(ListDeploymentInstancesInput, cb)
 	assert(ListDeploymentInstancesInput, "You must provide a ListDeploymentInstancesInput")
 	local headers = {
@@ -10419,19 +10444,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeploymentInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeploymentInstancesSync(ListDeploymentInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeploymentInstancesAsync(ListDeploymentInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeploymentInstancesAsync(ListDeploymentInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetApplicationRevisions asynchronously, invoking a callback when done
 -- @param BatchGetApplicationRevisionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetApplicationRevisionsAsync(BatchGetApplicationRevisionsInput, cb)
 	assert(BatchGetApplicationRevisionsInput, "You must provide a BatchGetApplicationRevisionsInput")
 	local headers = {
@@ -10454,19 +10480,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetApplicationRevisionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetApplicationRevisionsSync(BatchGetApplicationRevisionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetApplicationRevisionsAsync(BatchGetApplicationRevisionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetApplicationRevisionsAsync(BatchGetApplicationRevisionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutLifecycleEventHookExecutionStatus asynchronously, invoking a callback when done
 -- @param PutLifecycleEventHookExecutionStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutLifecycleEventHookExecutionStatusAsync(PutLifecycleEventHookExecutionStatusInput, cb)
 	assert(PutLifecycleEventHookExecutionStatusInput, "You must provide a PutLifecycleEventHookExecutionStatusInput")
 	local headers = {
@@ -10489,19 +10516,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutLifecycleEventHookExecutionStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutLifecycleEventHookExecutionStatusSync(PutLifecycleEventHookExecutionStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutLifecycleEventHookExecutionStatusAsync(PutLifecycleEventHookExecutionStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutLifecycleEventHookExecutionStatusAsync(PutLifecycleEventHookExecutionStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterOnPremisesInstance asynchronously, invoking a callback when done
 -- @param DeregisterOnPremisesInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterOnPremisesInstanceAsync(DeregisterOnPremisesInstanceInput, cb)
 	assert(DeregisterOnPremisesInstanceInput, "You must provide a DeregisterOnPremisesInstanceInput")
 	local headers = {
@@ -10524,19 +10552,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterOnPremisesInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterOnPremisesInstanceSync(DeregisterOnPremisesInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterOnPremisesInstanceAsync(DeregisterOnPremisesInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterOnPremisesInstanceAsync(DeregisterOnPremisesInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeploymentConfig asynchronously, invoking a callback when done
 -- @param CreateDeploymentConfigInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeploymentConfigAsync(CreateDeploymentConfigInput, cb)
 	assert(CreateDeploymentConfigInput, "You must provide a CreateDeploymentConfigInput")
 	local headers = {
@@ -10559,19 +10588,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeploymentConfigInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeploymentConfigSync(CreateDeploymentConfigInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeploymentConfigAsync(CreateDeploymentConfigInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeploymentConfigAsync(CreateDeploymentConfigInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOnPremisesInstance asynchronously, invoking a callback when done
 -- @param GetOnPremisesInstanceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOnPremisesInstanceAsync(GetOnPremisesInstanceInput, cb)
 	assert(GetOnPremisesInstanceInput, "You must provide a GetOnPremisesInstanceInput")
 	local headers = {
@@ -10594,19 +10624,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOnPremisesInstanceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOnPremisesInstanceSync(GetOnPremisesInstanceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOnPremisesInstanceAsync(GetOnPremisesInstanceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOnPremisesInstanceAsync(GetOnPremisesInstanceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToOnPremisesInstances asynchronously, invoking a callback when done
 -- @param AddTagsToOnPremisesInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToOnPremisesInstancesAsync(AddTagsToOnPremisesInstancesInput, cb)
 	assert(AddTagsToOnPremisesInstancesInput, "You must provide a AddTagsToOnPremisesInstancesInput")
 	local headers = {
@@ -10629,19 +10660,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToOnPremisesInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToOnPremisesInstancesSync(AddTagsToOnPremisesInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToOnPremisesInstancesAsync(AddTagsToOnPremisesInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToOnPremisesInstancesAsync(AddTagsToOnPremisesInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApplication asynchronously, invoking a callback when done
 -- @param CreateApplicationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApplicationAsync(CreateApplicationInput, cb)
 	assert(CreateApplicationInput, "You must provide a CreateApplicationInput")
 	local headers = {
@@ -10664,19 +10696,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApplicationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApplicationSync(CreateApplicationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApplicationAsync(CreateApplicationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApplicationAsync(CreateApplicationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeployments asynchronously, invoking a callback when done
 -- @param ListDeploymentsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeploymentsAsync(ListDeploymentsInput, cb)
 	assert(ListDeploymentsInput, "You must provide a ListDeploymentsInput")
 	local headers = {
@@ -10699,19 +10732,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeploymentsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeploymentsSync(ListDeploymentsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeploymentsAsync(ListDeploymentsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeploymentsAsync(ListDeploymentsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListApplications asynchronously, invoking a callback when done
 -- @param ListApplicationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListApplicationsAsync(ListApplicationsInput, cb)
 	assert(ListApplicationsInput, "You must provide a ListApplicationsInput")
 	local headers = {
@@ -10734,19 +10768,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListApplicationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListApplicationsSync(ListApplicationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListApplicationsAsync(ListApplicationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListApplicationsAsync(ListApplicationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDeploymentGroup asynchronously, invoking a callback when done
 -- @param DeleteDeploymentGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDeploymentGroupAsync(DeleteDeploymentGroupInput, cb)
 	assert(DeleteDeploymentGroupInput, "You must provide a DeleteDeploymentGroupInput")
 	local headers = {
@@ -10769,19 +10804,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDeploymentGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDeploymentGroupSync(DeleteDeploymentGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDeploymentGroupAsync(DeleteDeploymentGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDeploymentGroupAsync(DeleteDeploymentGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGitHubAccountTokenNames asynchronously, invoking a callback when done
 -- @param ListGitHubAccountTokenNamesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGitHubAccountTokenNamesAsync(ListGitHubAccountTokenNamesInput, cb)
 	assert(ListGitHubAccountTokenNamesInput, "You must provide a ListGitHubAccountTokenNamesInput")
 	local headers = {
@@ -10804,19 +10840,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGitHubAccountTokenNamesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGitHubAccountTokenNamesSync(ListGitHubAccountTokenNamesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGitHubAccountTokenNamesAsync(ListGitHubAccountTokenNamesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGitHubAccountTokenNamesAsync(ListGitHubAccountTokenNamesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterApplicationRevision asynchronously, invoking a callback when done
 -- @param RegisterApplicationRevisionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterApplicationRevisionAsync(RegisterApplicationRevisionInput, cb)
 	assert(RegisterApplicationRevisionInput, "You must provide a RegisterApplicationRevisionInput")
 	local headers = {
@@ -10839,19 +10876,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterApplicationRevisionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterApplicationRevisionSync(RegisterApplicationRevisionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterApplicationRevisionAsync(RegisterApplicationRevisionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterApplicationRevisionAsync(RegisterApplicationRevisionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeployment asynchronously, invoking a callback when done
 -- @param GetDeploymentInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeploymentAsync(GetDeploymentInput, cb)
 	assert(GetDeploymentInput, "You must provide a GetDeploymentInput")
 	local headers = {
@@ -10874,19 +10912,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeploymentInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeploymentSync(GetDeploymentInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeploymentAsync(GetDeploymentInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeploymentAsync(GetDeploymentInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetApplications asynchronously, invoking a callback when done
 -- @param BatchGetApplicationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetApplicationsAsync(BatchGetApplicationsInput, cb)
 	assert(BatchGetApplicationsInput, "You must provide a BatchGetApplicationsInput")
 	local headers = {
@@ -10909,12 +10948,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetApplicationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetApplicationsSync(BatchGetApplicationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetApplicationsAsync(BatchGetApplicationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetApplicationsAsync(BatchGetApplicationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/codepipeline.lua
+++ b/aws-sdk/codepipeline.lua
@@ -6836,7 +6836,7 @@ end
 --
 --- Call EnableStageTransition asynchronously, invoking a callback when done
 -- @param EnableStageTransitionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableStageTransitionAsync(EnableStageTransitionInput, cb)
 	assert(EnableStageTransitionInput, "You must provide a EnableStageTransitionInput")
 	local headers = {
@@ -6859,19 +6859,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableStageTransitionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableStageTransitionSync(EnableStageTransitionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableStageTransitionAsync(EnableStageTransitionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableStageTransitionAsync(EnableStageTransitionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RetryStageExecution asynchronously, invoking a callback when done
 -- @param RetryStageExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RetryStageExecutionAsync(RetryStageExecutionInput, cb)
 	assert(RetryStageExecutionInput, "You must provide a RetryStageExecutionInput")
 	local headers = {
@@ -6894,19 +6895,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RetryStageExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RetryStageExecutionSync(RetryStageExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RetryStageExecutionAsync(RetryStageExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RetryStageExecutionAsync(RetryStageExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableStageTransition asynchronously, invoking a callback when done
 -- @param DisableStageTransitionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableStageTransitionAsync(DisableStageTransitionInput, cb)
 	assert(DisableStageTransitionInput, "You must provide a DisableStageTransitionInput")
 	local headers = {
@@ -6929,19 +6931,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableStageTransitionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableStageTransitionSync(DisableStageTransitionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableStageTransitionAsync(DisableStageTransitionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableStageTransitionAsync(DisableStageTransitionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListWebhooks asynchronously, invoking a callback when done
 -- @param ListWebhooksInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListWebhooksAsync(ListWebhooksInput, cb)
 	assert(ListWebhooksInput, "You must provide a ListWebhooksInput")
 	local headers = {
@@ -6964,19 +6967,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListWebhooksInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListWebhooksSync(ListWebhooksInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListWebhooksAsync(ListWebhooksInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListWebhooksAsync(ListWebhooksInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PollForThirdPartyJobs asynchronously, invoking a callback when done
 -- @param PollForThirdPartyJobsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PollForThirdPartyJobsAsync(PollForThirdPartyJobsInput, cb)
 	assert(PollForThirdPartyJobsInput, "You must provide a PollForThirdPartyJobsInput")
 	local headers = {
@@ -6999,19 +7003,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PollForThirdPartyJobsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PollForThirdPartyJobsSync(PollForThirdPartyJobsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PollForThirdPartyJobsAsync(PollForThirdPartyJobsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PollForThirdPartyJobsAsync(PollForThirdPartyJobsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetThirdPartyJobDetails asynchronously, invoking a callback when done
 -- @param GetThirdPartyJobDetailsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetThirdPartyJobDetailsAsync(GetThirdPartyJobDetailsInput, cb)
 	assert(GetThirdPartyJobDetailsInput, "You must provide a GetThirdPartyJobDetailsInput")
 	local headers = {
@@ -7034,19 +7039,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetThirdPartyJobDetailsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetThirdPartyJobDetailsSync(GetThirdPartyJobDetailsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetThirdPartyJobDetailsAsync(GetThirdPartyJobDetailsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetThirdPartyJobDetailsAsync(GetThirdPartyJobDetailsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePipeline asynchronously, invoking a callback when done
 -- @param DeletePipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePipelineAsync(DeletePipelineInput, cb)
 	assert(DeletePipelineInput, "You must provide a DeletePipelineInput")
 	local headers = {
@@ -7069,19 +7075,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePipelineSync(DeletePipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePipelineAsync(DeletePipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePipelineAsync(DeletePipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePipeline asynchronously, invoking a callback when done
 -- @param UpdatePipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePipelineAsync(UpdatePipelineInput, cb)
 	assert(UpdatePipelineInput, "You must provide a UpdatePipelineInput")
 	local headers = {
@@ -7104,19 +7111,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePipelineSync(UpdatePipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePipelineAsync(UpdatePipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePipelineAsync(UpdatePipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutJobFailureResult asynchronously, invoking a callback when done
 -- @param PutJobFailureResultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutJobFailureResultAsync(PutJobFailureResultInput, cb)
 	assert(PutJobFailureResultInput, "You must provide a PutJobFailureResultInput")
 	local headers = {
@@ -7139,19 +7147,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutJobFailureResultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutJobFailureResultSync(PutJobFailureResultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutJobFailureResultAsync(PutJobFailureResultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutJobFailureResultAsync(PutJobFailureResultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListActionTypes asynchronously, invoking a callback when done
 -- @param ListActionTypesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListActionTypesAsync(ListActionTypesInput, cb)
 	assert(ListActionTypesInput, "You must provide a ListActionTypesInput")
 	local headers = {
@@ -7174,19 +7183,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListActionTypesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListActionTypesSync(ListActionTypesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListActionTypesAsync(ListActionTypesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListActionTypesAsync(ListActionTypesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcknowledgeThirdPartyJob asynchronously, invoking a callback when done
 -- @param AcknowledgeThirdPartyJobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcknowledgeThirdPartyJobAsync(AcknowledgeThirdPartyJobInput, cb)
 	assert(AcknowledgeThirdPartyJobInput, "You must provide a AcknowledgeThirdPartyJobInput")
 	local headers = {
@@ -7209,19 +7219,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcknowledgeThirdPartyJobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcknowledgeThirdPartyJobSync(AcknowledgeThirdPartyJobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcknowledgeThirdPartyJobAsync(AcknowledgeThirdPartyJobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcknowledgeThirdPartyJobAsync(AcknowledgeThirdPartyJobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutWebhook asynchronously, invoking a callback when done
 -- @param PutWebhookInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutWebhookAsync(PutWebhookInput, cb)
 	assert(PutWebhookInput, "You must provide a PutWebhookInput")
 	local headers = {
@@ -7244,19 +7255,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutWebhookInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutWebhookSync(PutWebhookInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutWebhookAsync(PutWebhookInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutWebhookAsync(PutWebhookInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteWebhook asynchronously, invoking a callback when done
 -- @param DeleteWebhookInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteWebhookAsync(DeleteWebhookInput, cb)
 	assert(DeleteWebhookInput, "You must provide a DeleteWebhookInput")
 	local headers = {
@@ -7279,19 +7291,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteWebhookInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteWebhookSync(DeleteWebhookInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteWebhookAsync(DeleteWebhookInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteWebhookAsync(DeleteWebhookInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterWebhookWithThirdParty asynchronously, invoking a callback when done
 -- @param DeregisterWebhookWithThirdPartyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterWebhookWithThirdPartyAsync(DeregisterWebhookWithThirdPartyInput, cb)
 	assert(DeregisterWebhookWithThirdPartyInput, "You must provide a DeregisterWebhookWithThirdPartyInput")
 	local headers = {
@@ -7314,19 +7327,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterWebhookWithThirdPartyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterWebhookWithThirdPartySync(DeregisterWebhookWithThirdPartyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterWebhookWithThirdPartyAsync(DeregisterWebhookWithThirdPartyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterWebhookWithThirdPartyAsync(DeregisterWebhookWithThirdPartyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPipelineExecution asynchronously, invoking a callback when done
 -- @param GetPipelineExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPipelineExecutionAsync(GetPipelineExecutionInput, cb)
 	assert(GetPipelineExecutionInput, "You must provide a GetPipelineExecutionInput")
 	local headers = {
@@ -7349,19 +7363,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPipelineExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPipelineExecutionSync(GetPipelineExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPipelineExecutionAsync(GetPipelineExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPipelineExecutionAsync(GetPipelineExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutThirdPartyJobSuccessResult asynchronously, invoking a callback when done
 -- @param PutThirdPartyJobSuccessResultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutThirdPartyJobSuccessResultAsync(PutThirdPartyJobSuccessResultInput, cb)
 	assert(PutThirdPartyJobSuccessResultInput, "You must provide a PutThirdPartyJobSuccessResultInput")
 	local headers = {
@@ -7384,19 +7399,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutThirdPartyJobSuccessResultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutThirdPartyJobSuccessResultSync(PutThirdPartyJobSuccessResultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutThirdPartyJobSuccessResultAsync(PutThirdPartyJobSuccessResultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutThirdPartyJobSuccessResultAsync(PutThirdPartyJobSuccessResultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcknowledgeJob asynchronously, invoking a callback when done
 -- @param AcknowledgeJobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcknowledgeJobAsync(AcknowledgeJobInput, cb)
 	assert(AcknowledgeJobInput, "You must provide a AcknowledgeJobInput")
 	local headers = {
@@ -7419,19 +7435,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcknowledgeJobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcknowledgeJobSync(AcknowledgeJobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcknowledgeJobAsync(AcknowledgeJobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcknowledgeJobAsync(AcknowledgeJobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutActionRevision asynchronously, invoking a callback when done
 -- @param PutActionRevisionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutActionRevisionAsync(PutActionRevisionInput, cb)
 	assert(PutActionRevisionInput, "You must provide a PutActionRevisionInput")
 	local headers = {
@@ -7454,19 +7471,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutActionRevisionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutActionRevisionSync(PutActionRevisionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutActionRevisionAsync(PutActionRevisionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutActionRevisionAsync(PutActionRevisionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPipelines asynchronously, invoking a callback when done
 -- @param ListPipelinesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPipelinesAsync(ListPipelinesInput, cb)
 	assert(ListPipelinesInput, "You must provide a ListPipelinesInput")
 	local headers = {
@@ -7489,19 +7507,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPipelinesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPipelinesSync(ListPipelinesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPipelinesAsync(ListPipelinesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPipelinesAsync(ListPipelinesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartPipelineExecution asynchronously, invoking a callback when done
 -- @param StartPipelineExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartPipelineExecutionAsync(StartPipelineExecutionInput, cb)
 	assert(StartPipelineExecutionInput, "You must provide a StartPipelineExecutionInput")
 	local headers = {
@@ -7524,19 +7543,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartPipelineExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartPipelineExecutionSync(StartPipelineExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartPipelineExecutionAsync(StartPipelineExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartPipelineExecutionAsync(StartPipelineExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutApprovalResult asynchronously, invoking a callback when done
 -- @param PutApprovalResultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutApprovalResultAsync(PutApprovalResultInput, cb)
 	assert(PutApprovalResultInput, "You must provide a PutApprovalResultInput")
 	local headers = {
@@ -7559,19 +7579,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutApprovalResultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutApprovalResultSync(PutApprovalResultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutApprovalResultAsync(PutApprovalResultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutApprovalResultAsync(PutApprovalResultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutThirdPartyJobFailureResult asynchronously, invoking a callback when done
 -- @param PutThirdPartyJobFailureResultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutThirdPartyJobFailureResultAsync(PutThirdPartyJobFailureResultInput, cb)
 	assert(PutThirdPartyJobFailureResultInput, "You must provide a PutThirdPartyJobFailureResultInput")
 	local headers = {
@@ -7594,19 +7615,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutThirdPartyJobFailureResultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutThirdPartyJobFailureResultSync(PutThirdPartyJobFailureResultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutThirdPartyJobFailureResultAsync(PutThirdPartyJobFailureResultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutThirdPartyJobFailureResultAsync(PutThirdPartyJobFailureResultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PollForJobs asynchronously, invoking a callback when done
 -- @param PollForJobsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PollForJobsAsync(PollForJobsInput, cb)
 	assert(PollForJobsInput, "You must provide a PollForJobsInput")
 	local headers = {
@@ -7629,19 +7651,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PollForJobsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PollForJobsSync(PollForJobsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PollForJobsAsync(PollForJobsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PollForJobsAsync(PollForJobsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPipelineState asynchronously, invoking a callback when done
 -- @param GetPipelineStateInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPipelineStateAsync(GetPipelineStateInput, cb)
 	assert(GetPipelineStateInput, "You must provide a GetPipelineStateInput")
 	local headers = {
@@ -7664,19 +7687,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPipelineStateInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPipelineStateSync(GetPipelineStateInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPipelineStateAsync(GetPipelineStateInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPipelineStateAsync(GetPipelineStateInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCustomActionType asynchronously, invoking a callback when done
 -- @param CreateCustomActionTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCustomActionTypeAsync(CreateCustomActionTypeInput, cb)
 	assert(CreateCustomActionTypeInput, "You must provide a CreateCustomActionTypeInput")
 	local headers = {
@@ -7699,19 +7723,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCustomActionTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCustomActionTypeSync(CreateCustomActionTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCustomActionTypeAsync(CreateCustomActionTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCustomActionTypeAsync(CreateCustomActionTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePipeline asynchronously, invoking a callback when done
 -- @param CreatePipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePipelineAsync(CreatePipelineInput, cb)
 	assert(CreatePipelineInput, "You must provide a CreatePipelineInput")
 	local headers = {
@@ -7734,19 +7759,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePipelineSync(CreatePipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePipelineAsync(CreatePipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePipelineAsync(CreatePipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterWebhookWithThirdParty asynchronously, invoking a callback when done
 -- @param RegisterWebhookWithThirdPartyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterWebhookWithThirdPartyAsync(RegisterWebhookWithThirdPartyInput, cb)
 	assert(RegisterWebhookWithThirdPartyInput, "You must provide a RegisterWebhookWithThirdPartyInput")
 	local headers = {
@@ -7769,19 +7795,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterWebhookWithThirdPartyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterWebhookWithThirdPartySync(RegisterWebhookWithThirdPartyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterWebhookWithThirdPartyAsync(RegisterWebhookWithThirdPartyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterWebhookWithThirdPartyAsync(RegisterWebhookWithThirdPartyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobDetails asynchronously, invoking a callback when done
 -- @param GetJobDetailsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobDetailsAsync(GetJobDetailsInput, cb)
 	assert(GetJobDetailsInput, "You must provide a GetJobDetailsInput")
 	local headers = {
@@ -7804,19 +7831,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobDetailsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobDetailsSync(GetJobDetailsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobDetailsAsync(GetJobDetailsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobDetailsAsync(GetJobDetailsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPipeline asynchronously, invoking a callback when done
 -- @param GetPipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPipelineAsync(GetPipelineInput, cb)
 	assert(GetPipelineInput, "You must provide a GetPipelineInput")
 	local headers = {
@@ -7839,19 +7867,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPipelineSync(GetPipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPipelineAsync(GetPipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPipelineAsync(GetPipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCustomActionType asynchronously, invoking a callback when done
 -- @param DeleteCustomActionTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCustomActionTypeAsync(DeleteCustomActionTypeInput, cb)
 	assert(DeleteCustomActionTypeInput, "You must provide a DeleteCustomActionTypeInput")
 	local headers = {
@@ -7874,19 +7903,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCustomActionTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCustomActionTypeSync(DeleteCustomActionTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCustomActionTypeAsync(DeleteCustomActionTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCustomActionTypeAsync(DeleteCustomActionTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPipelineExecutions asynchronously, invoking a callback when done
 -- @param ListPipelineExecutionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPipelineExecutionsAsync(ListPipelineExecutionsInput, cb)
 	assert(ListPipelineExecutionsInput, "You must provide a ListPipelineExecutionsInput")
 	local headers = {
@@ -7909,19 +7939,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPipelineExecutionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPipelineExecutionsSync(ListPipelineExecutionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPipelineExecutionsAsync(ListPipelineExecutionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPipelineExecutionsAsync(ListPipelineExecutionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutJobSuccessResult asynchronously, invoking a callback when done
 -- @param PutJobSuccessResultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutJobSuccessResultAsync(PutJobSuccessResultInput, cb)
 	assert(PutJobSuccessResultInput, "You must provide a PutJobSuccessResultInput")
 	local headers = {
@@ -7944,12 +7975,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutJobSuccessResultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutJobSuccessResultSync(PutJobSuccessResultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutJobSuccessResultAsync(PutJobSuccessResultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutJobSuccessResultAsync(PutJobSuccessResultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/codestar.lua
+++ b/aws-sdk/codestar.lua
@@ -2768,7 +2768,7 @@ end
 --
 --- Call AssociateTeamMember asynchronously, invoking a callback when done
 -- @param AssociateTeamMemberRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateTeamMemberAsync(AssociateTeamMemberRequest, cb)
 	assert(AssociateTeamMemberRequest, "You must provide a AssociateTeamMemberRequest")
 	local headers = {
@@ -2791,19 +2791,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateTeamMemberRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateTeamMemberSync(AssociateTeamMemberRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateTeamMemberAsync(AssociateTeamMemberRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateTeamMemberAsync(AssociateTeamMemberRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateTeamMember asynchronously, invoking a callback when done
 -- @param DisassociateTeamMemberRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateTeamMemberAsync(DisassociateTeamMemberRequest, cb)
 	assert(DisassociateTeamMemberRequest, "You must provide a DisassociateTeamMemberRequest")
 	local headers = {
@@ -2826,19 +2827,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateTeamMemberRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateTeamMemberSync(DisassociateTeamMemberRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateTeamMemberAsync(DisassociateTeamMemberRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateTeamMemberAsync(DisassociateTeamMemberRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagProject asynchronously, invoking a callback when done
 -- @param UntagProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagProjectAsync(UntagProjectRequest, cb)
 	assert(UntagProjectRequest, "You must provide a UntagProjectRequest")
 	local headers = {
@@ -2861,19 +2863,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagProjectSync(UntagProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagProjectAsync(UntagProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagProjectAsync(UntagProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTeamMember asynchronously, invoking a callback when done
 -- @param UpdateTeamMemberRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTeamMemberAsync(UpdateTeamMemberRequest, cb)
 	assert(UpdateTeamMemberRequest, "You must provide a UpdateTeamMemberRequest")
 	local headers = {
@@ -2896,19 +2899,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTeamMemberRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTeamMemberSync(UpdateTeamMemberRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTeamMemberAsync(UpdateTeamMemberRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTeamMemberAsync(UpdateTeamMemberRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForProject asynchronously, invoking a callback when done
 -- @param ListTagsForProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForProjectAsync(ListTagsForProjectRequest, cb)
 	assert(ListTagsForProjectRequest, "You must provide a ListTagsForProjectRequest")
 	local headers = {
@@ -2931,19 +2935,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForProjectSync(ListTagsForProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForProjectAsync(ListTagsForProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForProjectAsync(ListTagsForProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUserProfile asynchronously, invoking a callback when done
 -- @param CreateUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserProfileAsync(CreateUserProfileRequest, cb)
 	assert(CreateUserProfileRequest, "You must provide a CreateUserProfileRequest")
 	local headers = {
@@ -2966,19 +2971,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserProfileSync(CreateUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserProfileAsync(CreateUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserProfileAsync(CreateUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserProfile asynchronously, invoking a callback when done
 -- @param UpdateUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserProfileAsync(UpdateUserProfileRequest, cb)
 	assert(UpdateUserProfileRequest, "You must provide a UpdateUserProfileRequest")
 	local headers = {
@@ -3001,19 +3007,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserProfileSync(UpdateUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserProfileAsync(UpdateUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserProfileAsync(UpdateUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUserProfiles asynchronously, invoking a callback when done
 -- @param ListUserProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUserProfilesAsync(ListUserProfilesRequest, cb)
 	assert(ListUserProfilesRequest, "You must provide a ListUserProfilesRequest")
 	local headers = {
@@ -3036,19 +3043,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUserProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUserProfilesSync(ListUserProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUserProfilesAsync(ListUserProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUserProfilesAsync(ListUserProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResources asynchronously, invoking a callback when done
 -- @param ListResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourcesAsync(ListResourcesRequest, cb)
 	assert(ListResourcesRequest, "You must provide a ListResourcesRequest")
 	local headers = {
@@ -3071,19 +3079,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourcesSync(ListResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourcesAsync(ListResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourcesAsync(ListResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProject asynchronously, invoking a callback when done
 -- @param CreateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProjectAsync(CreateProjectRequest, cb)
 	assert(CreateProjectRequest, "You must provide a CreateProjectRequest")
 	local headers = {
@@ -3106,19 +3115,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProjectSync(CreateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProjectAsync(CreateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProjectAsync(CreateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagProject asynchronously, invoking a callback when done
 -- @param TagProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagProjectAsync(TagProjectRequest, cb)
 	assert(TagProjectRequest, "You must provide a TagProjectRequest")
 	local headers = {
@@ -3141,19 +3151,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagProjectSync(TagProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagProjectAsync(TagProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagProjectAsync(TagProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProjects asynchronously, invoking a callback when done
 -- @param ListProjectsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProjectsAsync(ListProjectsRequest, cb)
 	assert(ListProjectsRequest, "You must provide a ListProjectsRequest")
 	local headers = {
@@ -3176,19 +3187,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProjectsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProjectsSync(ListProjectsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProjectsAsync(ListProjectsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProjectsAsync(ListProjectsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTeamMembers asynchronously, invoking a callback when done
 -- @param ListTeamMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTeamMembersAsync(ListTeamMembersRequest, cb)
 	assert(ListTeamMembersRequest, "You must provide a ListTeamMembersRequest")
 	local headers = {
@@ -3211,19 +3223,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTeamMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTeamMembersSync(ListTeamMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTeamMembersAsync(ListTeamMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTeamMembersAsync(ListTeamMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProject asynchronously, invoking a callback when done
 -- @param DeleteProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProjectAsync(DeleteProjectRequest, cb)
 	assert(DeleteProjectRequest, "You must provide a DeleteProjectRequest")
 	local headers = {
@@ -3246,19 +3259,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProjectSync(DeleteProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProject asynchronously, invoking a callback when done
 -- @param DescribeProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProjectAsync(DescribeProjectRequest, cb)
 	assert(DescribeProjectRequest, "You must provide a DescribeProjectRequest")
 	local headers = {
@@ -3281,19 +3295,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProjectSync(DescribeProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProjectAsync(DescribeProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProjectAsync(DescribeProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProject asynchronously, invoking a callback when done
 -- @param UpdateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProjectAsync(UpdateProjectRequest, cb)
 	assert(UpdateProjectRequest, "You must provide a UpdateProjectRequest")
 	local headers = {
@@ -3316,19 +3331,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProjectSync(UpdateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserProfile asynchronously, invoking a callback when done
 -- @param DescribeUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserProfileAsync(DescribeUserProfileRequest, cb)
 	assert(DescribeUserProfileRequest, "You must provide a DescribeUserProfileRequest")
 	local headers = {
@@ -3351,19 +3367,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserProfileSync(DescribeUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserProfileAsync(DescribeUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserProfileAsync(DescribeUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserProfile asynchronously, invoking a callback when done
 -- @param DeleteUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserProfileAsync(DeleteUserProfileRequest, cb)
 	assert(DeleteUserProfileRequest, "You must provide a DeleteUserProfileRequest")
 	local headers = {
@@ -3386,12 +3403,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserProfileSync(DeleteUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserProfileAsync(DeleteUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserProfileAsync(DeleteUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cognito-identity.lua
+++ b/aws-sdk/cognito-identity.lua
@@ -2652,7 +2652,7 @@ end
 --
 --- Call MergeDeveloperIdentities asynchronously, invoking a callback when done
 -- @param MergeDeveloperIdentitiesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.MergeDeveloperIdentitiesAsync(MergeDeveloperIdentitiesInput, cb)
 	assert(MergeDeveloperIdentitiesInput, "You must provide a MergeDeveloperIdentitiesInput")
 	local headers = {
@@ -2675,19 +2675,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param MergeDeveloperIdentitiesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.MergeDeveloperIdentitiesSync(MergeDeveloperIdentitiesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.MergeDeveloperIdentitiesAsync(MergeDeveloperIdentitiesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.MergeDeveloperIdentitiesAsync(MergeDeveloperIdentitiesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityPoolRoles asynchronously, invoking a callback when done
 -- @param GetIdentityPoolRolesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityPoolRolesAsync(GetIdentityPoolRolesInput, cb)
 	assert(GetIdentityPoolRolesInput, "You must provide a GetIdentityPoolRolesInput")
 	local headers = {
@@ -2710,19 +2711,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityPoolRolesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityPoolRolesSync(GetIdentityPoolRolesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityPoolRolesAsync(GetIdentityPoolRolesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityPoolRolesAsync(GetIdentityPoolRolesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIdentities asynchronously, invoking a callback when done
 -- @param DeleteIdentitiesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIdentitiesAsync(DeleteIdentitiesInput, cb)
 	assert(DeleteIdentitiesInput, "You must provide a DeleteIdentitiesInput")
 	local headers = {
@@ -2745,19 +2747,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIdentitiesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIdentitiesSync(DeleteIdentitiesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIdentitiesAsync(DeleteIdentitiesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIdentitiesAsync(DeleteIdentitiesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOpenIdTokenForDeveloperIdentity asynchronously, invoking a callback when done
 -- @param GetOpenIdTokenForDeveloperIdentityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOpenIdTokenForDeveloperIdentityAsync(GetOpenIdTokenForDeveloperIdentityInput, cb)
 	assert(GetOpenIdTokenForDeveloperIdentityInput, "You must provide a GetOpenIdTokenForDeveloperIdentityInput")
 	local headers = {
@@ -2780,19 +2783,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOpenIdTokenForDeveloperIdentityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOpenIdTokenForDeveloperIdentitySync(GetOpenIdTokenForDeveloperIdentityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOpenIdTokenForDeveloperIdentityAsync(GetOpenIdTokenForDeveloperIdentityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOpenIdTokenForDeveloperIdentityAsync(GetOpenIdTokenForDeveloperIdentityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call LookupDeveloperIdentity asynchronously, invoking a callback when done
 -- @param LookupDeveloperIdentityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.LookupDeveloperIdentityAsync(LookupDeveloperIdentityInput, cb)
 	assert(LookupDeveloperIdentityInput, "You must provide a LookupDeveloperIdentityInput")
 	local headers = {
@@ -2815,19 +2819,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param LookupDeveloperIdentityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.LookupDeveloperIdentitySync(LookupDeveloperIdentityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.LookupDeveloperIdentityAsync(LookupDeveloperIdentityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.LookupDeveloperIdentityAsync(LookupDeveloperIdentityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIdentityPools asynchronously, invoking a callback when done
 -- @param ListIdentityPoolsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIdentityPoolsAsync(ListIdentityPoolsInput, cb)
 	assert(ListIdentityPoolsInput, "You must provide a ListIdentityPoolsInput")
 	local headers = {
@@ -2850,19 +2855,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIdentityPoolsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIdentityPoolsSync(ListIdentityPoolsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIdentityPoolsAsync(ListIdentityPoolsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIdentityPoolsAsync(ListIdentityPoolsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIdentity asynchronously, invoking a callback when done
 -- @param DescribeIdentityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIdentityAsync(DescribeIdentityInput, cb)
 	assert(DescribeIdentityInput, "You must provide a DescribeIdentityInput")
 	local headers = {
@@ -2885,19 +2891,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIdentityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIdentitySync(DescribeIdentityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIdentityAsync(DescribeIdentityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIdentityAsync(DescribeIdentityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetId asynchronously, invoking a callback when done
 -- @param GetIdInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdAsync(GetIdInput, cb)
 	assert(GetIdInput, "You must provide a GetIdInput")
 	local headers = {
@@ -2920,19 +2927,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdSync(GetIdInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdAsync(GetIdInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdAsync(GetIdInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnlinkIdentity asynchronously, invoking a callback when done
 -- @param UnlinkIdentityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnlinkIdentityAsync(UnlinkIdentityInput, cb)
 	assert(UnlinkIdentityInput, "You must provide a UnlinkIdentityInput")
 	local headers = {
@@ -2955,19 +2963,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnlinkIdentityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnlinkIdentitySync(UnlinkIdentityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnlinkIdentityAsync(UnlinkIdentityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnlinkIdentityAsync(UnlinkIdentityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIdentities asynchronously, invoking a callback when done
 -- @param ListIdentitiesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIdentitiesAsync(ListIdentitiesInput, cb)
 	assert(ListIdentitiesInput, "You must provide a ListIdentitiesInput")
 	local headers = {
@@ -2990,19 +2999,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIdentitiesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIdentitiesSync(ListIdentitiesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIdentitiesAsync(ListIdentitiesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIdentitiesAsync(ListIdentitiesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIdentityPool asynchronously, invoking a callback when done
 -- @param DeleteIdentityPoolInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIdentityPoolAsync(DeleteIdentityPoolInput, cb)
 	assert(DeleteIdentityPoolInput, "You must provide a DeleteIdentityPoolInput")
 	local headers = {
@@ -3025,19 +3035,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIdentityPoolInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIdentityPoolSync(DeleteIdentityPoolInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIdentityPoolAsync(DeleteIdentityPoolInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIdentityPoolAsync(DeleteIdentityPoolInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCredentialsForIdentity asynchronously, invoking a callback when done
 -- @param GetCredentialsForIdentityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCredentialsForIdentityAsync(GetCredentialsForIdentityInput, cb)
 	assert(GetCredentialsForIdentityInput, "You must provide a GetCredentialsForIdentityInput")
 	local headers = {
@@ -3060,19 +3071,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCredentialsForIdentityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCredentialsForIdentitySync(GetCredentialsForIdentityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCredentialsForIdentityAsync(GetCredentialsForIdentityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCredentialsForIdentityAsync(GetCredentialsForIdentityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIdentityPool asynchronously, invoking a callback when done
 -- @param IdentityPool
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIdentityPoolAsync(IdentityPool, cb)
 	assert(IdentityPool, "You must provide a IdentityPool")
 	local headers = {
@@ -3095,19 +3107,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IdentityPool
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIdentityPoolSync(IdentityPool, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIdentityPoolAsync(IdentityPool, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIdentityPoolAsync(IdentityPool, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIdentityPoolRoles asynchronously, invoking a callback when done
 -- @param SetIdentityPoolRolesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIdentityPoolRolesAsync(SetIdentityPoolRolesInput, cb)
 	assert(SetIdentityPoolRolesInput, "You must provide a SetIdentityPoolRolesInput")
 	local headers = {
@@ -3130,19 +3143,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIdentityPoolRolesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIdentityPoolRolesSync(SetIdentityPoolRolesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIdentityPoolRolesAsync(SetIdentityPoolRolesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIdentityPoolRolesAsync(SetIdentityPoolRolesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnlinkDeveloperIdentity asynchronously, invoking a callback when done
 -- @param UnlinkDeveloperIdentityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnlinkDeveloperIdentityAsync(UnlinkDeveloperIdentityInput, cb)
 	assert(UnlinkDeveloperIdentityInput, "You must provide a UnlinkDeveloperIdentityInput")
 	local headers = {
@@ -3165,19 +3179,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnlinkDeveloperIdentityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnlinkDeveloperIdentitySync(UnlinkDeveloperIdentityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnlinkDeveloperIdentityAsync(UnlinkDeveloperIdentityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnlinkDeveloperIdentityAsync(UnlinkDeveloperIdentityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIdentityPool asynchronously, invoking a callback when done
 -- @param DescribeIdentityPoolInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIdentityPoolAsync(DescribeIdentityPoolInput, cb)
 	assert(DescribeIdentityPoolInput, "You must provide a DescribeIdentityPoolInput")
 	local headers = {
@@ -3200,19 +3215,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIdentityPoolInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIdentityPoolSync(DescribeIdentityPoolInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIdentityPoolAsync(DescribeIdentityPoolInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIdentityPoolAsync(DescribeIdentityPoolInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOpenIdToken asynchronously, invoking a callback when done
 -- @param GetOpenIdTokenInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOpenIdTokenAsync(GetOpenIdTokenInput, cb)
 	assert(GetOpenIdTokenInput, "You must provide a GetOpenIdTokenInput")
 	local headers = {
@@ -3235,19 +3251,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOpenIdTokenInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOpenIdTokenSync(GetOpenIdTokenInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOpenIdTokenAsync(GetOpenIdTokenInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOpenIdTokenAsync(GetOpenIdTokenInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIdentityPool asynchronously, invoking a callback when done
 -- @param CreateIdentityPoolInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIdentityPoolAsync(CreateIdentityPoolInput, cb)
 	assert(CreateIdentityPoolInput, "You must provide a CreateIdentityPoolInput")
 	local headers = {
@@ -3270,12 +3287,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIdentityPoolInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIdentityPoolSync(CreateIdentityPoolInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIdentityPoolAsync(CreateIdentityPoolInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIdentityPoolAsync(CreateIdentityPoolInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cognito-idp.lua
+++ b/aws-sdk/cognito-idp.lua
@@ -12621,7 +12621,7 @@ end
 --
 --- Call VerifyUserAttribute asynchronously, invoking a callback when done
 -- @param VerifyUserAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.VerifyUserAttributeAsync(VerifyUserAttributeRequest, cb)
 	assert(VerifyUserAttributeRequest, "You must provide a VerifyUserAttributeRequest")
 	local headers = {
@@ -12644,19 +12644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param VerifyUserAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.VerifyUserAttributeSync(VerifyUserAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.VerifyUserAttributeAsync(VerifyUserAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.VerifyUserAttributeAsync(VerifyUserAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminListDevices asynchronously, invoking a callback when done
 -- @param AdminListDevicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminListDevicesAsync(AdminListDevicesRequest, cb)
 	assert(AdminListDevicesRequest, "You must provide a AdminListDevicesRequest")
 	local headers = {
@@ -12679,19 +12680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminListDevicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminListDevicesSync(AdminListDevicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminListDevicesAsync(AdminListDevicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminListDevicesAsync(AdminListDevicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SignUp asynchronously, invoking a callback when done
 -- @param SignUpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SignUpAsync(SignUpRequest, cb)
 	assert(SignUpRequest, "You must provide a SignUpRequest")
 	local headers = {
@@ -12714,19 +12716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SignUpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SignUpSync(SignUpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SignUpAsync(SignUpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SignUpAsync(SignUpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIdentityProviders asynchronously, invoking a callback when done
 -- @param ListIdentityProvidersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIdentityProvidersAsync(ListIdentityProvidersRequest, cb)
 	assert(ListIdentityProvidersRequest, "You must provide a ListIdentityProvidersRequest")
 	local headers = {
@@ -12749,19 +12752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIdentityProvidersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIdentityProvidersSync(ListIdentityProvidersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIdentityProvidersAsync(ListIdentityProvidersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIdentityProvidersAsync(ListIdentityProvidersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeResourceServer asynchronously, invoking a callback when done
 -- @param DescribeResourceServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeResourceServerAsync(DescribeResourceServerRequest, cb)
 	assert(DescribeResourceServerRequest, "You must provide a DescribeResourceServerRequest")
 	local headers = {
@@ -12784,19 +12788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeResourceServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeResourceServerSync(DescribeResourceServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeResourceServerAsync(DescribeResourceServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeResourceServerAsync(DescribeResourceServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUserPoolClients asynchronously, invoking a callback when done
 -- @param ListUserPoolClientsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUserPoolClientsAsync(ListUserPoolClientsRequest, cb)
 	assert(ListUserPoolClientsRequest, "You must provide a ListUserPoolClientsRequest")
 	local headers = {
@@ -12819,19 +12824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUserPoolClientsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUserPoolClientsSync(ListUserPoolClientsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUserPoolClientsAsync(ListUserPoolClientsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUserPoolClientsAsync(ListUserPoolClientsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserPool asynchronously, invoking a callback when done
 -- @param DescribeUserPoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserPoolAsync(DescribeUserPoolRequest, cb)
 	assert(DescribeUserPoolRequest, "You must provide a DescribeUserPoolRequest")
 	local headers = {
@@ -12854,19 +12860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserPoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserPoolSync(DescribeUserPoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserPoolAsync(DescribeUserPoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserPoolAsync(DescribeUserPoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminUserGlobalSignOut asynchronously, invoking a callback when done
 -- @param AdminUserGlobalSignOutRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminUserGlobalSignOutAsync(AdminUserGlobalSignOutRequest, cb)
 	assert(AdminUserGlobalSignOutRequest, "You must provide a AdminUserGlobalSignOutRequest")
 	local headers = {
@@ -12889,19 +12896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminUserGlobalSignOutRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminUserGlobalSignOutSync(AdminUserGlobalSignOutRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminUserGlobalSignOutAsync(AdminUserGlobalSignOutRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminUserGlobalSignOutAsync(AdminUserGlobalSignOutRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserPoolDomain asynchronously, invoking a callback when done
 -- @param DeleteUserPoolDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserPoolDomainAsync(DeleteUserPoolDomainRequest, cb)
 	assert(DeleteUserPoolDomainRequest, "You must provide a DeleteUserPoolDomainRequest")
 	local headers = {
@@ -12924,19 +12932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserPoolDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserPoolDomainSync(DeleteUserPoolDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserPoolDomainAsync(DeleteUserPoolDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserPoolDomainAsync(DeleteUserPoolDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUser asynchronously, invoking a callback when done
 -- @param GetUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserAsync(GetUserRequest, cb)
 	assert(GetUserRequest, "You must provide a GetUserRequest")
 	local headers = {
@@ -12959,19 +12968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserSync(GetUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserAsync(GetUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserAsync(GetUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUICustomization asynchronously, invoking a callback when done
 -- @param GetUICustomizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUICustomizationAsync(GetUICustomizationRequest, cb)
 	assert(GetUICustomizationRequest, "You must provide a GetUICustomizationRequest")
 	local headers = {
@@ -12994,19 +13004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUICustomizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUICustomizationSync(GetUICustomizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUICustomizationAsync(GetUICustomizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUICustomizationAsync(GetUICustomizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIdentityProvider asynchronously, invoking a callback when done
 -- @param DescribeIdentityProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIdentityProviderAsync(DescribeIdentityProviderRequest, cb)
 	assert(DescribeIdentityProviderRequest, "You must provide a DescribeIdentityProviderRequest")
 	local headers = {
@@ -13029,19 +13040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIdentityProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIdentityProviderSync(DescribeIdentityProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIdentityProviderAsync(DescribeIdentityProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIdentityProviderAsync(DescribeIdentityProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIdentityProvider asynchronously, invoking a callback when done
 -- @param UpdateIdentityProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIdentityProviderAsync(UpdateIdentityProviderRequest, cb)
 	assert(UpdateIdentityProviderRequest, "You must provide a UpdateIdentityProviderRequest")
 	local headers = {
@@ -13064,19 +13076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateIdentityProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIdentityProviderSync(UpdateIdentityProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIdentityProviderAsync(UpdateIdentityProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIdentityProviderAsync(UpdateIdentityProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ChangePassword asynchronously, invoking a callback when done
 -- @param ChangePasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ChangePasswordAsync(ChangePasswordRequest, cb)
 	assert(ChangePasswordRequest, "You must provide a ChangePasswordRequest")
 	local headers = {
@@ -13099,19 +13112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ChangePasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ChangePasswordSync(ChangePasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ChangePasswordAsync(ChangePasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ChangePasswordAsync(ChangePasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminForgetDevice asynchronously, invoking a callback when done
 -- @param AdminForgetDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminForgetDeviceAsync(AdminForgetDeviceRequest, cb)
 	assert(AdminForgetDeviceRequest, "You must provide a AdminForgetDeviceRequest")
 	local headers = {
@@ -13134,19 +13148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminForgetDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminForgetDeviceSync(AdminForgetDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminForgetDeviceAsync(AdminForgetDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminForgetDeviceAsync(AdminForgetDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRiskConfiguration asynchronously, invoking a callback when done
 -- @param DescribeRiskConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRiskConfigurationAsync(DescribeRiskConfigurationRequest, cb)
 	assert(DescribeRiskConfigurationRequest, "You must provide a DescribeRiskConfigurationRequest")
 	local headers = {
@@ -13169,19 +13184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRiskConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRiskConfigurationSync(DescribeRiskConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRiskConfigurationAsync(DescribeRiskConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRiskConfigurationAsync(DescribeRiskConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetUICustomization asynchronously, invoking a callback when done
 -- @param SetUICustomizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetUICustomizationAsync(SetUICustomizationRequest, cb)
 	assert(SetUICustomizationRequest, "You must provide a SetUICustomizationRequest")
 	local headers = {
@@ -13204,19 +13220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetUICustomizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetUICustomizationSync(SetUICustomizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetUICustomizationAsync(SetUICustomizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetUICustomizationAsync(SetUICustomizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -13239,19 +13256,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminDeleteUser asynchronously, invoking a callback when done
 -- @param AdminDeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminDeleteUserAsync(AdminDeleteUserRequest, cb)
 	assert(AdminDeleteUserRequest, "You must provide a AdminDeleteUserRequest")
 	local headers = {
@@ -13274,19 +13292,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminDeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminDeleteUserSync(AdminDeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminDeleteUserAsync(AdminDeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminDeleteUserAsync(AdminDeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminInitiateAuth asynchronously, invoking a callback when done
 -- @param AdminInitiateAuthRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminInitiateAuthAsync(AdminInitiateAuthRequest, cb)
 	assert(AdminInitiateAuthRequest, "You must provide a AdminInitiateAuthRequest")
 	local headers = {
@@ -13309,19 +13328,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminInitiateAuthRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminInitiateAuthSync(AdminInitiateAuthRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminInitiateAuthAsync(AdminInitiateAuthRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminInitiateAuthAsync(AdminInitiateAuthRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminUpdateAuthEventFeedback asynchronously, invoking a callback when done
 -- @param AdminUpdateAuthEventFeedbackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminUpdateAuthEventFeedbackAsync(AdminUpdateAuthEventFeedbackRequest, cb)
 	assert(AdminUpdateAuthEventFeedbackRequest, "You must provide a AdminUpdateAuthEventFeedbackRequest")
 	local headers = {
@@ -13344,19 +13364,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminUpdateAuthEventFeedbackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminUpdateAuthEventFeedbackSync(AdminUpdateAuthEventFeedbackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminUpdateAuthEventFeedbackAsync(AdminUpdateAuthEventFeedbackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminUpdateAuthEventFeedbackAsync(AdminUpdateAuthEventFeedbackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetRiskConfiguration asynchronously, invoking a callback when done
 -- @param SetRiskConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetRiskConfigurationAsync(SetRiskConfigurationRequest, cb)
 	assert(SetRiskConfigurationRequest, "You must provide a SetRiskConfigurationRequest")
 	local headers = {
@@ -13379,19 +13400,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetRiskConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetRiskConfigurationSync(SetRiskConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetRiskConfigurationAsync(SetRiskConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetRiskConfigurationAsync(SetRiskConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminSetUserSettings asynchronously, invoking a callback when done
 -- @param AdminSetUserSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminSetUserSettingsAsync(AdminSetUserSettingsRequest, cb)
 	assert(AdminSetUserSettingsRequest, "You must provide a AdminSetUserSettingsRequest")
 	local headers = {
@@ -13414,19 +13436,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminSetUserSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminSetUserSettingsSync(AdminSetUserSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminSetUserSettingsAsync(AdminSetUserSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminSetUserSettingsAsync(AdminSetUserSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminSetUserMFAPreference asynchronously, invoking a callback when done
 -- @param AdminSetUserMFAPreferenceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminSetUserMFAPreferenceAsync(AdminSetUserMFAPreferenceRequest, cb)
 	assert(AdminSetUserMFAPreferenceRequest, "You must provide a AdminSetUserMFAPreferenceRequest")
 	local headers = {
@@ -13449,19 +13472,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminSetUserMFAPreferenceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminSetUserMFAPreferenceSync(AdminSetUserMFAPreferenceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminSetUserMFAPreferenceAsync(AdminSetUserMFAPreferenceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminSetUserMFAPreferenceAsync(AdminSetUserMFAPreferenceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitiateAuth asynchronously, invoking a callback when done
 -- @param InitiateAuthRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitiateAuthAsync(InitiateAuthRequest, cb)
 	assert(InitiateAuthRequest, "You must provide a InitiateAuthRequest")
 	local headers = {
@@ -13484,19 +13508,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitiateAuthRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitiateAuthSync(InitiateAuthRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitiateAuthAsync(InitiateAuthRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitiateAuthAsync(InitiateAuthRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceServers asynchronously, invoking a callback when done
 -- @param ListResourceServersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceServersAsync(ListResourceServersRequest, cb)
 	assert(ListResourceServersRequest, "You must provide a ListResourceServersRequest")
 	local headers = {
@@ -13519,19 +13544,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceServersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceServersSync(ListResourceServersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceServersAsync(ListResourceServersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceServersAsync(ListResourceServersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDeviceStatus asynchronously, invoking a callback when done
 -- @param UpdateDeviceStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDeviceStatusAsync(UpdateDeviceStatusRequest, cb)
 	assert(UpdateDeviceStatusRequest, "You must provide a UpdateDeviceStatusRequest")
 	local headers = {
@@ -13554,19 +13580,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDeviceStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDeviceStatusSync(UpdateDeviceStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDeviceStatusAsync(UpdateDeviceStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDeviceStatusAsync(UpdateDeviceStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminDisableUser asynchronously, invoking a callback when done
 -- @param AdminDisableUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminDisableUserAsync(AdminDisableUserRequest, cb)
 	assert(AdminDisableUserRequest, "You must provide a AdminDisableUserRequest")
 	local headers = {
@@ -13589,19 +13616,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminDisableUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminDisableUserSync(AdminDisableUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminDisableUserAsync(AdminDisableUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminDisableUserAsync(AdminDisableUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminUpdateUserAttributes asynchronously, invoking a callback when done
 -- @param AdminUpdateUserAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminUpdateUserAttributesAsync(AdminUpdateUserAttributesRequest, cb)
 	assert(AdminUpdateUserAttributesRequest, "You must provide a AdminUpdateUserAttributesRequest")
 	local headers = {
@@ -13624,19 +13652,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminUpdateUserAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminUpdateUserAttributesSync(AdminUpdateUserAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminUpdateUserAttributesAsync(AdminUpdateUserAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminUpdateUserAttributesAsync(AdminUpdateUserAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ForgetDevice asynchronously, invoking a callback when done
 -- @param ForgetDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ForgetDeviceAsync(ForgetDeviceRequest, cb)
 	assert(ForgetDeviceRequest, "You must provide a ForgetDeviceRequest")
 	local headers = {
@@ -13659,19 +13688,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ForgetDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ForgetDeviceSync(ForgetDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ForgetDeviceAsync(ForgetDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ForgetDeviceAsync(ForgetDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmForgotPassword asynchronously, invoking a callback when done
 -- @param ConfirmForgotPasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmForgotPasswordAsync(ConfirmForgotPasswordRequest, cb)
 	assert(ConfirmForgotPasswordRequest, "You must provide a ConfirmForgotPasswordRequest")
 	local headers = {
@@ -13694,19 +13724,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmForgotPasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmForgotPasswordSync(ConfirmForgotPasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmForgotPasswordAsync(ConfirmForgotPasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmForgotPasswordAsync(ConfirmForgotPasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminDisableProviderForUser asynchronously, invoking a callback when done
 -- @param AdminDisableProviderForUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminDisableProviderForUserAsync(AdminDisableProviderForUserRequest, cb)
 	assert(AdminDisableProviderForUserRequest, "You must provide a AdminDisableProviderForUserRequest")
 	local headers = {
@@ -13729,19 +13760,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminDisableProviderForUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminDisableProviderForUserSync(AdminDisableProviderForUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminDisableProviderForUserAsync(AdminDisableProviderForUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminDisableProviderForUserAsync(AdminDisableProviderForUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUserPools asynchronously, invoking a callback when done
 -- @param ListUserPoolsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUserPoolsAsync(ListUserPoolsRequest, cb)
 	assert(ListUserPoolsRequest, "You must provide a ListUserPoolsRequest")
 	local headers = {
@@ -13764,19 +13796,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUserPoolsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUserPoolsSync(ListUserPoolsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUserPoolsAsync(ListUserPoolsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUserPoolsAsync(ListUserPoolsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminGetDevice asynchronously, invoking a callback when done
 -- @param AdminGetDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminGetDeviceAsync(AdminGetDeviceRequest, cb)
 	assert(AdminGetDeviceRequest, "You must provide a AdminGetDeviceRequest")
 	local headers = {
@@ -13799,19 +13832,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminGetDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminGetDeviceSync(AdminGetDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminGetDeviceAsync(AdminGetDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminGetDeviceAsync(AdminGetDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGroup asynchronously, invoking a callback when done
 -- @param UpdateGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGroupAsync(UpdateGroupRequest, cb)
 	assert(UpdateGroupRequest, "You must provide a UpdateGroupRequest")
 	local headers = {
@@ -13834,19 +13868,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGroupSync(UpdateGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGroupAsync(UpdateGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGroupAsync(UpdateGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroup asynchronously, invoking a callback when done
 -- @param GetGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupAsync(GetGroupRequest, cb)
 	assert(GetGroupRequest, "You must provide a GetGroupRequest")
 	local headers = {
@@ -13869,19 +13904,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupSync(GetGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupAsync(GetGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupAsync(GetGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminAddUserToGroup asynchronously, invoking a callback when done
 -- @param AdminAddUserToGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminAddUserToGroupAsync(AdminAddUserToGroupRequest, cb)
 	assert(AdminAddUserToGroupRequest, "You must provide a AdminAddUserToGroupRequest")
 	local headers = {
@@ -13904,19 +13940,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminAddUserToGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminAddUserToGroupSync(AdminAddUserToGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminAddUserToGroupAsync(AdminAddUserToGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminAddUserToGroupAsync(AdminAddUserToGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateSoftwareToken asynchronously, invoking a callback when done
 -- @param AssociateSoftwareTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateSoftwareTokenAsync(AssociateSoftwareTokenRequest, cb)
 	assert(AssociateSoftwareTokenRequest, "You must provide a AssociateSoftwareTokenRequest")
 	local headers = {
@@ -13939,19 +13976,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateSoftwareTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateSoftwareTokenSync(AssociateSoftwareTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateSoftwareTokenAsync(AssociateSoftwareTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateSoftwareTokenAsync(AssociateSoftwareTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminListGroupsForUser asynchronously, invoking a callback when done
 -- @param AdminListGroupsForUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminListGroupsForUserAsync(AdminListGroupsForUserRequest, cb)
 	assert(AdminListGroupsForUserRequest, "You must provide a AdminListGroupsForUserRequest")
 	local headers = {
@@ -13974,19 +14012,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminListGroupsForUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminListGroupsForUserSync(AdminListGroupsForUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminListGroupsForUserAsync(AdminListGroupsForUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminListGroupsForUserAsync(AdminListGroupsForUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserPoolClient asynchronously, invoking a callback when done
 -- @param DescribeUserPoolClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserPoolClientAsync(DescribeUserPoolClientRequest, cb)
 	assert(DescribeUserPoolClientRequest, "You must provide a DescribeUserPoolClientRequest")
 	local headers = {
@@ -14009,19 +14048,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserPoolClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserPoolClientSync(DescribeUserPoolClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserPoolClientAsync(DescribeUserPoolClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserPoolClientAsync(DescribeUserPoolClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDevices asynchronously, invoking a callback when done
 -- @param ListDevicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDevicesAsync(ListDevicesRequest, cb)
 	assert(ListDevicesRequest, "You must provide a ListDevicesRequest")
 	local headers = {
@@ -14044,19 +14084,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDevicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDevicesSync(ListDevicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDevicesAsync(ListDevicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDevicesAsync(ListDevicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RespondToAuthChallenge asynchronously, invoking a callback when done
 -- @param RespondToAuthChallengeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RespondToAuthChallengeAsync(RespondToAuthChallengeRequest, cb)
 	assert(RespondToAuthChallengeRequest, "You must provide a RespondToAuthChallengeRequest")
 	local headers = {
@@ -14079,19 +14120,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RespondToAuthChallengeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RespondToAuthChallengeSync(RespondToAuthChallengeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RespondToAuthChallengeAsync(RespondToAuthChallengeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RespondToAuthChallengeAsync(RespondToAuthChallengeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUserPoolClient asynchronously, invoking a callback when done
 -- @param CreateUserPoolClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserPoolClientAsync(CreateUserPoolClientRequest, cb)
 	assert(CreateUserPoolClientRequest, "You must provide a CreateUserPoolClientRequest")
 	local headers = {
@@ -14114,19 +14156,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserPoolClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserPoolClientSync(CreateUserPoolClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserPoolClientAsync(CreateUserPoolClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserPoolClientAsync(CreateUserPoolClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserAttributes asynchronously, invoking a callback when done
 -- @param DeleteUserAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAttributesAsync(DeleteUserAttributesRequest, cb)
 	assert(DeleteUserAttributesRequest, "You must provide a DeleteUserAttributesRequest")
 	local headers = {
@@ -14149,19 +14192,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserAttributesSync(DeleteUserAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAttributesAsync(DeleteUserAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAttributesAsync(DeleteUserAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GlobalSignOut asynchronously, invoking a callback when done
 -- @param GlobalSignOutRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GlobalSignOutAsync(GlobalSignOutRequest, cb)
 	assert(GlobalSignOutRequest, "You must provide a GlobalSignOutRequest")
 	local headers = {
@@ -14184,19 +14228,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GlobalSignOutRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GlobalSignOutSync(GlobalSignOutRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GlobalSignOutAsync(GlobalSignOutRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GlobalSignOutAsync(GlobalSignOutRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmSignUp asynchronously, invoking a callback when done
 -- @param ConfirmSignUpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmSignUpAsync(ConfirmSignUpRequest, cb)
 	assert(ConfirmSignUpRequest, "You must provide a ConfirmSignUpRequest")
 	local headers = {
@@ -14219,19 +14264,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmSignUpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmSignUpSync(ConfirmSignUpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmSignUpAsync(ConfirmSignUpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmSignUpAsync(ConfirmSignUpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ForgotPassword asynchronously, invoking a callback when done
 -- @param ForgotPasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ForgotPasswordAsync(ForgotPasswordRequest, cb)
 	assert(ForgotPasswordRequest, "You must provide a ForgotPasswordRequest")
 	local headers = {
@@ -14254,19 +14300,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ForgotPasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ForgotPasswordSync(ForgotPasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ForgotPasswordAsync(ForgotPasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ForgotPasswordAsync(ForgotPasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminCreateUser asynchronously, invoking a callback when done
 -- @param AdminCreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminCreateUserAsync(AdminCreateUserRequest, cb)
 	assert(AdminCreateUserRequest, "You must provide a AdminCreateUserRequest")
 	local headers = {
@@ -14289,19 +14336,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminCreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminCreateUserSync(AdminCreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminCreateUserAsync(AdminCreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminCreateUserAsync(AdminCreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIdentityProvider asynchronously, invoking a callback when done
 -- @param DeleteIdentityProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIdentityProviderAsync(DeleteIdentityProviderRequest, cb)
 	assert(DeleteIdentityProviderRequest, "You must provide a DeleteIdentityProviderRequest")
 	local headers = {
@@ -14324,19 +14372,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIdentityProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIdentityProviderSync(DeleteIdentityProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIdentityProviderAsync(DeleteIdentityProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIdentityProviderAsync(DeleteIdentityProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGroup asynchronously, invoking a callback when done
 -- @param CreateGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGroupAsync(CreateGroupRequest, cb)
 	assert(CreateGroupRequest, "You must provide a CreateGroupRequest")
 	local headers = {
@@ -14359,19 +14408,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGroupSync(CreateGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGroupAsync(CreateGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGroupAsync(CreateGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserPool asynchronously, invoking a callback when done
 -- @param DeleteUserPoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserPoolAsync(DeleteUserPoolRequest, cb)
 	assert(DeleteUserPoolRequest, "You must provide a DeleteUserPoolRequest")
 	local headers = {
@@ -14394,19 +14444,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserPoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserPoolSync(DeleteUserPoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserPoolAsync(DeleteUserPoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserPoolAsync(DeleteUserPoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminListUserAuthEvents asynchronously, invoking a callback when done
 -- @param AdminListUserAuthEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminListUserAuthEventsAsync(AdminListUserAuthEventsRequest, cb)
 	assert(AdminListUserAuthEventsRequest, "You must provide a AdminListUserAuthEventsRequest")
 	local headers = {
@@ -14429,19 +14480,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminListUserAuthEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminListUserAuthEventsSync(AdminListUserAuthEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminListUserAuthEventsAsync(AdminListUserAuthEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminListUserAuthEventsAsync(AdminListUserAuthEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUserPoolMfaConfig asynchronously, invoking a callback when done
 -- @param GetUserPoolMfaConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserPoolMfaConfigAsync(GetUserPoolMfaConfigRequest, cb)
 	assert(GetUserPoolMfaConfigRequest, "You must provide a GetUserPoolMfaConfigRequest")
 	local headers = {
@@ -14464,19 +14516,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserPoolMfaConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserPoolMfaConfigSync(GetUserPoolMfaConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserPoolMfaConfigAsync(GetUserPoolMfaConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserPoolMfaConfigAsync(GetUserPoolMfaConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminLinkProviderForUser asynchronously, invoking a callback when done
 -- @param AdminLinkProviderForUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminLinkProviderForUserAsync(AdminLinkProviderForUserRequest, cb)
 	assert(AdminLinkProviderForUserRequest, "You must provide a AdminLinkProviderForUserRequest")
 	local headers = {
@@ -14499,19 +14552,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminLinkProviderForUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminLinkProviderForUserSync(AdminLinkProviderForUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminLinkProviderForUserAsync(AdminLinkProviderForUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminLinkProviderForUserAsync(AdminLinkProviderForUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGroup asynchronously, invoking a callback when done
 -- @param DeleteGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGroupAsync(DeleteGroupRequest, cb)
 	assert(DeleteGroupRequest, "You must provide a DeleteGroupRequest")
 	local headers = {
@@ -14534,19 +14588,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGroupSync(DeleteGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResendConfirmationCode asynchronously, invoking a callback when done
 -- @param ResendConfirmationCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResendConfirmationCodeAsync(ResendConfirmationCodeRequest, cb)
 	assert(ResendConfirmationCodeRequest, "You must provide a ResendConfirmationCodeRequest")
 	local headers = {
@@ -14569,19 +14624,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResendConfirmationCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResendConfirmationCodeSync(ResendConfirmationCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResendConfirmationCodeAsync(ResendConfirmationCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResendConfirmationCodeAsync(ResendConfirmationCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUserAttributeVerificationCode asynchronously, invoking a callback when done
 -- @param GetUserAttributeVerificationCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserAttributeVerificationCodeAsync(GetUserAttributeVerificationCodeRequest, cb)
 	assert(GetUserAttributeVerificationCodeRequest, "You must provide a GetUserAttributeVerificationCodeRequest")
 	local headers = {
@@ -14604,19 +14660,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserAttributeVerificationCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserAttributeVerificationCodeSync(GetUserAttributeVerificationCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserAttributeVerificationCodeAsync(GetUserAttributeVerificationCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserAttributeVerificationCodeAsync(GetUserAttributeVerificationCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserPoolClient asynchronously, invoking a callback when done
 -- @param DeleteUserPoolClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserPoolClientAsync(DeleteUserPoolClientRequest, cb)
 	assert(DeleteUserPoolClientRequest, "You must provide a DeleteUserPoolClientRequest")
 	local headers = {
@@ -14639,19 +14696,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserPoolClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserPoolClientSync(DeleteUserPoolClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserPoolClientAsync(DeleteUserPoolClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserPoolClientAsync(DeleteUserPoolClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResourceServer asynchronously, invoking a callback when done
 -- @param CreateResourceServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResourceServerAsync(CreateResourceServerRequest, cb)
 	assert(CreateResourceServerRequest, "You must provide a CreateResourceServerRequest")
 	local headers = {
@@ -14674,19 +14732,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResourceServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResourceServerSync(CreateResourceServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResourceServerAsync(CreateResourceServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResourceServerAsync(CreateResourceServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCSVHeader asynchronously, invoking a callback when done
 -- @param GetCSVHeaderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCSVHeaderAsync(GetCSVHeaderRequest, cb)
 	assert(GetCSVHeaderRequest, "You must provide a GetCSVHeaderRequest")
 	local headers = {
@@ -14709,19 +14768,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCSVHeaderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCSVHeaderSync(GetCSVHeaderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCSVHeaderAsync(GetCSVHeaderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCSVHeaderAsync(GetCSVHeaderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminUpdateDeviceStatus asynchronously, invoking a callback when done
 -- @param AdminUpdateDeviceStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminUpdateDeviceStatusAsync(AdminUpdateDeviceStatusRequest, cb)
 	assert(AdminUpdateDeviceStatusRequest, "You must provide a AdminUpdateDeviceStatusRequest")
 	local headers = {
@@ -14744,19 +14804,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminUpdateDeviceStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminUpdateDeviceStatusSync(AdminUpdateDeviceStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminUpdateDeviceStatusAsync(AdminUpdateDeviceStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminUpdateDeviceStatusAsync(AdminUpdateDeviceStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserPoolClient asynchronously, invoking a callback when done
 -- @param UpdateUserPoolClientRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserPoolClientAsync(UpdateUserPoolClientRequest, cb)
 	assert(UpdateUserPoolClientRequest, "You must provide a UpdateUserPoolClientRequest")
 	local headers = {
@@ -14779,19 +14840,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserPoolClientRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserPoolClientSync(UpdateUserPoolClientRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserPoolClientAsync(UpdateUserPoolClientRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserPoolClientAsync(UpdateUserPoolClientRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResourceServer asynchronously, invoking a callback when done
 -- @param DeleteResourceServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourceServerAsync(DeleteResourceServerRequest, cb)
 	assert(DeleteResourceServerRequest, "You must provide a DeleteResourceServerRequest")
 	local headers = {
@@ -14814,19 +14876,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourceServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourceServerSync(DeleteResourceServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourceServerAsync(DeleteResourceServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourceServerAsync(DeleteResourceServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminRemoveUserFromGroup asynchronously, invoking a callback when done
 -- @param AdminRemoveUserFromGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminRemoveUserFromGroupAsync(AdminRemoveUserFromGroupRequest, cb)
 	assert(AdminRemoveUserFromGroupRequest, "You must provide a AdminRemoveUserFromGroupRequest")
 	local headers = {
@@ -14849,19 +14912,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminRemoveUserFromGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminRemoveUserFromGroupSync(AdminRemoveUserFromGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminRemoveUserFromGroupAsync(AdminRemoveUserFromGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminRemoveUserFromGroupAsync(AdminRemoveUserFromGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserPool asynchronously, invoking a callback when done
 -- @param UpdateUserPoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserPoolAsync(UpdateUserPoolRequest, cb)
 	assert(UpdateUserPoolRequest, "You must provide a UpdateUserPoolRequest")
 	local headers = {
@@ -14884,19 +14948,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserPoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserPoolSync(UpdateUserPoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserPoolAsync(UpdateUserPoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserPoolAsync(UpdateUserPoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateResourceServer asynchronously, invoking a callback when done
 -- @param UpdateResourceServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateResourceServerAsync(UpdateResourceServerRequest, cb)
 	assert(UpdateResourceServerRequest, "You must provide a UpdateResourceServerRequest")
 	local headers = {
@@ -14919,19 +14984,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateResourceServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateResourceServerSync(UpdateResourceServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateResourceServerAsync(UpdateResourceServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateResourceServerAsync(UpdateResourceServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroups asynchronously, invoking a callback when done
 -- @param ListGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupsAsync(ListGroupsRequest, cb)
 	assert(ListGroupsRequest, "You must provide a ListGroupsRequest")
 	local headers = {
@@ -14954,19 +15020,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupsSync(ListGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupsAsync(ListGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupsAsync(ListGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUserImportJobs asynchronously, invoking a callback when done
 -- @param ListUserImportJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUserImportJobsAsync(ListUserImportJobsRequest, cb)
 	assert(ListUserImportJobsRequest, "You must provide a ListUserImportJobsRequest")
 	local headers = {
@@ -14989,19 +15056,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUserImportJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUserImportJobsSync(ListUserImportJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUserImportJobsAsync(ListUserImportJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUserImportJobsAsync(ListUserImportJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUsers asynchronously, invoking a callback when done
 -- @param ListUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUsersAsync(ListUsersRequest, cb)
 	assert(ListUsersRequest, "You must provide a ListUsersRequest")
 	local headers = {
@@ -15024,19 +15092,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUsersSync(ListUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUsersAsync(ListUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUsersAsync(ListUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserImportJob asynchronously, invoking a callback when done
 -- @param DescribeUserImportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserImportJobAsync(DescribeUserImportJobRequest, cb)
 	assert(DescribeUserImportJobRequest, "You must provide a DescribeUserImportJobRequest")
 	local headers = {
@@ -15059,19 +15128,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserImportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserImportJobSync(DescribeUserImportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserImportJobAsync(DescribeUserImportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserImportJobAsync(DescribeUserImportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminDeleteUserAttributes asynchronously, invoking a callback when done
 -- @param AdminDeleteUserAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminDeleteUserAttributesAsync(AdminDeleteUserAttributesRequest, cb)
 	assert(AdminDeleteUserAttributesRequest, "You must provide a AdminDeleteUserAttributesRequest")
 	local headers = {
@@ -15094,19 +15164,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminDeleteUserAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminDeleteUserAttributesSync(AdminDeleteUserAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminDeleteUserAttributesAsync(AdminDeleteUserAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminDeleteUserAttributesAsync(AdminDeleteUserAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminRespondToAuthChallenge asynchronously, invoking a callback when done
 -- @param AdminRespondToAuthChallengeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminRespondToAuthChallengeAsync(AdminRespondToAuthChallengeRequest, cb)
 	assert(AdminRespondToAuthChallengeRequest, "You must provide a AdminRespondToAuthChallengeRequest")
 	local headers = {
@@ -15129,19 +15200,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminRespondToAuthChallengeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminRespondToAuthChallengeSync(AdminRespondToAuthChallengeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminRespondToAuthChallengeAsync(AdminRespondToAuthChallengeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminRespondToAuthChallengeAsync(AdminRespondToAuthChallengeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIdentityProvider asynchronously, invoking a callback when done
 -- @param CreateIdentityProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIdentityProviderAsync(CreateIdentityProviderRequest, cb)
 	assert(CreateIdentityProviderRequest, "You must provide a CreateIdentityProviderRequest")
 	local headers = {
@@ -15164,19 +15236,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIdentityProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIdentityProviderSync(CreateIdentityProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIdentityProviderAsync(CreateIdentityProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIdentityProviderAsync(CreateIdentityProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityProviderByIdentifier asynchronously, invoking a callback when done
 -- @param GetIdentityProviderByIdentifierRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityProviderByIdentifierAsync(GetIdentityProviderByIdentifierRequest, cb)
 	assert(GetIdentityProviderByIdentifierRequest, "You must provide a GetIdentityProviderByIdentifierRequest")
 	local headers = {
@@ -15199,19 +15272,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityProviderByIdentifierRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityProviderByIdentifierSync(GetIdentityProviderByIdentifierRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityProviderByIdentifierAsync(GetIdentityProviderByIdentifierRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityProviderByIdentifierAsync(GetIdentityProviderByIdentifierRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUserPool asynchronously, invoking a callback when done
 -- @param CreateUserPoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserPoolAsync(CreateUserPoolRequest, cb)
 	assert(CreateUserPoolRequest, "You must provide a CreateUserPoolRequest")
 	local headers = {
@@ -15234,19 +15308,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserPoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserPoolSync(CreateUserPoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserPoolAsync(CreateUserPoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserPoolAsync(CreateUserPoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call VerifySoftwareToken asynchronously, invoking a callback when done
 -- @param VerifySoftwareTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.VerifySoftwareTokenAsync(VerifySoftwareTokenRequest, cb)
 	assert(VerifySoftwareTokenRequest, "You must provide a VerifySoftwareTokenRequest")
 	local headers = {
@@ -15269,19 +15344,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param VerifySoftwareTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.VerifySoftwareTokenSync(VerifySoftwareTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.VerifySoftwareTokenAsync(VerifySoftwareTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.VerifySoftwareTokenAsync(VerifySoftwareTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserAttributes asynchronously, invoking a callback when done
 -- @param UpdateUserAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserAttributesAsync(UpdateUserAttributesRequest, cb)
 	assert(UpdateUserAttributesRequest, "You must provide a UpdateUserAttributesRequest")
 	local headers = {
@@ -15304,19 +15380,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserAttributesSync(UpdateUserAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserAttributesAsync(UpdateUserAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserAttributesAsync(UpdateUserAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserPoolDomain asynchronously, invoking a callback when done
 -- @param DescribeUserPoolDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserPoolDomainAsync(DescribeUserPoolDomainRequest, cb)
 	assert(DescribeUserPoolDomainRequest, "You must provide a DescribeUserPoolDomainRequest")
 	local headers = {
@@ -15339,19 +15416,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserPoolDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserPoolDomainSync(DescribeUserPoolDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserPoolDomainAsync(DescribeUserPoolDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserPoolDomainAsync(DescribeUserPoolDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminResetUserPassword asynchronously, invoking a callback when done
 -- @param AdminResetUserPasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminResetUserPasswordAsync(AdminResetUserPasswordRequest, cb)
 	assert(AdminResetUserPasswordRequest, "You must provide a AdminResetUserPasswordRequest")
 	local headers = {
@@ -15374,19 +15452,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminResetUserPasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminResetUserPasswordSync(AdminResetUserPasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminResetUserPasswordAsync(AdminResetUserPasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminResetUserPasswordAsync(AdminResetUserPasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminConfirmSignUp asynchronously, invoking a callback when done
 -- @param AdminConfirmSignUpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminConfirmSignUpAsync(AdminConfirmSignUpRequest, cb)
 	assert(AdminConfirmSignUpRequest, "You must provide a AdminConfirmSignUpRequest")
 	local headers = {
@@ -15409,19 +15488,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminConfirmSignUpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminConfirmSignUpSync(AdminConfirmSignUpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminConfirmSignUpAsync(AdminConfirmSignUpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminConfirmSignUpAsync(AdminConfirmSignUpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopUserImportJob asynchronously, invoking a callback when done
 -- @param StopUserImportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopUserImportJobAsync(StopUserImportJobRequest, cb)
 	assert(StopUserImportJobRequest, "You must provide a StopUserImportJobRequest")
 	local headers = {
@@ -15444,19 +15524,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopUserImportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopUserImportJobSync(StopUserImportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopUserImportJobAsync(StopUserImportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopUserImportJobAsync(StopUserImportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmDevice asynchronously, invoking a callback when done
 -- @param ConfirmDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmDeviceAsync(ConfirmDeviceRequest, cb)
 	assert(ConfirmDeviceRequest, "You must provide a ConfirmDeviceRequest")
 	local headers = {
@@ -15479,19 +15560,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmDeviceSync(ConfirmDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmDeviceAsync(ConfirmDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmDeviceAsync(ConfirmDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAuthEventFeedback asynchronously, invoking a callback when done
 -- @param UpdateAuthEventFeedbackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAuthEventFeedbackAsync(UpdateAuthEventFeedbackRequest, cb)
 	assert(UpdateAuthEventFeedbackRequest, "You must provide a UpdateAuthEventFeedbackRequest")
 	local headers = {
@@ -15514,19 +15596,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAuthEventFeedbackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAuthEventFeedbackSync(UpdateAuthEventFeedbackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAuthEventFeedbackAsync(UpdateAuthEventFeedbackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAuthEventFeedbackAsync(UpdateAuthEventFeedbackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUsersInGroup asynchronously, invoking a callback when done
 -- @param ListUsersInGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUsersInGroupAsync(ListUsersInGroupRequest, cb)
 	assert(ListUsersInGroupRequest, "You must provide a ListUsersInGroupRequest")
 	local headers = {
@@ -15549,19 +15632,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUsersInGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUsersInGroupSync(ListUsersInGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUsersInGroupAsync(ListUsersInGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUsersInGroupAsync(ListUsersInGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminEnableUser asynchronously, invoking a callback when done
 -- @param AdminEnableUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminEnableUserAsync(AdminEnableUserRequest, cb)
 	assert(AdminEnableUserRequest, "You must provide a AdminEnableUserRequest")
 	local headers = {
@@ -15584,19 +15668,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminEnableUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminEnableUserSync(AdminEnableUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminEnableUserAsync(AdminEnableUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminEnableUserAsync(AdminEnableUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddCustomAttributes asynchronously, invoking a callback when done
 -- @param AddCustomAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddCustomAttributesAsync(AddCustomAttributesRequest, cb)
 	assert(AddCustomAttributesRequest, "You must provide a AddCustomAttributesRequest")
 	local headers = {
@@ -15619,19 +15704,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddCustomAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddCustomAttributesSync(AddCustomAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddCustomAttributesAsync(AddCustomAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddCustomAttributesAsync(AddCustomAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartUserImportJob asynchronously, invoking a callback when done
 -- @param StartUserImportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartUserImportJobAsync(StartUserImportJobRequest, cb)
 	assert(StartUserImportJobRequest, "You must provide a StartUserImportJobRequest")
 	local headers = {
@@ -15654,19 +15740,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartUserImportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartUserImportJobSync(StartUserImportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartUserImportJobAsync(StartUserImportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartUserImportJobAsync(StartUserImportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdminGetUser asynchronously, invoking a callback when done
 -- @param AdminGetUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdminGetUserAsync(AdminGetUserRequest, cb)
 	assert(AdminGetUserRequest, "You must provide a AdminGetUserRequest")
 	local headers = {
@@ -15689,19 +15776,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdminGetUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdminGetUserSync(AdminGetUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdminGetUserAsync(AdminGetUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdminGetUserAsync(AdminGetUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetUserPoolMfaConfig asynchronously, invoking a callback when done
 -- @param SetUserPoolMfaConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetUserPoolMfaConfigAsync(SetUserPoolMfaConfigRequest, cb)
 	assert(SetUserPoolMfaConfigRequest, "You must provide a SetUserPoolMfaConfigRequest")
 	local headers = {
@@ -15724,19 +15812,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetUserPoolMfaConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetUserPoolMfaConfigSync(SetUserPoolMfaConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetUserPoolMfaConfigAsync(SetUserPoolMfaConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetUserPoolMfaConfigAsync(SetUserPoolMfaConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevice asynchronously, invoking a callback when done
 -- @param GetDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeviceAsync(GetDeviceRequest, cb)
 	assert(GetDeviceRequest, "You must provide a GetDeviceRequest")
 	local headers = {
@@ -15759,19 +15848,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeviceSync(GetDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeviceAsync(GetDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeviceAsync(GetDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUserImportJob asynchronously, invoking a callback when done
 -- @param CreateUserImportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserImportJobAsync(CreateUserImportJobRequest, cb)
 	assert(CreateUserImportJobRequest, "You must provide a CreateUserImportJobRequest")
 	local headers = {
@@ -15794,19 +15884,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserImportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserImportJobSync(CreateUserImportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserImportJobAsync(CreateUserImportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserImportJobAsync(CreateUserImportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetUserMFAPreference asynchronously, invoking a callback when done
 -- @param SetUserMFAPreferenceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetUserMFAPreferenceAsync(SetUserMFAPreferenceRequest, cb)
 	assert(SetUserMFAPreferenceRequest, "You must provide a SetUserMFAPreferenceRequest")
 	local headers = {
@@ -15829,19 +15920,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetUserMFAPreferenceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetUserMFAPreferenceSync(SetUserMFAPreferenceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetUserMFAPreferenceAsync(SetUserMFAPreferenceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetUserMFAPreferenceAsync(SetUserMFAPreferenceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetUserSettings asynchronously, invoking a callback when done
 -- @param SetUserSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetUserSettingsAsync(SetUserSettingsRequest, cb)
 	assert(SetUserSettingsRequest, "You must provide a SetUserSettingsRequest")
 	local headers = {
@@ -15864,19 +15956,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetUserSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetUserSettingsSync(SetUserSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetUserSettingsAsync(SetUserSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetUserSettingsAsync(SetUserSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUserPoolDomain asynchronously, invoking a callback when done
 -- @param CreateUserPoolDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserPoolDomainAsync(CreateUserPoolDomainRequest, cb)
 	assert(CreateUserPoolDomainRequest, "You must provide a CreateUserPoolDomainRequest")
 	local headers = {
@@ -15899,19 +15992,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserPoolDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserPoolDomainSync(CreateUserPoolDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserPoolDomainAsync(CreateUserPoolDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserPoolDomainAsync(CreateUserPoolDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSigningCertificate asynchronously, invoking a callback when done
 -- @param GetSigningCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSigningCertificateAsync(GetSigningCertificateRequest, cb)
 	assert(GetSigningCertificateRequest, "You must provide a GetSigningCertificateRequest")
 	local headers = {
@@ -15934,12 +16028,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSigningCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSigningCertificateSync(GetSigningCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSigningCertificateAsync(GetSigningCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSigningCertificateAsync(GetSigningCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/cognito-sync.lua
+++ b/aws-sdk/cognito-sync.lua
@@ -2798,7 +2798,7 @@ end
 --
 --- Call SetCognitoEvents asynchronously, invoking a callback when done
 -- @param SetCognitoEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetCognitoEventsAsync(SetCognitoEventsRequest, cb)
 	assert(SetCognitoEventsRequest, "You must provide a SetCognitoEventsRequest")
 	local headers = {
@@ -2821,19 +2821,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetCognitoEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetCognitoEventsSync(SetCognitoEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetCognitoEventsAsync(SetCognitoEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetCognitoEventsAsync(SetCognitoEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIdentityUsage asynchronously, invoking a callback when done
 -- @param DescribeIdentityUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIdentityUsageAsync(DescribeIdentityUsageRequest, cb)
 	assert(DescribeIdentityUsageRequest, "You must provide a DescribeIdentityUsageRequest")
 	local headers = {
@@ -2856,19 +2857,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIdentityUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIdentityUsageSync(DescribeIdentityUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIdentityUsageAsync(DescribeIdentityUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIdentityUsageAsync(DescribeIdentityUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRecords asynchronously, invoking a callback when done
 -- @param ListRecordsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRecordsAsync(ListRecordsRequest, cb)
 	assert(ListRecordsRequest, "You must provide a ListRecordsRequest")
 	local headers = {
@@ -2891,19 +2893,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRecordsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRecordsSync(ListRecordsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRecordsAsync(ListRecordsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRecordsAsync(ListRecordsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDataset asynchronously, invoking a callback when done
 -- @param DescribeDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDatasetAsync(DescribeDatasetRequest, cb)
 	assert(DescribeDatasetRequest, "You must provide a DescribeDatasetRequest")
 	local headers = {
@@ -2926,19 +2929,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDatasetSync(DescribeDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDatasetAsync(DescribeDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDatasetAsync(DescribeDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BulkPublish asynchronously, invoking a callback when done
 -- @param BulkPublishRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BulkPublishAsync(BulkPublishRequest, cb)
 	assert(BulkPublishRequest, "You must provide a BulkPublishRequest")
 	local headers = {
@@ -2961,19 +2965,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BulkPublishRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BulkPublishSync(BulkPublishRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BulkPublishAsync(BulkPublishRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BulkPublishAsync(BulkPublishRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnsubscribeFromDataset asynchronously, invoking a callback when done
 -- @param UnsubscribeFromDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnsubscribeFromDatasetAsync(UnsubscribeFromDatasetRequest, cb)
 	assert(UnsubscribeFromDatasetRequest, "You must provide a UnsubscribeFromDatasetRequest")
 	local headers = {
@@ -2996,19 +3001,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnsubscribeFromDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnsubscribeFromDatasetSync(UnsubscribeFromDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnsubscribeFromDatasetAsync(UnsubscribeFromDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnsubscribeFromDatasetAsync(UnsubscribeFromDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIdentityPoolUsage asynchronously, invoking a callback when done
 -- @param ListIdentityPoolUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIdentityPoolUsageAsync(ListIdentityPoolUsageRequest, cb)
 	assert(ListIdentityPoolUsageRequest, "You must provide a ListIdentityPoolUsageRequest")
 	local headers = {
@@ -3031,19 +3037,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIdentityPoolUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIdentityPoolUsageSync(ListIdentityPoolUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIdentityPoolUsageAsync(ListIdentityPoolUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIdentityPoolUsageAsync(ListIdentityPoolUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterDevice asynchronously, invoking a callback when done
 -- @param RegisterDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterDeviceAsync(RegisterDeviceRequest, cb)
 	assert(RegisterDeviceRequest, "You must provide a RegisterDeviceRequest")
 	local headers = {
@@ -3066,19 +3073,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterDeviceSync(RegisterDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterDeviceAsync(RegisterDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterDeviceAsync(RegisterDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBulkPublishDetails asynchronously, invoking a callback when done
 -- @param GetBulkPublishDetailsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBulkPublishDetailsAsync(GetBulkPublishDetailsRequest, cb)
 	assert(GetBulkPublishDetailsRequest, "You must provide a GetBulkPublishDetailsRequest")
 	local headers = {
@@ -3101,19 +3109,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBulkPublishDetailsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBulkPublishDetailsSync(GetBulkPublishDetailsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBulkPublishDetailsAsync(GetBulkPublishDetailsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBulkPublishDetailsAsync(GetBulkPublishDetailsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCognitoEvents asynchronously, invoking a callback when done
 -- @param GetCognitoEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCognitoEventsAsync(GetCognitoEventsRequest, cb)
 	assert(GetCognitoEventsRequest, "You must provide a GetCognitoEventsRequest")
 	local headers = {
@@ -3136,19 +3145,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCognitoEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCognitoEventsSync(GetCognitoEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCognitoEventsAsync(GetCognitoEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCognitoEventsAsync(GetCognitoEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDataset asynchronously, invoking a callback when done
 -- @param DeleteDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDatasetAsync(DeleteDatasetRequest, cb)
 	assert(DeleteDatasetRequest, "You must provide a DeleteDatasetRequest")
 	local headers = {
@@ -3171,19 +3181,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDatasetSync(DeleteDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDatasetAsync(DeleteDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDatasetAsync(DeleteDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIdentityPoolUsage asynchronously, invoking a callback when done
 -- @param DescribeIdentityPoolUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIdentityPoolUsageAsync(DescribeIdentityPoolUsageRequest, cb)
 	assert(DescribeIdentityPoolUsageRequest, "You must provide a DescribeIdentityPoolUsageRequest")
 	local headers = {
@@ -3206,19 +3217,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIdentityPoolUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIdentityPoolUsageSync(DescribeIdentityPoolUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIdentityPoolUsageAsync(DescribeIdentityPoolUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIdentityPoolUsageAsync(DescribeIdentityPoolUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRecords asynchronously, invoking a callback when done
 -- @param UpdateRecordsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRecordsAsync(UpdateRecordsRequest, cb)
 	assert(UpdateRecordsRequest, "You must provide a UpdateRecordsRequest")
 	local headers = {
@@ -3241,19 +3253,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRecordsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRecordsSync(UpdateRecordsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRecordsAsync(UpdateRecordsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRecordsAsync(UpdateRecordsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SubscribeToDataset asynchronously, invoking a callback when done
 -- @param SubscribeToDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SubscribeToDatasetAsync(SubscribeToDatasetRequest, cb)
 	assert(SubscribeToDatasetRequest, "You must provide a SubscribeToDatasetRequest")
 	local headers = {
@@ -3276,19 +3289,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SubscribeToDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SubscribeToDatasetSync(SubscribeToDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SubscribeToDatasetAsync(SubscribeToDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SubscribeToDatasetAsync(SubscribeToDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIdentityPoolConfiguration asynchronously, invoking a callback when done
 -- @param SetIdentityPoolConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIdentityPoolConfigurationAsync(SetIdentityPoolConfigurationRequest, cb)
 	assert(SetIdentityPoolConfigurationRequest, "You must provide a SetIdentityPoolConfigurationRequest")
 	local headers = {
@@ -3311,19 +3325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIdentityPoolConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIdentityPoolConfigurationSync(SetIdentityPoolConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIdentityPoolConfigurationAsync(SetIdentityPoolConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIdentityPoolConfigurationAsync(SetIdentityPoolConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityPoolConfiguration asynchronously, invoking a callback when done
 -- @param GetIdentityPoolConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityPoolConfigurationAsync(GetIdentityPoolConfigurationRequest, cb)
 	assert(GetIdentityPoolConfigurationRequest, "You must provide a GetIdentityPoolConfigurationRequest")
 	local headers = {
@@ -3346,19 +3361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityPoolConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityPoolConfigurationSync(GetIdentityPoolConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityPoolConfigurationAsync(GetIdentityPoolConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityPoolConfigurationAsync(GetIdentityPoolConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDatasets asynchronously, invoking a callback when done
 -- @param ListDatasetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDatasetsAsync(ListDatasetsRequest, cb)
 	assert(ListDatasetsRequest, "You must provide a ListDatasetsRequest")
 	local headers = {
@@ -3381,12 +3397,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDatasetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDatasetsSync(ListDatasetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDatasetsAsync(ListDatasetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDatasetsAsync(ListDatasetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/comprehend.lua
+++ b/aws-sdk/comprehend.lua
@@ -4108,7 +4108,7 @@ end
 --
 --- Call StopEntitiesDetectionJob asynchronously, invoking a callback when done
 -- @param StopEntitiesDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopEntitiesDetectionJobAsync(StopEntitiesDetectionJobRequest, cb)
 	assert(StopEntitiesDetectionJobRequest, "You must provide a StopEntitiesDetectionJobRequest")
 	local headers = {
@@ -4131,19 +4131,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopEntitiesDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopEntitiesDetectionJobSync(StopEntitiesDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopEntitiesDetectionJobAsync(StopEntitiesDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopEntitiesDetectionJobAsync(StopEntitiesDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectSyntax asynchronously, invoking a callback when done
 -- @param DetectSyntaxRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectSyntaxAsync(DetectSyntaxRequest, cb)
 	assert(DetectSyntaxRequest, "You must provide a DetectSyntaxRequest")
 	local headers = {
@@ -4166,19 +4167,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectSyntaxRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectSyntaxSync(DetectSyntaxRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectSyntaxAsync(DetectSyntaxRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectSyntaxAsync(DetectSyntaxRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartDominantLanguageDetectionJob asynchronously, invoking a callback when done
 -- @param StartDominantLanguageDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartDominantLanguageDetectionJobAsync(StartDominantLanguageDetectionJobRequest, cb)
 	assert(StartDominantLanguageDetectionJobRequest, "You must provide a StartDominantLanguageDetectionJobRequest")
 	local headers = {
@@ -4201,19 +4203,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartDominantLanguageDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartDominantLanguageDetectionJobSync(StartDominantLanguageDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartDominantLanguageDetectionJobAsync(StartDominantLanguageDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartDominantLanguageDetectionJobAsync(StartDominantLanguageDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListKeyPhrasesDetectionJobs asynchronously, invoking a callback when done
 -- @param ListKeyPhrasesDetectionJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListKeyPhrasesDetectionJobsAsync(ListKeyPhrasesDetectionJobsRequest, cb)
 	assert(ListKeyPhrasesDetectionJobsRequest, "You must provide a ListKeyPhrasesDetectionJobsRequest")
 	local headers = {
@@ -4236,19 +4239,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListKeyPhrasesDetectionJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListKeyPhrasesDetectionJobsSync(ListKeyPhrasesDetectionJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListKeyPhrasesDetectionJobsAsync(ListKeyPhrasesDetectionJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListKeyPhrasesDetectionJobsAsync(ListKeyPhrasesDetectionJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDetectDominantLanguage asynchronously, invoking a callback when done
 -- @param BatchDetectDominantLanguageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDetectDominantLanguageAsync(BatchDetectDominantLanguageRequest, cb)
 	assert(BatchDetectDominantLanguageRequest, "You must provide a BatchDetectDominantLanguageRequest")
 	local headers = {
@@ -4271,19 +4275,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDetectDominantLanguageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDetectDominantLanguageSync(BatchDetectDominantLanguageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDetectDominantLanguageAsync(BatchDetectDominantLanguageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDetectDominantLanguageAsync(BatchDetectDominantLanguageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEntitiesDetectionJob asynchronously, invoking a callback when done
 -- @param DescribeEntitiesDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEntitiesDetectionJobAsync(DescribeEntitiesDetectionJobRequest, cb)
 	assert(DescribeEntitiesDetectionJobRequest, "You must provide a DescribeEntitiesDetectionJobRequest")
 	local headers = {
@@ -4306,19 +4311,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEntitiesDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEntitiesDetectionJobSync(DescribeEntitiesDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEntitiesDetectionJobAsync(DescribeEntitiesDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEntitiesDetectionJobAsync(DescribeEntitiesDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDetectSentiment asynchronously, invoking a callback when done
 -- @param BatchDetectSentimentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDetectSentimentAsync(BatchDetectSentimentRequest, cb)
 	assert(BatchDetectSentimentRequest, "You must provide a BatchDetectSentimentRequest")
 	local headers = {
@@ -4341,19 +4347,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDetectSentimentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDetectSentimentSync(BatchDetectSentimentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDetectSentimentAsync(BatchDetectSentimentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDetectSentimentAsync(BatchDetectSentimentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopKeyPhrasesDetectionJob asynchronously, invoking a callback when done
 -- @param StopKeyPhrasesDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopKeyPhrasesDetectionJobAsync(StopKeyPhrasesDetectionJobRequest, cb)
 	assert(StopKeyPhrasesDetectionJobRequest, "You must provide a StopKeyPhrasesDetectionJobRequest")
 	local headers = {
@@ -4376,19 +4383,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopKeyPhrasesDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopKeyPhrasesDetectionJobSync(StopKeyPhrasesDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopKeyPhrasesDetectionJobAsync(StopKeyPhrasesDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopKeyPhrasesDetectionJobAsync(StopKeyPhrasesDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopDominantLanguageDetectionJob asynchronously, invoking a callback when done
 -- @param StopDominantLanguageDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopDominantLanguageDetectionJobAsync(StopDominantLanguageDetectionJobRequest, cb)
 	assert(StopDominantLanguageDetectionJobRequest, "You must provide a StopDominantLanguageDetectionJobRequest")
 	local headers = {
@@ -4411,19 +4419,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopDominantLanguageDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopDominantLanguageDetectionJobSync(StopDominantLanguageDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopDominantLanguageDetectionJobAsync(StopDominantLanguageDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopDominantLanguageDetectionJobAsync(StopDominantLanguageDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectEntities asynchronously, invoking a callback when done
 -- @param DetectEntitiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectEntitiesAsync(DetectEntitiesRequest, cb)
 	assert(DetectEntitiesRequest, "You must provide a DetectEntitiesRequest")
 	local headers = {
@@ -4446,19 +4455,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectEntitiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectEntitiesSync(DetectEntitiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectEntitiesAsync(DetectEntitiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectEntitiesAsync(DetectEntitiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTopicsDetectionJob asynchronously, invoking a callback when done
 -- @param DescribeTopicsDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTopicsDetectionJobAsync(DescribeTopicsDetectionJobRequest, cb)
 	assert(DescribeTopicsDetectionJobRequest, "You must provide a DescribeTopicsDetectionJobRequest")
 	local headers = {
@@ -4481,19 +4491,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTopicsDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTopicsDetectionJobSync(DescribeTopicsDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTopicsDetectionJobAsync(DescribeTopicsDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTopicsDetectionJobAsync(DescribeTopicsDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListEntitiesDetectionJobs asynchronously, invoking a callback when done
 -- @param ListEntitiesDetectionJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEntitiesDetectionJobsAsync(ListEntitiesDetectionJobsRequest, cb)
 	assert(ListEntitiesDetectionJobsRequest, "You must provide a ListEntitiesDetectionJobsRequest")
 	local headers = {
@@ -4516,19 +4527,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEntitiesDetectionJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEntitiesDetectionJobsSync(ListEntitiesDetectionJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEntitiesDetectionJobsAsync(ListEntitiesDetectionJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEntitiesDetectionJobsAsync(ListEntitiesDetectionJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartEntitiesDetectionJob asynchronously, invoking a callback when done
 -- @param StartEntitiesDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartEntitiesDetectionJobAsync(StartEntitiesDetectionJobRequest, cb)
 	assert(StartEntitiesDetectionJobRequest, "You must provide a StartEntitiesDetectionJobRequest")
 	local headers = {
@@ -4551,19 +4563,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartEntitiesDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartEntitiesDetectionJobSync(StartEntitiesDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartEntitiesDetectionJobAsync(StartEntitiesDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartEntitiesDetectionJobAsync(StartEntitiesDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectSentiment asynchronously, invoking a callback when done
 -- @param DetectSentimentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectSentimentAsync(DetectSentimentRequest, cb)
 	assert(DetectSentimentRequest, "You must provide a DetectSentimentRequest")
 	local headers = {
@@ -4586,19 +4599,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectSentimentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectSentimentSync(DetectSentimentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectSentimentAsync(DetectSentimentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectSentimentAsync(DetectSentimentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSentimentDetectionJob asynchronously, invoking a callback when done
 -- @param DescribeSentimentDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSentimentDetectionJobAsync(DescribeSentimentDetectionJobRequest, cb)
 	assert(DescribeSentimentDetectionJobRequest, "You must provide a DescribeSentimentDetectionJobRequest")
 	local headers = {
@@ -4621,19 +4635,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSentimentDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSentimentDetectionJobSync(DescribeSentimentDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSentimentDetectionJobAsync(DescribeSentimentDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSentimentDetectionJobAsync(DescribeSentimentDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartTopicsDetectionJob asynchronously, invoking a callback when done
 -- @param StartTopicsDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartTopicsDetectionJobAsync(StartTopicsDetectionJobRequest, cb)
 	assert(StartTopicsDetectionJobRequest, "You must provide a StartTopicsDetectionJobRequest")
 	local headers = {
@@ -4656,19 +4671,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartTopicsDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartTopicsDetectionJobSync(StartTopicsDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartTopicsDetectionJobAsync(StartTopicsDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartTopicsDetectionJobAsync(StartTopicsDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTopicsDetectionJobs asynchronously, invoking a callback when done
 -- @param ListTopicsDetectionJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTopicsDetectionJobsAsync(ListTopicsDetectionJobsRequest, cb)
 	assert(ListTopicsDetectionJobsRequest, "You must provide a ListTopicsDetectionJobsRequest")
 	local headers = {
@@ -4691,19 +4707,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTopicsDetectionJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTopicsDetectionJobsSync(ListTopicsDetectionJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTopicsDetectionJobsAsync(ListTopicsDetectionJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTopicsDetectionJobsAsync(ListTopicsDetectionJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectKeyPhrases asynchronously, invoking a callback when done
 -- @param DetectKeyPhrasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectKeyPhrasesAsync(DetectKeyPhrasesRequest, cb)
 	assert(DetectKeyPhrasesRequest, "You must provide a DetectKeyPhrasesRequest")
 	local headers = {
@@ -4726,19 +4743,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectKeyPhrasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectKeyPhrasesSync(DetectKeyPhrasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectKeyPhrasesAsync(DetectKeyPhrasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectKeyPhrasesAsync(DetectKeyPhrasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSentimentDetectionJobs asynchronously, invoking a callback when done
 -- @param ListSentimentDetectionJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSentimentDetectionJobsAsync(ListSentimentDetectionJobsRequest, cb)
 	assert(ListSentimentDetectionJobsRequest, "You must provide a ListSentimentDetectionJobsRequest")
 	local headers = {
@@ -4761,19 +4779,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSentimentDetectionJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSentimentDetectionJobsSync(ListSentimentDetectionJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSentimentDetectionJobsAsync(ListSentimentDetectionJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSentimentDetectionJobsAsync(ListSentimentDetectionJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSentimentDetectionJob asynchronously, invoking a callback when done
 -- @param StartSentimentDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSentimentDetectionJobAsync(StartSentimentDetectionJobRequest, cb)
 	assert(StartSentimentDetectionJobRequest, "You must provide a StartSentimentDetectionJobRequest")
 	local headers = {
@@ -4796,19 +4815,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSentimentDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSentimentDetectionJobSync(StartSentimentDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSentimentDetectionJobAsync(StartSentimentDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSentimentDetectionJobAsync(StartSentimentDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeKeyPhrasesDetectionJob asynchronously, invoking a callback when done
 -- @param DescribeKeyPhrasesDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeKeyPhrasesDetectionJobAsync(DescribeKeyPhrasesDetectionJobRequest, cb)
 	assert(DescribeKeyPhrasesDetectionJobRequest, "You must provide a DescribeKeyPhrasesDetectionJobRequest")
 	local headers = {
@@ -4831,19 +4851,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeKeyPhrasesDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeKeyPhrasesDetectionJobSync(DescribeKeyPhrasesDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeKeyPhrasesDetectionJobAsync(DescribeKeyPhrasesDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeKeyPhrasesDetectionJobAsync(DescribeKeyPhrasesDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectDominantLanguage asynchronously, invoking a callback when done
 -- @param DetectDominantLanguageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectDominantLanguageAsync(DetectDominantLanguageRequest, cb)
 	assert(DetectDominantLanguageRequest, "You must provide a DetectDominantLanguageRequest")
 	local headers = {
@@ -4866,19 +4887,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectDominantLanguageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectDominantLanguageSync(DetectDominantLanguageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectDominantLanguageAsync(DetectDominantLanguageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectDominantLanguageAsync(DetectDominantLanguageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartKeyPhrasesDetectionJob asynchronously, invoking a callback when done
 -- @param StartKeyPhrasesDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartKeyPhrasesDetectionJobAsync(StartKeyPhrasesDetectionJobRequest, cb)
 	assert(StartKeyPhrasesDetectionJobRequest, "You must provide a StartKeyPhrasesDetectionJobRequest")
 	local headers = {
@@ -4901,19 +4923,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartKeyPhrasesDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartKeyPhrasesDetectionJobSync(StartKeyPhrasesDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartKeyPhrasesDetectionJobAsync(StartKeyPhrasesDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartKeyPhrasesDetectionJobAsync(StartKeyPhrasesDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDetectSyntax asynchronously, invoking a callback when done
 -- @param BatchDetectSyntaxRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDetectSyntaxAsync(BatchDetectSyntaxRequest, cb)
 	assert(BatchDetectSyntaxRequest, "You must provide a BatchDetectSyntaxRequest")
 	local headers = {
@@ -4936,19 +4959,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDetectSyntaxRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDetectSyntaxSync(BatchDetectSyntaxRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDetectSyntaxAsync(BatchDetectSyntaxRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDetectSyntaxAsync(BatchDetectSyntaxRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDominantLanguageDetectionJob asynchronously, invoking a callback when done
 -- @param DescribeDominantLanguageDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDominantLanguageDetectionJobAsync(DescribeDominantLanguageDetectionJobRequest, cb)
 	assert(DescribeDominantLanguageDetectionJobRequest, "You must provide a DescribeDominantLanguageDetectionJobRequest")
 	local headers = {
@@ -4971,19 +4995,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDominantLanguageDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDominantLanguageDetectionJobSync(DescribeDominantLanguageDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDominantLanguageDetectionJobAsync(DescribeDominantLanguageDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDominantLanguageDetectionJobAsync(DescribeDominantLanguageDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopSentimentDetectionJob asynchronously, invoking a callback when done
 -- @param StopSentimentDetectionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopSentimentDetectionJobAsync(StopSentimentDetectionJobRequest, cb)
 	assert(StopSentimentDetectionJobRequest, "You must provide a StopSentimentDetectionJobRequest")
 	local headers = {
@@ -5006,19 +5031,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopSentimentDetectionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopSentimentDetectionJobSync(StopSentimentDetectionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopSentimentDetectionJobAsync(StopSentimentDetectionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopSentimentDetectionJobAsync(StopSentimentDetectionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDetectKeyPhrases asynchronously, invoking a callback when done
 -- @param BatchDetectKeyPhrasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDetectKeyPhrasesAsync(BatchDetectKeyPhrasesRequest, cb)
 	assert(BatchDetectKeyPhrasesRequest, "You must provide a BatchDetectKeyPhrasesRequest")
 	local headers = {
@@ -5041,19 +5067,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDetectKeyPhrasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDetectKeyPhrasesSync(BatchDetectKeyPhrasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDetectKeyPhrasesAsync(BatchDetectKeyPhrasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDetectKeyPhrasesAsync(BatchDetectKeyPhrasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDominantLanguageDetectionJobs asynchronously, invoking a callback when done
 -- @param ListDominantLanguageDetectionJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDominantLanguageDetectionJobsAsync(ListDominantLanguageDetectionJobsRequest, cb)
 	assert(ListDominantLanguageDetectionJobsRequest, "You must provide a ListDominantLanguageDetectionJobsRequest")
 	local headers = {
@@ -5076,19 +5103,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDominantLanguageDetectionJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDominantLanguageDetectionJobsSync(ListDominantLanguageDetectionJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDominantLanguageDetectionJobsAsync(ListDominantLanguageDetectionJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDominantLanguageDetectionJobsAsync(ListDominantLanguageDetectionJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDetectEntities asynchronously, invoking a callback when done
 -- @param BatchDetectEntitiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDetectEntitiesAsync(BatchDetectEntitiesRequest, cb)
 	assert(BatchDetectEntitiesRequest, "You must provide a BatchDetectEntitiesRequest")
 	local headers = {
@@ -5111,12 +5139,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDetectEntitiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDetectEntitiesSync(BatchDetectEntitiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDetectEntitiesAsync(BatchDetectEntitiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDetectEntitiesAsync(BatchDetectEntitiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/config.lua
+++ b/aws-sdk/config.lua
@@ -6400,7 +6400,7 @@ end
 --
 --- Call StopConfigurationRecorder asynchronously, invoking a callback when done
 -- @param StopConfigurationRecorderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopConfigurationRecorderAsync(StopConfigurationRecorderRequest, cb)
 	assert(StopConfigurationRecorderRequest, "You must provide a StopConfigurationRecorderRequest")
 	local headers = {
@@ -6423,19 +6423,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopConfigurationRecorderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopConfigurationRecorderSync(StopConfigurationRecorderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopConfigurationRecorderAsync(StopConfigurationRecorderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopConfigurationRecorderAsync(StopConfigurationRecorderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetComplianceDetailsByResource asynchronously, invoking a callback when done
 -- @param GetComplianceDetailsByResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetComplianceDetailsByResourceAsync(GetComplianceDetailsByResourceRequest, cb)
 	assert(GetComplianceDetailsByResourceRequest, "You must provide a GetComplianceDetailsByResourceRequest")
 	local headers = {
@@ -6458,19 +6459,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetComplianceDetailsByResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetComplianceDetailsByResourceSync(GetComplianceDetailsByResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetComplianceDetailsByResourceAsync(GetComplianceDetailsByResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetComplianceDetailsByResourceAsync(GetComplianceDetailsByResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDiscoveredResources asynchronously, invoking a callback when done
 -- @param ListDiscoveredResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDiscoveredResourcesAsync(ListDiscoveredResourcesRequest, cb)
 	assert(ListDiscoveredResourcesRequest, "You must provide a ListDiscoveredResourcesRequest")
 	local headers = {
@@ -6493,19 +6495,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDiscoveredResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDiscoveredResourcesSync(ListDiscoveredResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDiscoveredResourcesAsync(ListDiscoveredResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDiscoveredResourcesAsync(ListDiscoveredResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDeliveryChannel asynchronously, invoking a callback when done
 -- @param DeleteDeliveryChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDeliveryChannelAsync(DeleteDeliveryChannelRequest, cb)
 	assert(DeleteDeliveryChannelRequest, "You must provide a DeleteDeliveryChannelRequest")
 	local headers = {
@@ -6528,19 +6531,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDeliveryChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDeliveryChannelSync(DeleteDeliveryChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDeliveryChannelAsync(DeleteDeliveryChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDeliveryChannelAsync(DeleteDeliveryChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAggregationAuthorization asynchronously, invoking a callback when done
 -- @param DeleteAggregationAuthorizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAggregationAuthorizationAsync(DeleteAggregationAuthorizationRequest, cb)
 	assert(DeleteAggregationAuthorizationRequest, "You must provide a DeleteAggregationAuthorizationRequest")
 	local headers = {
@@ -6563,19 +6567,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAggregationAuthorizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAggregationAuthorizationSync(DeleteAggregationAuthorizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAggregationAuthorizationAsync(DeleteAggregationAuthorizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAggregationAuthorizationAsync(DeleteAggregationAuthorizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAggregateConfigRuleComplianceSummary asynchronously, invoking a callback when done
 -- @param GetAggregateConfigRuleComplianceSummaryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAggregateConfigRuleComplianceSummaryAsync(GetAggregateConfigRuleComplianceSummaryRequest, cb)
 	assert(GetAggregateConfigRuleComplianceSummaryRequest, "You must provide a GetAggregateConfigRuleComplianceSummaryRequest")
 	local headers = {
@@ -6598,19 +6603,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAggregateConfigRuleComplianceSummaryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAggregateConfigRuleComplianceSummarySync(GetAggregateConfigRuleComplianceSummaryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAggregateConfigRuleComplianceSummaryAsync(GetAggregateConfigRuleComplianceSummaryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAggregateConfigRuleComplianceSummaryAsync(GetAggregateConfigRuleComplianceSummaryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConfigurationAggregator asynchronously, invoking a callback when done
 -- @param DeleteConfigurationAggregatorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConfigurationAggregatorAsync(DeleteConfigurationAggregatorRequest, cb)
 	assert(DeleteConfigurationAggregatorRequest, "You must provide a DeleteConfigurationAggregatorRequest")
 	local headers = {
@@ -6633,19 +6639,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConfigurationAggregatorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConfigurationAggregatorSync(DeleteConfigurationAggregatorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConfigurationAggregatorAsync(DeleteConfigurationAggregatorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConfigurationAggregatorAsync(DeleteConfigurationAggregatorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRetentionConfiguration asynchronously, invoking a callback when done
 -- @param DeleteRetentionConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRetentionConfigurationAsync(DeleteRetentionConfigurationRequest, cb)
 	assert(DeleteRetentionConfigurationRequest, "You must provide a DeleteRetentionConfigurationRequest")
 	local headers = {
@@ -6668,19 +6675,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRetentionConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRetentionConfigurationSync(DeleteRetentionConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRetentionConfigurationAsync(DeleteRetentionConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRetentionConfigurationAsync(DeleteRetentionConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutEvaluations asynchronously, invoking a callback when done
 -- @param PutEvaluationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutEvaluationsAsync(PutEvaluationsRequest, cb)
 	assert(PutEvaluationsRequest, "You must provide a PutEvaluationsRequest")
 	local headers = {
@@ -6703,19 +6711,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutEvaluationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutEvaluationsSync(PutEvaluationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutEvaluationsAsync(PutEvaluationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutEvaluationsAsync(PutEvaluationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConfigRule asynchronously, invoking a callback when done
 -- @param DeleteConfigRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConfigRuleAsync(DeleteConfigRuleRequest, cb)
 	assert(DeleteConfigRuleRequest, "You must provide a DeleteConfigRuleRequest")
 	local headers = {
@@ -6738,19 +6747,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConfigRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConfigRuleSync(DeleteConfigRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConfigRuleAsync(DeleteConfigRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConfigRuleAsync(DeleteConfigRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationRecorders asynchronously, invoking a callback when done
 -- @param DescribeConfigurationRecordersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationRecordersAsync(DescribeConfigurationRecordersRequest, cb)
 	assert(DescribeConfigurationRecordersRequest, "You must provide a DescribeConfigurationRecordersRequest")
 	local headers = {
@@ -6773,19 +6783,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationRecordersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationRecordersSync(DescribeConfigurationRecordersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationRecordersAsync(DescribeConfigurationRecordersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationRecordersAsync(DescribeConfigurationRecordersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAggregationAuthorizations asynchronously, invoking a callback when done
 -- @param DescribeAggregationAuthorizationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAggregationAuthorizationsAsync(DescribeAggregationAuthorizationsRequest, cb)
 	assert(DescribeAggregationAuthorizationsRequest, "You must provide a DescribeAggregationAuthorizationsRequest")
 	local headers = {
@@ -6808,19 +6819,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAggregationAuthorizationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAggregationAuthorizationsSync(DescribeAggregationAuthorizationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAggregationAuthorizationsAsync(DescribeAggregationAuthorizationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAggregationAuthorizationsAsync(DescribeAggregationAuthorizationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutConfigurationRecorder asynchronously, invoking a callback when done
 -- @param PutConfigurationRecorderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutConfigurationRecorderAsync(PutConfigurationRecorderRequest, cb)
 	assert(PutConfigurationRecorderRequest, "You must provide a PutConfigurationRecorderRequest")
 	local headers = {
@@ -6843,19 +6855,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutConfigurationRecorderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutConfigurationRecorderSync(PutConfigurationRecorderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutConfigurationRecorderAsync(PutConfigurationRecorderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutConfigurationRecorderAsync(PutConfigurationRecorderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationRecorderStatus asynchronously, invoking a callback when done
 -- @param DescribeConfigurationRecorderStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationRecorderStatusAsync(DescribeConfigurationRecorderStatusRequest, cb)
 	assert(DescribeConfigurationRecorderStatusRequest, "You must provide a DescribeConfigurationRecorderStatusRequest")
 	local headers = {
@@ -6878,19 +6891,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationRecorderStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationRecorderStatusSync(DescribeConfigurationRecorderStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationRecorderStatusAsync(DescribeConfigurationRecorderStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationRecorderStatusAsync(DescribeConfigurationRecorderStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetComplianceDetailsByConfigRule asynchronously, invoking a callback when done
 -- @param GetComplianceDetailsByConfigRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetComplianceDetailsByConfigRuleAsync(GetComplianceDetailsByConfigRuleRequest, cb)
 	assert(GetComplianceDetailsByConfigRuleRequest, "You must provide a GetComplianceDetailsByConfigRuleRequest")
 	local headers = {
@@ -6913,19 +6927,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetComplianceDetailsByConfigRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetComplianceDetailsByConfigRuleSync(GetComplianceDetailsByConfigRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetComplianceDetailsByConfigRuleAsync(GetComplianceDetailsByConfigRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetComplianceDetailsByConfigRuleAsync(GetComplianceDetailsByConfigRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDeliveryChannelStatus asynchronously, invoking a callback when done
 -- @param DescribeDeliveryChannelStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDeliveryChannelStatusAsync(DescribeDeliveryChannelStatusRequest, cb)
 	assert(DescribeDeliveryChannelStatusRequest, "You must provide a DescribeDeliveryChannelStatusRequest")
 	local headers = {
@@ -6948,19 +6963,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDeliveryChannelStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDeliveryChannelStatusSync(DescribeDeliveryChannelStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDeliveryChannelStatusAsync(DescribeDeliveryChannelStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDeliveryChannelStatusAsync(DescribeDeliveryChannelStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeliverConfigSnapshot asynchronously, invoking a callback when done
 -- @param DeliverConfigSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeliverConfigSnapshotAsync(DeliverConfigSnapshotRequest, cb)
 	assert(DeliverConfigSnapshotRequest, "You must provide a DeliverConfigSnapshotRequest")
 	local headers = {
@@ -6983,19 +6999,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeliverConfigSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeliverConfigSnapshotSync(DeliverConfigSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeliverConfigSnapshotAsync(DeliverConfigSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeliverConfigSnapshotAsync(DeliverConfigSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartConfigRulesEvaluation asynchronously, invoking a callback when done
 -- @param StartConfigRulesEvaluationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartConfigRulesEvaluationAsync(StartConfigRulesEvaluationRequest, cb)
 	assert(StartConfigRulesEvaluationRequest, "You must provide a StartConfigRulesEvaluationRequest")
 	local headers = {
@@ -7018,18 +7035,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartConfigRulesEvaluationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartConfigRulesEvaluationSync(StartConfigRulesEvaluationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartConfigRulesEvaluationAsync(StartConfigRulesEvaluationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartConfigRulesEvaluationAsync(StartConfigRulesEvaluationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetComplianceSummaryByConfigRule asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetComplianceSummaryByConfigRuleAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -7048,19 +7066,20 @@ end
 --- Call GetComplianceSummaryByConfigRule synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetComplianceSummaryByConfigRuleSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetComplianceSummaryByConfigRuleAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetComplianceSummaryByConfigRuleAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartConfigurationRecorder asynchronously, invoking a callback when done
 -- @param StartConfigurationRecorderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartConfigurationRecorderAsync(StartConfigurationRecorderRequest, cb)
 	assert(StartConfigurationRecorderRequest, "You must provide a StartConfigurationRecorderRequest")
 	local headers = {
@@ -7083,19 +7102,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartConfigurationRecorderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartConfigurationRecorderSync(StartConfigurationRecorderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartConfigurationRecorderAsync(StartConfigurationRecorderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartConfigurationRecorderAsync(StartConfigurationRecorderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePendingAggregationRequest asynchronously, invoking a callback when done
 -- @param DeletePendingAggregationRequestRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePendingAggregationRequestAsync(DeletePendingAggregationRequestRequest, cb)
 	assert(DeletePendingAggregationRequestRequest, "You must provide a DeletePendingAggregationRequestRequest")
 	local headers = {
@@ -7118,19 +7138,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePendingAggregationRequestRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePendingAggregationRequestSync(DeletePendingAggregationRequestRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePendingAggregationRequestAsync(DeletePendingAggregationRequestRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePendingAggregationRequestAsync(DeletePendingAggregationRequestRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDiscoveredResourceCounts asynchronously, invoking a callback when done
 -- @param GetDiscoveredResourceCountsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDiscoveredResourceCountsAsync(GetDiscoveredResourceCountsRequest, cb)
 	assert(GetDiscoveredResourceCountsRequest, "You must provide a GetDiscoveredResourceCountsRequest")
 	local headers = {
@@ -7153,19 +7174,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDiscoveredResourceCountsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDiscoveredResourceCountsSync(GetDiscoveredResourceCountsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDiscoveredResourceCountsAsync(GetDiscoveredResourceCountsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDiscoveredResourceCountsAsync(GetDiscoveredResourceCountsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetResourceConfig asynchronously, invoking a callback when done
 -- @param BatchGetResourceConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetResourceConfigAsync(BatchGetResourceConfigRequest, cb)
 	assert(BatchGetResourceConfigRequest, "You must provide a BatchGetResourceConfigRequest")
 	local headers = {
@@ -7188,19 +7210,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetResourceConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetResourceConfigSync(BatchGetResourceConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetResourceConfigAsync(BatchGetResourceConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetResourceConfigAsync(BatchGetResourceConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeComplianceByResource asynchronously, invoking a callback when done
 -- @param DescribeComplianceByResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeComplianceByResourceAsync(DescribeComplianceByResourceRequest, cb)
 	assert(DescribeComplianceByResourceRequest, "You must provide a DescribeComplianceByResourceRequest")
 	local headers = {
@@ -7223,19 +7246,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeComplianceByResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeComplianceByResourceSync(DescribeComplianceByResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeComplianceByResourceAsync(DescribeComplianceByResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeComplianceByResourceAsync(DescribeComplianceByResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResourceConfigHistory asynchronously, invoking a callback when done
 -- @param GetResourceConfigHistoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourceConfigHistoryAsync(GetResourceConfigHistoryRequest, cb)
 	assert(GetResourceConfigHistoryRequest, "You must provide a GetResourceConfigHistoryRequest")
 	local headers = {
@@ -7258,19 +7282,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourceConfigHistoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourceConfigHistorySync(GetResourceConfigHistoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourceConfigHistoryAsync(GetResourceConfigHistoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourceConfigHistoryAsync(GetResourceConfigHistoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationAggregatorSourcesStatus asynchronously, invoking a callback when done
 -- @param DescribeConfigurationAggregatorSourcesStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationAggregatorSourcesStatusAsync(DescribeConfigurationAggregatorSourcesStatusRequest, cb)
 	assert(DescribeConfigurationAggregatorSourcesStatusRequest, "You must provide a DescribeConfigurationAggregatorSourcesStatusRequest")
 	local headers = {
@@ -7293,19 +7318,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationAggregatorSourcesStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationAggregatorSourcesStatusSync(DescribeConfigurationAggregatorSourcesStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationAggregatorSourcesStatusAsync(DescribeConfigurationAggregatorSourcesStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationAggregatorSourcesStatusAsync(DescribeConfigurationAggregatorSourcesStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutAggregationAuthorization asynchronously, invoking a callback when done
 -- @param PutAggregationAuthorizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutAggregationAuthorizationAsync(PutAggregationAuthorizationRequest, cb)
 	assert(PutAggregationAuthorizationRequest, "You must provide a PutAggregationAuthorizationRequest")
 	local headers = {
@@ -7328,19 +7354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutAggregationAuthorizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutAggregationAuthorizationSync(PutAggregationAuthorizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutAggregationAuthorizationAsync(PutAggregationAuthorizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutAggregationAuthorizationAsync(PutAggregationAuthorizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigRuleEvaluationStatus asynchronously, invoking a callback when done
 -- @param DescribeConfigRuleEvaluationStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigRuleEvaluationStatusAsync(DescribeConfigRuleEvaluationStatusRequest, cb)
 	assert(DescribeConfigRuleEvaluationStatusRequest, "You must provide a DescribeConfigRuleEvaluationStatusRequest")
 	local headers = {
@@ -7363,19 +7390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigRuleEvaluationStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigRuleEvaluationStatusSync(DescribeConfigRuleEvaluationStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigRuleEvaluationStatusAsync(DescribeConfigRuleEvaluationStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigRuleEvaluationStatusAsync(DescribeConfigRuleEvaluationStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRetentionConfiguration asynchronously, invoking a callback when done
 -- @param PutRetentionConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRetentionConfigurationAsync(PutRetentionConfigurationRequest, cb)
 	assert(PutRetentionConfigurationRequest, "You must provide a PutRetentionConfigurationRequest")
 	local headers = {
@@ -7398,19 +7426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRetentionConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRetentionConfigurationSync(PutRetentionConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRetentionConfigurationAsync(PutRetentionConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRetentionConfigurationAsync(PutRetentionConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDeliveryChannels asynchronously, invoking a callback when done
 -- @param DescribeDeliveryChannelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDeliveryChannelsAsync(DescribeDeliveryChannelsRequest, cb)
 	assert(DescribeDeliveryChannelsRequest, "You must provide a DescribeDeliveryChannelsRequest")
 	local headers = {
@@ -7433,19 +7462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDeliveryChannelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDeliveryChannelsSync(DescribeDeliveryChannelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDeliveryChannelsAsync(DescribeDeliveryChannelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDeliveryChannelsAsync(DescribeDeliveryChannelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetComplianceSummaryByResourceType asynchronously, invoking a callback when done
 -- @param GetComplianceSummaryByResourceTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetComplianceSummaryByResourceTypeAsync(GetComplianceSummaryByResourceTypeRequest, cb)
 	assert(GetComplianceSummaryByResourceTypeRequest, "You must provide a GetComplianceSummaryByResourceTypeRequest")
 	local headers = {
@@ -7468,19 +7498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetComplianceSummaryByResourceTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetComplianceSummaryByResourceTypeSync(GetComplianceSummaryByResourceTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetComplianceSummaryByResourceTypeAsync(GetComplianceSummaryByResourceTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetComplianceSummaryByResourceTypeAsync(GetComplianceSummaryByResourceTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAggregateComplianceDetailsByConfigRule asynchronously, invoking a callback when done
 -- @param GetAggregateComplianceDetailsByConfigRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAggregateComplianceDetailsByConfigRuleAsync(GetAggregateComplianceDetailsByConfigRuleRequest, cb)
 	assert(GetAggregateComplianceDetailsByConfigRuleRequest, "You must provide a GetAggregateComplianceDetailsByConfigRuleRequest")
 	local headers = {
@@ -7503,19 +7534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAggregateComplianceDetailsByConfigRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAggregateComplianceDetailsByConfigRuleSync(GetAggregateComplianceDetailsByConfigRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAggregateComplianceDetailsByConfigRuleAsync(GetAggregateComplianceDetailsByConfigRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAggregateComplianceDetailsByConfigRuleAsync(GetAggregateComplianceDetailsByConfigRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePendingAggregationRequests asynchronously, invoking a callback when done
 -- @param DescribePendingAggregationRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePendingAggregationRequestsAsync(DescribePendingAggregationRequestsRequest, cb)
 	assert(DescribePendingAggregationRequestsRequest, "You must provide a DescribePendingAggregationRequestsRequest")
 	local headers = {
@@ -7538,19 +7570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePendingAggregationRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePendingAggregationRequestsSync(DescribePendingAggregationRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePendingAggregationRequestsAsync(DescribePendingAggregationRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePendingAggregationRequestsAsync(DescribePendingAggregationRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigRules asynchronously, invoking a callback when done
 -- @param DescribeConfigRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigRulesAsync(DescribeConfigRulesRequest, cb)
 	assert(DescribeConfigRulesRequest, "You must provide a DescribeConfigRulesRequest")
 	local headers = {
@@ -7573,19 +7606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigRulesSync(DescribeConfigRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigRulesAsync(DescribeConfigRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigRulesAsync(DescribeConfigRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAggregateComplianceByConfigRules asynchronously, invoking a callback when done
 -- @param DescribeAggregateComplianceByConfigRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAggregateComplianceByConfigRulesAsync(DescribeAggregateComplianceByConfigRulesRequest, cb)
 	assert(DescribeAggregateComplianceByConfigRulesRequest, "You must provide a DescribeAggregateComplianceByConfigRulesRequest")
 	local headers = {
@@ -7608,19 +7642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAggregateComplianceByConfigRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAggregateComplianceByConfigRulesSync(DescribeAggregateComplianceByConfigRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAggregateComplianceByConfigRulesAsync(DescribeAggregateComplianceByConfigRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAggregateComplianceByConfigRulesAsync(DescribeAggregateComplianceByConfigRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutConfigRule asynchronously, invoking a callback when done
 -- @param PutConfigRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutConfigRuleAsync(PutConfigRuleRequest, cb)
 	assert(PutConfigRuleRequest, "You must provide a PutConfigRuleRequest")
 	local headers = {
@@ -7643,19 +7678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutConfigRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutConfigRuleSync(PutConfigRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutConfigRuleAsync(PutConfigRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutConfigRuleAsync(PutConfigRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEvaluationResults asynchronously, invoking a callback when done
 -- @param DeleteEvaluationResultsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEvaluationResultsAsync(DeleteEvaluationResultsRequest, cb)
 	assert(DeleteEvaluationResultsRequest, "You must provide a DeleteEvaluationResultsRequest")
 	local headers = {
@@ -7678,19 +7714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEvaluationResultsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEvaluationResultsSync(DeleteEvaluationResultsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEvaluationResultsAsync(DeleteEvaluationResultsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEvaluationResultsAsync(DeleteEvaluationResultsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeComplianceByConfigRule asynchronously, invoking a callback when done
 -- @param DescribeComplianceByConfigRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeComplianceByConfigRuleAsync(DescribeComplianceByConfigRuleRequest, cb)
 	assert(DescribeComplianceByConfigRuleRequest, "You must provide a DescribeComplianceByConfigRuleRequest")
 	local headers = {
@@ -7713,19 +7750,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeComplianceByConfigRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeComplianceByConfigRuleSync(DescribeComplianceByConfigRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeComplianceByConfigRuleAsync(DescribeComplianceByConfigRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeComplianceByConfigRuleAsync(DescribeComplianceByConfigRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationAggregators asynchronously, invoking a callback when done
 -- @param DescribeConfigurationAggregatorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationAggregatorsAsync(DescribeConfigurationAggregatorsRequest, cb)
 	assert(DescribeConfigurationAggregatorsRequest, "You must provide a DescribeConfigurationAggregatorsRequest")
 	local headers = {
@@ -7748,19 +7786,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationAggregatorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationAggregatorsSync(DescribeConfigurationAggregatorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationAggregatorsAsync(DescribeConfigurationAggregatorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationAggregatorsAsync(DescribeConfigurationAggregatorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutDeliveryChannel asynchronously, invoking a callback when done
 -- @param PutDeliveryChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutDeliveryChannelAsync(PutDeliveryChannelRequest, cb)
 	assert(PutDeliveryChannelRequest, "You must provide a PutDeliveryChannelRequest")
 	local headers = {
@@ -7783,19 +7822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutDeliveryChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutDeliveryChannelSync(PutDeliveryChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutDeliveryChannelAsync(PutDeliveryChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutDeliveryChannelAsync(PutDeliveryChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRetentionConfigurations asynchronously, invoking a callback when done
 -- @param DescribeRetentionConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRetentionConfigurationsAsync(DescribeRetentionConfigurationsRequest, cb)
 	assert(DescribeRetentionConfigurationsRequest, "You must provide a DescribeRetentionConfigurationsRequest")
 	local headers = {
@@ -7818,19 +7858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRetentionConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRetentionConfigurationsSync(DescribeRetentionConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRetentionConfigurationsAsync(DescribeRetentionConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRetentionConfigurationsAsync(DescribeRetentionConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutConfigurationAggregator asynchronously, invoking a callback when done
 -- @param PutConfigurationAggregatorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutConfigurationAggregatorAsync(PutConfigurationAggregatorRequest, cb)
 	assert(PutConfigurationAggregatorRequest, "You must provide a PutConfigurationAggregatorRequest")
 	local headers = {
@@ -7853,19 +7894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutConfigurationAggregatorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutConfigurationAggregatorSync(PutConfigurationAggregatorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutConfigurationAggregatorAsync(PutConfigurationAggregatorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutConfigurationAggregatorAsync(PutConfigurationAggregatorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConfigurationRecorder asynchronously, invoking a callback when done
 -- @param DeleteConfigurationRecorderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConfigurationRecorderAsync(DeleteConfigurationRecorderRequest, cb)
 	assert(DeleteConfigurationRecorderRequest, "You must provide a DeleteConfigurationRecorderRequest")
 	local headers = {
@@ -7888,12 +7930,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConfigurationRecorderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConfigurationRecorderSync(DeleteConfigurationRecorderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConfigurationRecorderAsync(DeleteConfigurationRecorderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConfigurationRecorderAsync(DeleteConfigurationRecorderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/connect.lua
+++ b/aws-sdk/connect.lua
@@ -3283,7 +3283,7 @@ end
 --
 --- Call DescribeUserHierarchyStructure asynchronously, invoking a callback when done
 -- @param DescribeUserHierarchyStructureRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserHierarchyStructureAsync(DescribeUserHierarchyStructureRequest, cb)
 	assert(DescribeUserHierarchyStructureRequest, "You must provide a DescribeUserHierarchyStructureRequest")
 	local headers = {
@@ -3306,19 +3306,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserHierarchyStructureRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserHierarchyStructureSync(DescribeUserHierarchyStructureRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserHierarchyStructureAsync(DescribeUserHierarchyStructureRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserHierarchyStructureAsync(DescribeUserHierarchyStructureRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFederationToken asynchronously, invoking a callback when done
 -- @param GetFederationTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFederationTokenAsync(GetFederationTokenRequest, cb)
 	assert(GetFederationTokenRequest, "You must provide a GetFederationTokenRequest")
 	local headers = {
@@ -3341,19 +3342,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFederationTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFederationTokenSync(GetFederationTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFederationTokenAsync(GetFederationTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFederationTokenAsync(GetFederationTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -3376,19 +3378,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRoutingProfiles asynchronously, invoking a callback when done
 -- @param ListRoutingProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRoutingProfilesAsync(ListRoutingProfilesRequest, cb)
 	assert(ListRoutingProfilesRequest, "You must provide a ListRoutingProfilesRequest")
 	local headers = {
@@ -3411,19 +3414,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRoutingProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRoutingProfilesSync(ListRoutingProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRoutingProfilesAsync(ListRoutingProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRoutingProfilesAsync(ListRoutingProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSecurityProfiles asynchronously, invoking a callback when done
 -- @param ListSecurityProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSecurityProfilesAsync(ListSecurityProfilesRequest, cb)
 	assert(ListSecurityProfilesRequest, "You must provide a ListSecurityProfilesRequest")
 	local headers = {
@@ -3446,19 +3450,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSecurityProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSecurityProfilesSync(ListSecurityProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSecurityProfilesAsync(ListSecurityProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSecurityProfilesAsync(ListSecurityProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserIdentityInfo asynchronously, invoking a callback when done
 -- @param UpdateUserIdentityInfoRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserIdentityInfoAsync(UpdateUserIdentityInfoRequest, cb)
 	assert(UpdateUserIdentityInfoRequest, "You must provide a UpdateUserIdentityInfoRequest")
 	local headers = {
@@ -3481,19 +3486,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserIdentityInfoRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserIdentityInfoSync(UpdateUserIdentityInfoRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserIdentityInfoAsync(UpdateUserIdentityInfoRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserIdentityInfoAsync(UpdateUserIdentityInfoRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartOutboundVoiceContact asynchronously, invoking a callback when done
 -- @param StartOutboundVoiceContactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartOutboundVoiceContactAsync(StartOutboundVoiceContactRequest, cb)
 	assert(StartOutboundVoiceContactRequest, "You must provide a StartOutboundVoiceContactRequest")
 	local headers = {
@@ -3516,19 +3522,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartOutboundVoiceContactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartOutboundVoiceContactSync(StartOutboundVoiceContactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartOutboundVoiceContactAsync(StartOutboundVoiceContactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartOutboundVoiceContactAsync(StartOutboundVoiceContactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserHierarchy asynchronously, invoking a callback when done
 -- @param UpdateUserHierarchyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserHierarchyAsync(UpdateUserHierarchyRequest, cb)
 	assert(UpdateUserHierarchyRequest, "You must provide a UpdateUserHierarchyRequest")
 	local headers = {
@@ -3551,19 +3558,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserHierarchyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserHierarchySync(UpdateUserHierarchyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserHierarchyAsync(UpdateUserHierarchyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserHierarchyAsync(UpdateUserHierarchyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserSecurityProfiles asynchronously, invoking a callback when done
 -- @param UpdateUserSecurityProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserSecurityProfilesAsync(UpdateUserSecurityProfilesRequest, cb)
 	assert(UpdateUserSecurityProfilesRequest, "You must provide a UpdateUserSecurityProfilesRequest")
 	local headers = {
@@ -3586,19 +3594,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserSecurityProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserSecurityProfilesSync(UpdateUserSecurityProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserSecurityProfilesAsync(UpdateUserSecurityProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserSecurityProfilesAsync(UpdateUserSecurityProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserHierarchyGroup asynchronously, invoking a callback when done
 -- @param DescribeUserHierarchyGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserHierarchyGroupAsync(DescribeUserHierarchyGroupRequest, cb)
 	assert(DescribeUserHierarchyGroupRequest, "You must provide a DescribeUserHierarchyGroupRequest")
 	local headers = {
@@ -3621,19 +3630,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserHierarchyGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserHierarchyGroupSync(DescribeUserHierarchyGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserHierarchyGroupAsync(DescribeUserHierarchyGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserHierarchyGroupAsync(DescribeUserHierarchyGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCurrentMetricData asynchronously, invoking a callback when done
 -- @param GetCurrentMetricDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCurrentMetricDataAsync(GetCurrentMetricDataRequest, cb)
 	assert(GetCurrentMetricDataRequest, "You must provide a GetCurrentMetricDataRequest")
 	local headers = {
@@ -3656,19 +3666,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCurrentMetricDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCurrentMetricDataSync(GetCurrentMetricDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCurrentMetricDataAsync(GetCurrentMetricDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCurrentMetricDataAsync(GetCurrentMetricDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopContact asynchronously, invoking a callback when done
 -- @param StopContactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopContactAsync(StopContactRequest, cb)
 	assert(StopContactRequest, "You must provide a StopContactRequest")
 	local headers = {
@@ -3691,19 +3702,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopContactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopContactSync(StopContactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopContactAsync(StopContactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopContactAsync(StopContactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUser asynchronously, invoking a callback when done
 -- @param DescribeUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserAsync(DescribeUserRequest, cb)
 	assert(DescribeUserRequest, "You must provide a DescribeUserRequest")
 	local headers = {
@@ -3726,19 +3738,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserSync(DescribeUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserAsync(DescribeUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserAsync(DescribeUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserPhoneConfig asynchronously, invoking a callback when done
 -- @param UpdateUserPhoneConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserPhoneConfigAsync(UpdateUserPhoneConfigRequest, cb)
 	assert(UpdateUserPhoneConfigRequest, "You must provide a UpdateUserPhoneConfigRequest")
 	local headers = {
@@ -3761,19 +3774,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserPhoneConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserPhoneConfigSync(UpdateUserPhoneConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserPhoneConfigAsync(UpdateUserPhoneConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserPhoneConfigAsync(UpdateUserPhoneConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUsers asynchronously, invoking a callback when done
 -- @param ListUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUsersAsync(ListUsersRequest, cb)
 	assert(ListUsersRequest, "You must provide a ListUsersRequest")
 	local headers = {
@@ -3796,19 +3810,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUsersSync(ListUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUsersAsync(ListUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUsersAsync(ListUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUserHierarchyGroups asynchronously, invoking a callback when done
 -- @param ListUserHierarchyGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUserHierarchyGroupsAsync(ListUserHierarchyGroupsRequest, cb)
 	assert(ListUserHierarchyGroupsRequest, "You must provide a ListUserHierarchyGroupsRequest")
 	local headers = {
@@ -3831,19 +3846,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUserHierarchyGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUserHierarchyGroupsSync(ListUserHierarchyGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUserHierarchyGroupsAsync(ListUserHierarchyGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUserHierarchyGroupsAsync(ListUserHierarchyGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUser asynchronously, invoking a callback when done
 -- @param CreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserAsync(CreateUserRequest, cb)
 	assert(CreateUserRequest, "You must provide a CreateUserRequest")
 	local headers = {
@@ -3866,19 +3882,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserSync(CreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserAsync(CreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserAsync(CreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateContactAttributes asynchronously, invoking a callback when done
 -- @param UpdateContactAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateContactAttributesAsync(UpdateContactAttributesRequest, cb)
 	assert(UpdateContactAttributesRequest, "You must provide a UpdateContactAttributesRequest")
 	local headers = {
@@ -3901,19 +3918,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateContactAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateContactAttributesSync(UpdateContactAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateContactAttributesAsync(UpdateContactAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateContactAttributesAsync(UpdateContactAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserRoutingProfile asynchronously, invoking a callback when done
 -- @param UpdateUserRoutingProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserRoutingProfileAsync(UpdateUserRoutingProfileRequest, cb)
 	assert(UpdateUserRoutingProfileRequest, "You must provide a UpdateUserRoutingProfileRequest")
 	local headers = {
@@ -3936,19 +3954,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserRoutingProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserRoutingProfileSync(UpdateUserRoutingProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserRoutingProfileAsync(UpdateUserRoutingProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserRoutingProfileAsync(UpdateUserRoutingProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMetricData asynchronously, invoking a callback when done
 -- @param GetMetricDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMetricDataAsync(GetMetricDataRequest, cb)
 	assert(GetMetricDataRequest, "You must provide a GetMetricDataRequest")
 	local headers = {
@@ -3971,12 +3990,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMetricDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMetricDataSync(GetMetricDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMetricDataAsync(GetMetricDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMetricDataAsync(GetMetricDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/core/request_handlers/json.lua
+++ b/aws-sdk/core/request_handlers/json.lua
@@ -36,12 +36,12 @@ function M.post(base_uri, request_uri, args, headers, settings, cb)
 		headers[request_headers.HOST_HEADER] = nil
 	end
 
-	config.http_request(base_uri .. request_uri, "POST", headers, post_data, function(response)
+	config.http_request(base_uri .. request_uri, "POST", headers, post_data, function (response)
+		local data = assert(json.decode(response.response))
 		if response.status >= 200 and response.status < 300 then
-			cb(json.decode(response.response))
+			cb(data)
 		else
-			pprint(response)
-			cb(false, "Error")
+			cb(false, data.__type, data.Message)
 		end
 	end)
 end

--- a/aws-sdk/core/request_handlers/rest_json.lua
+++ b/aws-sdk/core/request_handlers/rest_json.lua
@@ -34,12 +34,11 @@ function M.get(base_uri, request_uri, args, headers, settings, cb)
 	end
 
 	config.http_request(base_uri .. request_uri, "GET", headers, nil, function(response)
+		local data = assert(json.decode(response.response))
 		if response.status >= 200 and response.status < 300 then
-			print(response.response)
-			cb(json.decode(response.response))
+			cb(data)
 		else
-			pprint(response)
-			cb(false, "Error")
+			cb(false, data.__type, data.Message)
 		end
 	end)
 end

--- a/aws-sdk/core/request_handlers/rest_xml.lua
+++ b/aws-sdk/core/request_handlers/rest_xml.lua
@@ -34,13 +34,11 @@ function M.get(base_uri, request_uri, args, headers, settings, cb)
 	end
 
 	config.http_request(base_uri .. request_uri, "GET", headers, nil, function(response)
+		local data = assert(xml.parse(response.response))
 		if response.status >= 200 and response.status < 300 then
-			local r = xml.parse(response.response)
-			print(response.response)
-			cb(response.response)
+			cb(data)
 		else
-			pprint(response)
-			cb(false, "Error")
+			cb(false, data.__type, data.Message)
 		end
 	end)
 end

--- a/aws-sdk/cur.lua
+++ b/aws-sdk/cur.lua
@@ -711,7 +711,7 @@ end
 --
 --- Call DescribeReportDefinitions asynchronously, invoking a callback when done
 -- @param DescribeReportDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReportDefinitionsAsync(DescribeReportDefinitionsRequest, cb)
 	assert(DescribeReportDefinitionsRequest, "You must provide a DescribeReportDefinitionsRequest")
 	local headers = {
@@ -734,19 +734,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReportDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReportDefinitionsSync(DescribeReportDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReportDefinitionsAsync(DescribeReportDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReportDefinitionsAsync(DescribeReportDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutReportDefinition asynchronously, invoking a callback when done
 -- @param PutReportDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutReportDefinitionAsync(PutReportDefinitionRequest, cb)
 	assert(PutReportDefinitionRequest, "You must provide a PutReportDefinitionRequest")
 	local headers = {
@@ -769,19 +770,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutReportDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutReportDefinitionSync(PutReportDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutReportDefinitionAsync(PutReportDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutReportDefinitionAsync(PutReportDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReportDefinition asynchronously, invoking a callback when done
 -- @param DeleteReportDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReportDefinitionAsync(DeleteReportDefinitionRequest, cb)
 	assert(DeleteReportDefinitionRequest, "You must provide a DeleteReportDefinitionRequest")
 	local headers = {
@@ -804,12 +806,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReportDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReportDefinitionSync(DeleteReportDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReportDefinitionAsync(DeleteReportDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReportDefinitionAsync(DeleteReportDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/data_iot.lua
+++ b/aws-sdk/data_iot.lua
@@ -799,7 +799,7 @@ end
 --
 --- Call UpdateThingShadow asynchronously, invoking a callback when done
 -- @param UpdateThingShadowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateThingShadowAsync(UpdateThingShadowRequest, cb)
 	assert(UpdateThingShadowRequest, "You must provide a UpdateThingShadowRequest")
 	local headers = {
@@ -822,19 +822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateThingShadowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateThingShadowSync(UpdateThingShadowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateThingShadowAsync(UpdateThingShadowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateThingShadowAsync(UpdateThingShadowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetThingShadow asynchronously, invoking a callback when done
 -- @param GetThingShadowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetThingShadowAsync(GetThingShadowRequest, cb)
 	assert(GetThingShadowRequest, "You must provide a GetThingShadowRequest")
 	local headers = {
@@ -857,19 +858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetThingShadowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetThingShadowSync(GetThingShadowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetThingShadowAsync(GetThingShadowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetThingShadowAsync(GetThingShadowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Publish asynchronously, invoking a callback when done
 -- @param PublishRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PublishAsync(PublishRequest, cb)
 	assert(PublishRequest, "You must provide a PublishRequest")
 	local headers = {
@@ -892,19 +894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PublishRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PublishSync(PublishRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PublishAsync(PublishRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PublishAsync(PublishRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteThingShadow asynchronously, invoking a callback when done
 -- @param DeleteThingShadowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteThingShadowAsync(DeleteThingShadowRequest, cb)
 	assert(DeleteThingShadowRequest, "You must provide a DeleteThingShadowRequest")
 	local headers = {
@@ -927,12 +930,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteThingShadowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteThingShadowSync(DeleteThingShadowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteThingShadowAsync(DeleteThingShadowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteThingShadowAsync(DeleteThingShadowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/data_jobs_iot.lua
+++ b/aws-sdk/data_jobs_iot.lua
@@ -814,7 +814,7 @@ end
 --
 --- Call GetPendingJobExecutions asynchronously, invoking a callback when done
 -- @param GetPendingJobExecutionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPendingJobExecutionsAsync(GetPendingJobExecutionsRequest, cb)
 	assert(GetPendingJobExecutionsRequest, "You must provide a GetPendingJobExecutionsRequest")
 	local headers = {
@@ -837,19 +837,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPendingJobExecutionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPendingJobExecutionsSync(GetPendingJobExecutionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPendingJobExecutionsAsync(GetPendingJobExecutionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPendingJobExecutionsAsync(GetPendingJobExecutionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartNextPendingJobExecution asynchronously, invoking a callback when done
 -- @param StartNextPendingJobExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartNextPendingJobExecutionAsync(StartNextPendingJobExecutionRequest, cb)
 	assert(StartNextPendingJobExecutionRequest, "You must provide a StartNextPendingJobExecutionRequest")
 	local headers = {
@@ -872,19 +873,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartNextPendingJobExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartNextPendingJobExecutionSync(StartNextPendingJobExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartNextPendingJobExecutionAsync(StartNextPendingJobExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartNextPendingJobExecutionAsync(StartNextPendingJobExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateJobExecution asynchronously, invoking a callback when done
 -- @param UpdateJobExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateJobExecutionAsync(UpdateJobExecutionRequest, cb)
 	assert(UpdateJobExecutionRequest, "You must provide a UpdateJobExecutionRequest")
 	local headers = {
@@ -907,19 +909,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateJobExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateJobExecutionSync(UpdateJobExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateJobExecutionAsync(UpdateJobExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateJobExecutionAsync(UpdateJobExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJobExecution asynchronously, invoking a callback when done
 -- @param DescribeJobExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobExecutionAsync(DescribeJobExecutionRequest, cb)
 	assert(DescribeJobExecutionRequest, "You must provide a DescribeJobExecutionRequest")
 	local headers = {
@@ -942,12 +945,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobExecutionSync(DescribeJobExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobExecutionAsync(DescribeJobExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobExecutionAsync(DescribeJobExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/data_mediastore.lua
+++ b/aws-sdk/data_mediastore.lua
@@ -793,7 +793,7 @@ end
 --
 --- Call GetObject asynchronously, invoking a callback when done
 -- @param GetObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetObjectAsync(GetObjectRequest, cb)
 	assert(GetObjectRequest, "You must provide a GetObjectRequest")
 	local headers = {
@@ -816,19 +816,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetObjectSync(GetObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetObjectAsync(GetObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetObjectAsync(GetObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeObject asynchronously, invoking a callback when done
 -- @param DescribeObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeObjectAsync(DescribeObjectRequest, cb)
 	assert(DescribeObjectRequest, "You must provide a DescribeObjectRequest")
 	local headers = {
@@ -851,19 +852,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeObjectSync(DescribeObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeObjectAsync(DescribeObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeObjectAsync(DescribeObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutObject asynchronously, invoking a callback when done
 -- @param PutObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutObjectAsync(PutObjectRequest, cb)
 	assert(PutObjectRequest, "You must provide a PutObjectRequest")
 	local headers = {
@@ -886,19 +888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutObjectSync(PutObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutObjectAsync(PutObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutObjectAsync(PutObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteObject asynchronously, invoking a callback when done
 -- @param DeleteObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteObjectAsync(DeleteObjectRequest, cb)
 	assert(DeleteObjectRequest, "You must provide a DeleteObjectRequest")
 	local headers = {
@@ -921,19 +924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteObjectSync(DeleteObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteObjectAsync(DeleteObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteObjectAsync(DeleteObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListItems asynchronously, invoking a callback when done
 -- @param ListItemsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListItemsAsync(ListItemsRequest, cb)
 	assert(ListItemsRequest, "You must provide a ListItemsRequest")
 	local headers = {
@@ -956,12 +960,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListItemsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListItemsSync(ListItemsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListItemsAsync(ListItemsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListItemsAsync(ListItemsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/datapipeline.lua
+++ b/aws-sdk/datapipeline.lua
@@ -2871,7 +2871,7 @@ end
 --
 --- Call RemoveTags asynchronously, invoking a callback when done
 -- @param RemoveTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsAsync(RemoveTagsInput, cb)
 	assert(RemoveTagsInput, "You must provide a RemoveTagsInput")
 	local headers = {
@@ -2894,19 +2894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsSync(RemoveTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsAsync(RemoveTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsAsync(RemoveTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeactivatePipeline asynchronously, invoking a callback when done
 -- @param DeactivatePipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeactivatePipelineAsync(DeactivatePipelineInput, cb)
 	assert(DeactivatePipelineInput, "You must provide a DeactivatePipelineInput")
 	local headers = {
@@ -2929,19 +2930,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeactivatePipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeactivatePipelineSync(DeactivatePipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeactivatePipelineAsync(DeactivatePipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeactivatePipelineAsync(DeactivatePipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTags asynchronously, invoking a callback when done
 -- @param AddTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsAsync(AddTagsInput, cb)
 	assert(AddTagsInput, "You must provide a AddTagsInput")
 	local headers = {
@@ -2964,19 +2966,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsSync(AddTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsAsync(AddTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsAsync(AddTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ValidatePipelineDefinition asynchronously, invoking a callback when done
 -- @param ValidatePipelineDefinitionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ValidatePipelineDefinitionAsync(ValidatePipelineDefinitionInput, cb)
 	assert(ValidatePipelineDefinitionInput, "You must provide a ValidatePipelineDefinitionInput")
 	local headers = {
@@ -2999,19 +3002,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ValidatePipelineDefinitionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ValidatePipelineDefinitionSync(ValidatePipelineDefinitionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ValidatePipelineDefinitionAsync(ValidatePipelineDefinitionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ValidatePipelineDefinitionAsync(ValidatePipelineDefinitionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPipelines asynchronously, invoking a callback when done
 -- @param ListPipelinesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPipelinesAsync(ListPipelinesInput, cb)
 	assert(ListPipelinesInput, "You must provide a ListPipelinesInput")
 	local headers = {
@@ -3034,19 +3038,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPipelinesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPipelinesSync(ListPipelinesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPipelinesAsync(ListPipelinesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPipelinesAsync(ListPipelinesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePipeline asynchronously, invoking a callback when done
 -- @param DeletePipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePipelineAsync(DeletePipelineInput, cb)
 	assert(DeletePipelineInput, "You must provide a DeletePipelineInput")
 	local headers = {
@@ -3069,19 +3074,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePipelineSync(DeletePipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePipelineAsync(DeletePipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePipelineAsync(DeletePipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeObjects asynchronously, invoking a callback when done
 -- @param DescribeObjectsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeObjectsAsync(DescribeObjectsInput, cb)
 	assert(DescribeObjectsInput, "You must provide a DescribeObjectsInput")
 	local headers = {
@@ -3104,19 +3110,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeObjectsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeObjectsSync(DescribeObjectsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeObjectsAsync(DescribeObjectsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeObjectsAsync(DescribeObjectsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call QueryObjects asynchronously, invoking a callback when done
 -- @param QueryObjectsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.QueryObjectsAsync(QueryObjectsInput, cb)
 	assert(QueryObjectsInput, "You must provide a QueryObjectsInput")
 	local headers = {
@@ -3139,19 +3146,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param QueryObjectsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.QueryObjectsSync(QueryObjectsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.QueryObjectsAsync(QueryObjectsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.QueryObjectsAsync(QueryObjectsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetStatus asynchronously, invoking a callback when done
 -- @param SetStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetStatusAsync(SetStatusInput, cb)
 	assert(SetStatusInput, "You must provide a SetStatusInput")
 	local headers = {
@@ -3174,19 +3182,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetStatusSync(SetStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetStatusAsync(SetStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetStatusAsync(SetStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetTaskStatus asynchronously, invoking a callback when done
 -- @param SetTaskStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetTaskStatusAsync(SetTaskStatusInput, cb)
 	assert(SetTaskStatusInput, "You must provide a SetTaskStatusInput")
 	local headers = {
@@ -3209,19 +3218,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetTaskStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetTaskStatusSync(SetTaskStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetTaskStatusAsync(SetTaskStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetTaskStatusAsync(SetTaskStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutPipelineDefinition asynchronously, invoking a callback when done
 -- @param PutPipelineDefinitionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutPipelineDefinitionAsync(PutPipelineDefinitionInput, cb)
 	assert(PutPipelineDefinitionInput, "You must provide a PutPipelineDefinitionInput")
 	local headers = {
@@ -3244,19 +3254,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutPipelineDefinitionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutPipelineDefinitionSync(PutPipelineDefinitionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutPipelineDefinitionAsync(PutPipelineDefinitionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutPipelineDefinitionAsync(PutPipelineDefinitionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PollForTask asynchronously, invoking a callback when done
 -- @param PollForTaskInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PollForTaskAsync(PollForTaskInput, cb)
 	assert(PollForTaskInput, "You must provide a PollForTaskInput")
 	local headers = {
@@ -3279,19 +3290,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PollForTaskInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PollForTaskSync(PollForTaskInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PollForTaskAsync(PollForTaskInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PollForTaskAsync(PollForTaskInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ActivatePipeline asynchronously, invoking a callback when done
 -- @param ActivatePipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ActivatePipelineAsync(ActivatePipelineInput, cb)
 	assert(ActivatePipelineInput, "You must provide a ActivatePipelineInput")
 	local headers = {
@@ -3314,19 +3326,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ActivatePipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ActivatePipelineSync(ActivatePipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ActivatePipelineAsync(ActivatePipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ActivatePipelineAsync(ActivatePipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePipeline asynchronously, invoking a callback when done
 -- @param CreatePipelineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePipelineAsync(CreatePipelineInput, cb)
 	assert(CreatePipelineInput, "You must provide a CreatePipelineInput")
 	local headers = {
@@ -3349,19 +3362,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePipelineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePipelineSync(CreatePipelineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePipelineAsync(CreatePipelineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePipelineAsync(CreatePipelineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EvaluateExpression asynchronously, invoking a callback when done
 -- @param EvaluateExpressionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EvaluateExpressionAsync(EvaluateExpressionInput, cb)
 	assert(EvaluateExpressionInput, "You must provide a EvaluateExpressionInput")
 	local headers = {
@@ -3384,19 +3398,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EvaluateExpressionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EvaluateExpressionSync(EvaluateExpressionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EvaluateExpressionAsync(EvaluateExpressionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EvaluateExpressionAsync(EvaluateExpressionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPipelineDefinition asynchronously, invoking a callback when done
 -- @param GetPipelineDefinitionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPipelineDefinitionAsync(GetPipelineDefinitionInput, cb)
 	assert(GetPipelineDefinitionInput, "You must provide a GetPipelineDefinitionInput")
 	local headers = {
@@ -3419,19 +3434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPipelineDefinitionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPipelineDefinitionSync(GetPipelineDefinitionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPipelineDefinitionAsync(GetPipelineDefinitionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPipelineDefinitionAsync(GetPipelineDefinitionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReportTaskProgress asynchronously, invoking a callback when done
 -- @param ReportTaskProgressInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReportTaskProgressAsync(ReportTaskProgressInput, cb)
 	assert(ReportTaskProgressInput, "You must provide a ReportTaskProgressInput")
 	local headers = {
@@ -3454,19 +3470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReportTaskProgressInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReportTaskProgressSync(ReportTaskProgressInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReportTaskProgressAsync(ReportTaskProgressInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReportTaskProgressAsync(ReportTaskProgressInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReportTaskRunnerHeartbeat asynchronously, invoking a callback when done
 -- @param ReportTaskRunnerHeartbeatInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReportTaskRunnerHeartbeatAsync(ReportTaskRunnerHeartbeatInput, cb)
 	assert(ReportTaskRunnerHeartbeatInput, "You must provide a ReportTaskRunnerHeartbeatInput")
 	local headers = {
@@ -3489,19 +3506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReportTaskRunnerHeartbeatInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReportTaskRunnerHeartbeatSync(ReportTaskRunnerHeartbeatInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReportTaskRunnerHeartbeatAsync(ReportTaskRunnerHeartbeatInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReportTaskRunnerHeartbeatAsync(ReportTaskRunnerHeartbeatInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePipelines asynchronously, invoking a callback when done
 -- @param DescribePipelinesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePipelinesAsync(DescribePipelinesInput, cb)
 	assert(DescribePipelinesInput, "You must provide a DescribePipelinesInput")
 	local headers = {
@@ -3524,12 +3542,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePipelinesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePipelinesSync(DescribePipelinesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePipelinesAsync(DescribePipelinesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePipelinesAsync(DescribePipelinesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/dax.lua
+++ b/aws-sdk/dax.lua
@@ -2965,7 +2965,7 @@ end
 --
 --- Call CreateParameterGroup asynchronously, invoking a callback when done
 -- @param CreateParameterGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateParameterGroupAsync(CreateParameterGroupRequest, cb)
 	assert(CreateParameterGroupRequest, "You must provide a CreateParameterGroupRequest")
 	local headers = {
@@ -2988,19 +2988,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateParameterGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateParameterGroupSync(CreateParameterGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateParameterGroupAsync(CreateParameterGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateParameterGroupAsync(CreateParameterGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteParameterGroup asynchronously, invoking a callback when done
 -- @param DeleteParameterGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteParameterGroupAsync(DeleteParameterGroupRequest, cb)
 	assert(DeleteParameterGroupRequest, "You must provide a DeleteParameterGroupRequest")
 	local headers = {
@@ -3023,19 +3024,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteParameterGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteParameterGroupSync(DeleteParameterGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteParameterGroupAsync(DeleteParameterGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteParameterGroupAsync(DeleteParameterGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCluster asynchronously, invoking a callback when done
 -- @param UpdateClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateClusterAsync(UpdateClusterRequest, cb)
 	assert(UpdateClusterRequest, "You must provide a UpdateClusterRequest")
 	local headers = {
@@ -3058,19 +3060,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateClusterSync(UpdateClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateClusterAsync(UpdateClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateClusterAsync(UpdateClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -3093,19 +3096,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCluster asynchronously, invoking a callback when done
 -- @param CreateClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterAsync(CreateClusterRequest, cb)
 	assert(CreateClusterRequest, "You must provide a CreateClusterRequest")
 	local headers = {
@@ -3128,19 +3132,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSync(CreateClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterAsync(CreateClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterAsync(CreateClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSubnetGroups asynchronously, invoking a callback when done
 -- @param DescribeSubnetGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSubnetGroupsAsync(DescribeSubnetGroupsRequest, cb)
 	assert(DescribeSubnetGroupsRequest, "You must provide a DescribeSubnetGroupsRequest")
 	local headers = {
@@ -3163,19 +3168,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSubnetGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSubnetGroupsSync(DescribeSubnetGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSubnetGroupsAsync(DescribeSubnetGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSubnetGroupsAsync(DescribeSubnetGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call IncreaseReplicationFactor asynchronously, invoking a callback when done
 -- @param IncreaseReplicationFactorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.IncreaseReplicationFactorAsync(IncreaseReplicationFactorRequest, cb)
 	assert(IncreaseReplicationFactorRequest, "You must provide a IncreaseReplicationFactorRequest")
 	local headers = {
@@ -3198,19 +3204,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IncreaseReplicationFactorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.IncreaseReplicationFactorSync(IncreaseReplicationFactorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.IncreaseReplicationFactorAsync(IncreaseReplicationFactorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.IncreaseReplicationFactorAsync(IncreaseReplicationFactorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -3233,19 +3240,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSubnetGroup asynchronously, invoking a callback when done
 -- @param UpdateSubnetGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSubnetGroupAsync(UpdateSubnetGroupRequest, cb)
 	assert(UpdateSubnetGroupRequest, "You must provide a UpdateSubnetGroupRequest")
 	local headers = {
@@ -3268,19 +3276,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSubnetGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSubnetGroupSync(UpdateSubnetGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSubnetGroupAsync(UpdateSubnetGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSubnetGroupAsync(UpdateSubnetGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeParameters asynchronously, invoking a callback when done
 -- @param DescribeParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeParametersAsync(DescribeParametersRequest, cb)
 	assert(DescribeParametersRequest, "You must provide a DescribeParametersRequest")
 	local headers = {
@@ -3303,19 +3312,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeParametersSync(DescribeParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeParametersAsync(DescribeParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeParametersAsync(DescribeParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DecreaseReplicationFactor asynchronously, invoking a callback when done
 -- @param DecreaseReplicationFactorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DecreaseReplicationFactorAsync(DecreaseReplicationFactorRequest, cb)
 	assert(DecreaseReplicationFactorRequest, "You must provide a DecreaseReplicationFactorRequest")
 	local headers = {
@@ -3338,19 +3348,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DecreaseReplicationFactorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DecreaseReplicationFactorSync(DecreaseReplicationFactorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DecreaseReplicationFactorAsync(DecreaseReplicationFactorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DecreaseReplicationFactorAsync(DecreaseReplicationFactorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootNode asynchronously, invoking a callback when done
 -- @param RebootNodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootNodeAsync(RebootNodeRequest, cb)
 	assert(RebootNodeRequest, "You must provide a RebootNodeRequest")
 	local headers = {
@@ -3373,19 +3384,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootNodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootNodeSync(RebootNodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootNodeAsync(RebootNodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootNodeAsync(RebootNodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSubnetGroup asynchronously, invoking a callback when done
 -- @param CreateSubnetGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSubnetGroupAsync(CreateSubnetGroupRequest, cb)
 	assert(CreateSubnetGroupRequest, "You must provide a CreateSubnetGroupRequest")
 	local headers = {
@@ -3408,19 +3420,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSubnetGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSubnetGroupSync(CreateSubnetGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSubnetGroupAsync(CreateSubnetGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSubnetGroupAsync(CreateSubnetGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateParameterGroup asynchronously, invoking a callback when done
 -- @param UpdateParameterGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateParameterGroupAsync(UpdateParameterGroupRequest, cb)
 	assert(UpdateParameterGroupRequest, "You must provide a UpdateParameterGroupRequest")
 	local headers = {
@@ -3443,19 +3456,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateParameterGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateParameterGroupSync(UpdateParameterGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateParameterGroupAsync(UpdateParameterGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateParameterGroupAsync(UpdateParameterGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -3478,19 +3492,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsRequest, cb)
 	assert(DescribeEventsRequest, "You must provide a DescribeEventsRequest")
 	local headers = {
@@ -3513,19 +3528,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSubnetGroup asynchronously, invoking a callback when done
 -- @param DeleteSubnetGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSubnetGroupAsync(DeleteSubnetGroupRequest, cb)
 	assert(DeleteSubnetGroupRequest, "You must provide a DeleteSubnetGroupRequest")
 	local headers = {
@@ -3548,19 +3564,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSubnetGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSubnetGroupSync(DeleteSubnetGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSubnetGroupAsync(DeleteSubnetGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSubnetGroupAsync(DeleteSubnetGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDefaultParameters asynchronously, invoking a callback when done
 -- @param DescribeDefaultParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDefaultParametersAsync(DescribeDefaultParametersRequest, cb)
 	assert(DescribeDefaultParametersRequest, "You must provide a DescribeDefaultParametersRequest")
 	local headers = {
@@ -3583,19 +3600,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDefaultParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDefaultParametersSync(DescribeDefaultParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDefaultParametersAsync(DescribeDefaultParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDefaultParametersAsync(DescribeDefaultParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusters asynchronously, invoking a callback when done
 -- @param DescribeClustersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClustersAsync(DescribeClustersRequest, cb)
 	assert(DescribeClustersRequest, "You must provide a DescribeClustersRequest")
 	local headers = {
@@ -3618,19 +3636,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClustersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClustersSync(DescribeClustersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClustersAsync(DescribeClustersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClustersAsync(DescribeClustersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeParameterGroups asynchronously, invoking a callback when done
 -- @param DescribeParameterGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeParameterGroupsAsync(DescribeParameterGroupsRequest, cb)
 	assert(DescribeParameterGroupsRequest, "You must provide a DescribeParameterGroupsRequest")
 	local headers = {
@@ -3653,19 +3672,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeParameterGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeParameterGroupsSync(DescribeParameterGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeParameterGroupsAsync(DescribeParameterGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeParameterGroupsAsync(DescribeParameterGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCluster asynchronously, invoking a callback when done
 -- @param DeleteClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterAsync(DeleteClusterRequest, cb)
 	assert(DeleteClusterRequest, "You must provide a DeleteClusterRequest")
 	local headers = {
@@ -3688,12 +3708,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSync(DeleteClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/devicefarm.lua
+++ b/aws-sdk/devicefarm.lua
@@ -8798,7 +8798,7 @@ end
 --
 --- Call ListSamples asynchronously, invoking a callback when done
 -- @param ListSamplesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSamplesAsync(ListSamplesRequest, cb)
 	assert(ListSamplesRequest, "You must provide a ListSamplesRequest")
 	local headers = {
@@ -8821,19 +8821,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSamplesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSamplesSync(ListSamplesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSamplesAsync(ListSamplesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSamplesAsync(ListSamplesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseOffering asynchronously, invoking a callback when done
 -- @param PurchaseOfferingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseOfferingAsync(PurchaseOfferingRequest, cb)
 	assert(PurchaseOfferingRequest, "You must provide a PurchaseOfferingRequest")
 	local headers = {
@@ -8856,19 +8857,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseOfferingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseOfferingSync(PurchaseOfferingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseOfferingAsync(PurchaseOfferingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseOfferingAsync(PurchaseOfferingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUpload asynchronously, invoking a callback when done
 -- @param GetUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUploadAsync(GetUploadRequest, cb)
 	assert(GetUploadRequest, "You must provide a GetUploadRequest")
 	local headers = {
@@ -8891,19 +8893,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUploadSync(GetUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUploadAsync(GetUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUploadAsync(GetUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOfferingPromotions asynchronously, invoking a callback when done
 -- @param ListOfferingPromotionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOfferingPromotionsAsync(ListOfferingPromotionsRequest, cb)
 	assert(ListOfferingPromotionsRequest, "You must provide a ListOfferingPromotionsRequest")
 	local headers = {
@@ -8926,19 +8929,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOfferingPromotionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOfferingPromotionsSync(ListOfferingPromotionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOfferingPromotionsAsync(ListOfferingPromotionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOfferingPromotionsAsync(ListOfferingPromotionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDevicePool asynchronously, invoking a callback when done
 -- @param UpdateDevicePoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDevicePoolAsync(UpdateDevicePoolRequest, cb)
 	assert(UpdateDevicePoolRequest, "You must provide a UpdateDevicePoolRequest")
 	local headers = {
@@ -8961,19 +8965,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDevicePoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDevicePoolSync(UpdateDevicePoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDevicePoolAsync(UpdateDevicePoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDevicePoolAsync(UpdateDevicePoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopRun asynchronously, invoking a callback when done
 -- @param StopRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopRunAsync(StopRunRequest, cb)
 	assert(StopRunRequest, "You must provide a StopRunRequest")
 	local headers = {
@@ -8996,19 +9001,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopRunSync(StopRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopRunAsync(StopRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopRunAsync(StopRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRemoteAccessSession asynchronously, invoking a callback when done
 -- @param CreateRemoteAccessSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRemoteAccessSessionAsync(CreateRemoteAccessSessionRequest, cb)
 	assert(CreateRemoteAccessSessionRequest, "You must provide a CreateRemoteAccessSessionRequest")
 	local headers = {
@@ -9031,19 +9037,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRemoteAccessSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRemoteAccessSessionSync(CreateRemoteAccessSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRemoteAccessSessionAsync(CreateRemoteAccessSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRemoteAccessSessionAsync(CreateRemoteAccessSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInstanceProfile asynchronously, invoking a callback when done
 -- @param DeleteInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInstanceProfileAsync(DeleteInstanceProfileRequest, cb)
 	assert(DeleteInstanceProfileRequest, "You must provide a DeleteInstanceProfileRequest")
 	local headers = {
@@ -9066,19 +9073,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInstanceProfileSync(DeleteInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInstanceProfileAsync(DeleteInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInstanceProfileAsync(DeleteInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOfferings asynchronously, invoking a callback when done
 -- @param ListOfferingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOfferingsAsync(ListOfferingsRequest, cb)
 	assert(ListOfferingsRequest, "You must provide a ListOfferingsRequest")
 	local headers = {
@@ -9101,19 +9109,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOfferingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOfferingsSync(ListOfferingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOfferingsAsync(ListOfferingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOfferingsAsync(ListOfferingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeviceInstances asynchronously, invoking a callback when done
 -- @param ListDeviceInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeviceInstancesAsync(ListDeviceInstancesRequest, cb)
 	assert(ListDeviceInstancesRequest, "You must provide a ListDeviceInstancesRequest")
 	local headers = {
@@ -9136,19 +9145,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeviceInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeviceInstancesSync(ListDeviceInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeviceInstancesAsync(ListDeviceInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeviceInstancesAsync(ListDeviceInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTest asynchronously, invoking a callback when done
 -- @param GetTestRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTestAsync(GetTestRequest, cb)
 	assert(GetTestRequest, "You must provide a GetTestRequest")
 	local headers = {
@@ -9171,19 +9181,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTestRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTestSync(GetTestRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTestAsync(GetTestRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTestAsync(GetTestRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNetworkProfile asynchronously, invoking a callback when done
 -- @param DeleteNetworkProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNetworkProfileAsync(DeleteNetworkProfileRequest, cb)
 	assert(DeleteNetworkProfileRequest, "You must provide a DeleteNetworkProfileRequest")
 	local headers = {
@@ -9206,19 +9217,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNetworkProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNetworkProfileSync(DeleteNetworkProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNetworkProfileAsync(DeleteNetworkProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNetworkProfileAsync(DeleteNetworkProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProjects asynchronously, invoking a callback when done
 -- @param ListProjectsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProjectsAsync(ListProjectsRequest, cb)
 	assert(ListProjectsRequest, "You must provide a ListProjectsRequest")
 	local headers = {
@@ -9241,19 +9253,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProjectsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProjectsSync(ListProjectsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProjectsAsync(ListProjectsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProjectsAsync(ListProjectsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListNetworkProfiles asynchronously, invoking a callback when done
 -- @param ListNetworkProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListNetworkProfilesAsync(ListNetworkProfilesRequest, cb)
 	assert(ListNetworkProfilesRequest, "You must provide a ListNetworkProfilesRequest")
 	local headers = {
@@ -9276,19 +9289,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListNetworkProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListNetworkProfilesSync(ListNetworkProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListNetworkProfilesAsync(ListNetworkProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListNetworkProfilesAsync(ListNetworkProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateInstanceProfile asynchronously, invoking a callback when done
 -- @param UpdateInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateInstanceProfileAsync(UpdateInstanceProfileRequest, cb)
 	assert(UpdateInstanceProfileRequest, "You must provide a UpdateInstanceProfileRequest")
 	local headers = {
@@ -9311,19 +9325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateInstanceProfileSync(UpdateInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateInstanceProfileAsync(UpdateInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateInstanceProfileAsync(UpdateInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateVPCEConfiguration asynchronously, invoking a callback when done
 -- @param UpdateVPCEConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateVPCEConfigurationAsync(UpdateVPCEConfigurationRequest, cb)
 	assert(UpdateVPCEConfigurationRequest, "You must provide a UpdateVPCEConfigurationRequest")
 	local headers = {
@@ -9346,19 +9361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateVPCEConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateVPCEConfigurationSync(UpdateVPCEConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateVPCEConfigurationAsync(UpdateVPCEConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateVPCEConfigurationAsync(UpdateVPCEConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUpload asynchronously, invoking a callback when done
 -- @param DeleteUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUploadAsync(DeleteUploadRequest, cb)
 	assert(DeleteUploadRequest, "You must provide a DeleteUploadRequest")
 	local headers = {
@@ -9381,19 +9397,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUploadSync(DeleteUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUploadAsync(DeleteUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUploadAsync(DeleteUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSuite asynchronously, invoking a callback when done
 -- @param GetSuiteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSuiteAsync(GetSuiteRequest, cb)
 	assert(GetSuiteRequest, "You must provide a GetSuiteRequest")
 	local headers = {
@@ -9416,19 +9433,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSuiteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSuiteSync(GetSuiteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSuiteAsync(GetSuiteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSuiteAsync(GetSuiteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRemoteAccessSession asynchronously, invoking a callback when done
 -- @param DeleteRemoteAccessSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRemoteAccessSessionAsync(DeleteRemoteAccessSessionRequest, cb)
 	assert(DeleteRemoteAccessSessionRequest, "You must provide a DeleteRemoteAccessSessionRequest")
 	local headers = {
@@ -9451,19 +9469,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRemoteAccessSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRemoteAccessSessionSync(DeleteRemoteAccessSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRemoteAccessSessionAsync(DeleteRemoteAccessSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRemoteAccessSessionAsync(DeleteRemoteAccessSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceProfile asynchronously, invoking a callback when done
 -- @param GetInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceProfileAsync(GetInstanceProfileRequest, cb)
 	assert(GetInstanceProfileRequest, "You must provide a GetInstanceProfileRequest")
 	local headers = {
@@ -9486,19 +9505,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceProfileSync(GetInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceProfileAsync(GetInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceProfileAsync(GetInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRun asynchronously, invoking a callback when done
 -- @param DeleteRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRunAsync(DeleteRunRequest, cb)
 	assert(DeleteRunRequest, "You must provide a DeleteRunRequest")
 	local headers = {
@@ -9521,19 +9541,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRunSync(DeleteRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRunAsync(DeleteRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRunAsync(DeleteRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOfferingTransactions asynchronously, invoking a callback when done
 -- @param ListOfferingTransactionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOfferingTransactionsAsync(ListOfferingTransactionsRequest, cb)
 	assert(ListOfferingTransactionsRequest, "You must provide a ListOfferingTransactionsRequest")
 	local headers = {
@@ -9556,19 +9577,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOfferingTransactionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOfferingTransactionsSync(ListOfferingTransactionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOfferingTransactionsAsync(ListOfferingTransactionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOfferingTransactionsAsync(ListOfferingTransactionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetProject asynchronously, invoking a callback when done
 -- @param GetProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetProjectAsync(GetProjectRequest, cb)
 	assert(GetProjectRequest, "You must provide a GetProjectRequest")
 	local headers = {
@@ -9591,19 +9613,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetProjectSync(GetProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetProjectAsync(GetProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetProjectAsync(GetProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InstallToRemoteAccessSession asynchronously, invoking a callback when done
 -- @param InstallToRemoteAccessSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InstallToRemoteAccessSessionAsync(InstallToRemoteAccessSessionRequest, cb)
 	assert(InstallToRemoteAccessSessionRequest, "You must provide a InstallToRemoteAccessSessionRequest")
 	local headers = {
@@ -9626,19 +9649,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InstallToRemoteAccessSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InstallToRemoteAccessSessionSync(InstallToRemoteAccessSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InstallToRemoteAccessSessionAsync(InstallToRemoteAccessSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InstallToRemoteAccessSessionAsync(InstallToRemoteAccessSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInstanceProfiles asynchronously, invoking a callback when done
 -- @param ListInstanceProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInstanceProfilesAsync(ListInstanceProfilesRequest, cb)
 	assert(ListInstanceProfilesRequest, "You must provide a ListInstanceProfilesRequest")
 	local headers = {
@@ -9661,19 +9685,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInstanceProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInstanceProfilesSync(ListInstanceProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInstanceProfilesAsync(ListInstanceProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInstanceProfilesAsync(ListInstanceProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUpload asynchronously, invoking a callback when done
 -- @param UpdateUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUploadAsync(UpdateUploadRequest, cb)
 	assert(UpdateUploadRequest, "You must provide a UpdateUploadRequest")
 	local headers = {
@@ -9696,19 +9721,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUploadSync(UpdateUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUploadAsync(UpdateUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUploadAsync(UpdateUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUniqueProblems asynchronously, invoking a callback when done
 -- @param ListUniqueProblemsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUniqueProblemsAsync(ListUniqueProblemsRequest, cb)
 	assert(ListUniqueProblemsRequest, "You must provide a ListUniqueProblemsRequest")
 	local headers = {
@@ -9731,19 +9757,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUniqueProblemsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUniqueProblemsSync(ListUniqueProblemsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUniqueProblemsAsync(ListUniqueProblemsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUniqueProblemsAsync(ListUniqueProblemsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDevicePools asynchronously, invoking a callback when done
 -- @param ListDevicePoolsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDevicePoolsAsync(ListDevicePoolsRequest, cb)
 	assert(ListDevicePoolsRequest, "You must provide a ListDevicePoolsRequest")
 	local headers = {
@@ -9766,19 +9793,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDevicePoolsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDevicePoolsSync(ListDevicePoolsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDevicePoolsAsync(ListDevicePoolsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDevicePoolsAsync(ListDevicePoolsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUpload asynchronously, invoking a callback when done
 -- @param CreateUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUploadAsync(CreateUploadRequest, cb)
 	assert(CreateUploadRequest, "You must provide a CreateUploadRequest")
 	local headers = {
@@ -9801,19 +9829,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUploadSync(CreateUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUploadAsync(CreateUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUploadAsync(CreateUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetVPCEConfiguration asynchronously, invoking a callback when done
 -- @param GetVPCEConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetVPCEConfigurationAsync(GetVPCEConfigurationRequest, cb)
 	assert(GetVPCEConfigurationRequest, "You must provide a GetVPCEConfigurationRequest")
 	local headers = {
@@ -9836,19 +9865,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetVPCEConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetVPCEConfigurationSync(GetVPCEConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetVPCEConfigurationAsync(GetVPCEConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetVPCEConfigurationAsync(GetVPCEConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevicePoolCompatibility asynchronously, invoking a callback when done
 -- @param GetDevicePoolCompatibilityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDevicePoolCompatibilityAsync(GetDevicePoolCompatibilityRequest, cb)
 	assert(GetDevicePoolCompatibilityRequest, "You must provide a GetDevicePoolCompatibilityRequest")
 	local headers = {
@@ -9871,19 +9901,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDevicePoolCompatibilityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDevicePoolCompatibilitySync(GetDevicePoolCompatibilityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDevicePoolCompatibilityAsync(GetDevicePoolCompatibilityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDevicePoolCompatibilityAsync(GetDevicePoolCompatibilityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDevicePool asynchronously, invoking a callback when done
 -- @param DeleteDevicePoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDevicePoolAsync(DeleteDevicePoolRequest, cb)
 	assert(DeleteDevicePoolRequest, "You must provide a DeleteDevicePoolRequest")
 	local headers = {
@@ -9906,19 +9937,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDevicePoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDevicePoolSync(DeleteDevicePoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDevicePoolAsync(DeleteDevicePoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDevicePoolAsync(DeleteDevicePoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDeviceInstance asynchronously, invoking a callback when done
 -- @param UpdateDeviceInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDeviceInstanceAsync(UpdateDeviceInstanceRequest, cb)
 	assert(UpdateDeviceInstanceRequest, "You must provide a UpdateDeviceInstanceRequest")
 	local headers = {
@@ -9941,19 +9973,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDeviceInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDeviceInstanceSync(UpdateDeviceInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDeviceInstanceAsync(UpdateDeviceInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDeviceInstanceAsync(UpdateDeviceInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTests asynchronously, invoking a callback when done
 -- @param ListTestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTestsAsync(ListTestsRequest, cb)
 	assert(ListTestsRequest, "You must provide a ListTestsRequest")
 	local headers = {
@@ -9976,19 +10009,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTestsSync(ListTestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTestsAsync(ListTestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTestsAsync(ListTestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProject asynchronously, invoking a callback when done
 -- @param UpdateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProjectAsync(UpdateProjectRequest, cb)
 	assert(UpdateProjectRequest, "You must provide a UpdateProjectRequest")
 	local headers = {
@@ -10011,19 +10045,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProjectSync(UpdateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSuites asynchronously, invoking a callback when done
 -- @param ListSuitesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSuitesAsync(ListSuitesRequest, cb)
 	assert(ListSuitesRequest, "You must provide a ListSuitesRequest")
 	local headers = {
@@ -10046,19 +10081,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSuitesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSuitesSync(ListSuitesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSuitesAsync(ListSuitesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSuitesAsync(ListSuitesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevicePool asynchronously, invoking a callback when done
 -- @param GetDevicePoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDevicePoolAsync(GetDevicePoolRequest, cb)
 	assert(GetDevicePoolRequest, "You must provide a GetDevicePoolRequest")
 	local headers = {
@@ -10081,19 +10117,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDevicePoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDevicePoolSync(GetDevicePoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDevicePoolAsync(GetDevicePoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDevicePoolAsync(GetDevicePoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDevices asynchronously, invoking a callback when done
 -- @param ListDevicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDevicesAsync(ListDevicesRequest, cb)
 	assert(ListDevicesRequest, "You must provide a ListDevicesRequest")
 	local headers = {
@@ -10116,19 +10153,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDevicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDevicesSync(ListDevicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDevicesAsync(ListDevicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDevicesAsync(ListDevicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVPCEConfigurations asynchronously, invoking a callback when done
 -- @param ListVPCEConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVPCEConfigurationsAsync(ListVPCEConfigurationsRequest, cb)
 	assert(ListVPCEConfigurationsRequest, "You must provide a ListVPCEConfigurationsRequest")
 	local headers = {
@@ -10151,19 +10189,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVPCEConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVPCEConfigurationsSync(ListVPCEConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVPCEConfigurationsAsync(ListVPCEConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVPCEConfigurationsAsync(ListVPCEConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopRemoteAccessSession asynchronously, invoking a callback when done
 -- @param StopRemoteAccessSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopRemoteAccessSessionAsync(StopRemoteAccessSessionRequest, cb)
 	assert(StopRemoteAccessSessionRequest, "You must provide a StopRemoteAccessSessionRequest")
 	local headers = {
@@ -10186,19 +10225,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopRemoteAccessSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopRemoteAccessSessionSync(StopRemoteAccessSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopRemoteAccessSessionAsync(StopRemoteAccessSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopRemoteAccessSessionAsync(StopRemoteAccessSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RenewOffering asynchronously, invoking a callback when done
 -- @param RenewOfferingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RenewOfferingAsync(RenewOfferingRequest, cb)
 	assert(RenewOfferingRequest, "You must provide a RenewOfferingRequest")
 	local headers = {
@@ -10221,19 +10261,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RenewOfferingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RenewOfferingSync(RenewOfferingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RenewOfferingAsync(RenewOfferingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RenewOfferingAsync(RenewOfferingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRemoteAccessSession asynchronously, invoking a callback when done
 -- @param GetRemoteAccessSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRemoteAccessSessionAsync(GetRemoteAccessSessionRequest, cb)
 	assert(GetRemoteAccessSessionRequest, "You must provide a GetRemoteAccessSessionRequest")
 	local headers = {
@@ -10256,19 +10297,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRemoteAccessSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRemoteAccessSessionSync(GetRemoteAccessSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRemoteAccessSessionAsync(GetRemoteAccessSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRemoteAccessSessionAsync(GetRemoteAccessSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProject asynchronously, invoking a callback when done
 -- @param DeleteProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProjectAsync(DeleteProjectRequest, cb)
 	assert(DeleteProjectRequest, "You must provide a DeleteProjectRequest")
 	local headers = {
@@ -10291,19 +10333,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProjectSync(DeleteProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobs asynchronously, invoking a callback when done
 -- @param ListJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsAsync(ListJobsRequest, cb)
 	assert(ListJobsRequest, "You must provide a ListJobsRequest")
 	local headers = {
@@ -10326,19 +10369,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsSync(ListJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsAsync(ListJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsAsync(ListJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRun asynchronously, invoking a callback when done
 -- @param GetRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRunAsync(GetRunRequest, cb)
 	assert(GetRunRequest, "You must provide a GetRunRequest")
 	local headers = {
@@ -10361,19 +10405,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRunSync(GetRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRunAsync(GetRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRunAsync(GetRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVPCEConfiguration asynchronously, invoking a callback when done
 -- @param CreateVPCEConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVPCEConfigurationAsync(CreateVPCEConfigurationRequest, cb)
 	assert(CreateVPCEConfigurationRequest, "You must provide a CreateVPCEConfigurationRequest")
 	local headers = {
@@ -10396,19 +10441,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVPCEConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVPCEConfigurationSync(CreateVPCEConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVPCEConfigurationAsync(CreateVPCEConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVPCEConfigurationAsync(CreateVPCEConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateNetworkProfile asynchronously, invoking a callback when done
 -- @param UpdateNetworkProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateNetworkProfileAsync(UpdateNetworkProfileRequest, cb)
 	assert(UpdateNetworkProfileRequest, "You must provide a UpdateNetworkProfileRequest")
 	local headers = {
@@ -10431,19 +10477,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateNetworkProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateNetworkProfileSync(UpdateNetworkProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateNetworkProfileAsync(UpdateNetworkProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateNetworkProfileAsync(UpdateNetworkProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopJob asynchronously, invoking a callback when done
 -- @param StopJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopJobAsync(StopJobRequest, cb)
 	assert(StopJobRequest, "You must provide a StopJobRequest")
 	local headers = {
@@ -10466,19 +10513,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopJobSync(StopJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopJobAsync(StopJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopJobAsync(StopJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRemoteAccessSessions asynchronously, invoking a callback when done
 -- @param ListRemoteAccessSessionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRemoteAccessSessionsAsync(ListRemoteAccessSessionsRequest, cb)
 	assert(ListRemoteAccessSessionsRequest, "You must provide a ListRemoteAccessSessionsRequest")
 	local headers = {
@@ -10501,19 +10549,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRemoteAccessSessionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRemoteAccessSessionsSync(ListRemoteAccessSessionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRemoteAccessSessionsAsync(ListRemoteAccessSessionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRemoteAccessSessionsAsync(ListRemoteAccessSessionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetNetworkProfile asynchronously, invoking a callback when done
 -- @param GetNetworkProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetNetworkProfileAsync(GetNetworkProfileRequest, cb)
 	assert(GetNetworkProfileRequest, "You must provide a GetNetworkProfileRequest")
 	local headers = {
@@ -10536,19 +10585,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetNetworkProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetNetworkProfileSync(GetNetworkProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetNetworkProfileAsync(GetNetworkProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetNetworkProfileAsync(GetNetworkProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOfferingStatus asynchronously, invoking a callback when done
 -- @param GetOfferingStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOfferingStatusAsync(GetOfferingStatusRequest, cb)
 	assert(GetOfferingStatusRequest, "You must provide a GetOfferingStatusRequest")
 	local headers = {
@@ -10571,19 +10621,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOfferingStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOfferingStatusSync(GetOfferingStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOfferingStatusAsync(GetOfferingStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOfferingStatusAsync(GetOfferingStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeviceInstance asynchronously, invoking a callback when done
 -- @param GetDeviceInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeviceInstanceAsync(GetDeviceInstanceRequest, cb)
 	assert(GetDeviceInstanceRequest, "You must provide a GetDeviceInstanceRequest")
 	local headers = {
@@ -10606,19 +10657,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeviceInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeviceInstanceSync(GetDeviceInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeviceInstanceAsync(GetDeviceInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeviceInstanceAsync(GetDeviceInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevice asynchronously, invoking a callback when done
 -- @param GetDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeviceAsync(GetDeviceRequest, cb)
 	assert(GetDeviceRequest, "You must provide a GetDeviceRequest")
 	local headers = {
@@ -10641,19 +10693,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeviceSync(GetDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeviceAsync(GetDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeviceAsync(GetDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDevicePool asynchronously, invoking a callback when done
 -- @param CreateDevicePoolRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDevicePoolAsync(CreateDevicePoolRequest, cb)
 	assert(CreateDevicePoolRequest, "You must provide a CreateDevicePoolRequest")
 	local headers = {
@@ -10676,19 +10729,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDevicePoolRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDevicePoolSync(CreateDevicePoolRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDevicePoolAsync(CreateDevicePoolRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDevicePoolAsync(CreateDevicePoolRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ScheduleRun asynchronously, invoking a callback when done
 -- @param ScheduleRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ScheduleRunAsync(ScheduleRunRequest, cb)
 	assert(ScheduleRunRequest, "You must provide a ScheduleRunRequest")
 	local headers = {
@@ -10711,19 +10765,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ScheduleRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ScheduleRunSync(ScheduleRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ScheduleRunAsync(ScheduleRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ScheduleRunAsync(ScheduleRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListArtifacts asynchronously, invoking a callback when done
 -- @param ListArtifactsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListArtifactsAsync(ListArtifactsRequest, cb)
 	assert(ListArtifactsRequest, "You must provide a ListArtifactsRequest")
 	local headers = {
@@ -10746,19 +10801,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListArtifactsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListArtifactsSync(ListArtifactsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListArtifactsAsync(ListArtifactsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListArtifactsAsync(ListArtifactsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProject asynchronously, invoking a callback when done
 -- @param CreateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProjectAsync(CreateProjectRequest, cb)
 	assert(CreateProjectRequest, "You must provide a CreateProjectRequest")
 	local headers = {
@@ -10781,19 +10837,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProjectSync(CreateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProjectAsync(CreateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProjectAsync(CreateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJob asynchronously, invoking a callback when done
 -- @param GetJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobAsync(GetJobRequest, cb)
 	assert(GetJobRequest, "You must provide a GetJobRequest")
 	local headers = {
@@ -10816,19 +10873,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobSync(GetJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobAsync(GetJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobAsync(GetJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVPCEConfiguration asynchronously, invoking a callback when done
 -- @param DeleteVPCEConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVPCEConfigurationAsync(DeleteVPCEConfigurationRequest, cb)
 	assert(DeleteVPCEConfigurationRequest, "You must provide a DeleteVPCEConfigurationRequest")
 	local headers = {
@@ -10851,19 +10909,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVPCEConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVPCEConfigurationSync(DeleteVPCEConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVPCEConfigurationAsync(DeleteVPCEConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVPCEConfigurationAsync(DeleteVPCEConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInstanceProfile asynchronously, invoking a callback when done
 -- @param CreateInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInstanceProfileAsync(CreateInstanceProfileRequest, cb)
 	assert(CreateInstanceProfileRequest, "You must provide a CreateInstanceProfileRequest")
 	local headers = {
@@ -10886,19 +10945,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInstanceProfileSync(CreateInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInstanceProfileAsync(CreateInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInstanceProfileAsync(CreateInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRuns asynchronously, invoking a callback when done
 -- @param ListRunsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRunsAsync(ListRunsRequest, cb)
 	assert(ListRunsRequest, "You must provide a ListRunsRequest")
 	local headers = {
@@ -10921,19 +10981,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRunsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRunsSync(ListRunsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRunsAsync(ListRunsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRunsAsync(ListRunsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUploads asynchronously, invoking a callback when done
 -- @param ListUploadsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUploadsAsync(ListUploadsRequest, cb)
 	assert(ListUploadsRequest, "You must provide a ListUploadsRequest")
 	local headers = {
@@ -10956,19 +11017,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUploadsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUploadsSync(ListUploadsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUploadsAsync(ListUploadsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUploadsAsync(ListUploadsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountSettings asynchronously, invoking a callback when done
 -- @param GetAccountSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountSettingsAsync(GetAccountSettingsRequest, cb)
 	assert(GetAccountSettingsRequest, "You must provide a GetAccountSettingsRequest")
 	local headers = {
@@ -10991,19 +11053,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountSettingsSync(GetAccountSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountSettingsAsync(GetAccountSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountSettingsAsync(GetAccountSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNetworkProfile asynchronously, invoking a callback when done
 -- @param CreateNetworkProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNetworkProfileAsync(CreateNetworkProfileRequest, cb)
 	assert(CreateNetworkProfileRequest, "You must provide a CreateNetworkProfileRequest")
 	local headers = {
@@ -11026,12 +11089,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNetworkProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNetworkProfileSync(CreateNetworkProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNetworkProfileAsync(CreateNetworkProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNetworkProfileAsync(CreateNetworkProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/devices_iot1click.lua
+++ b/aws-sdk/devices_iot1click.lua
@@ -1642,7 +1642,7 @@ end
 --
 --- Call DescribeDevice asynchronously, invoking a callback when done
 -- @param DescribeDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDeviceAsync(DescribeDeviceRequest, cb)
 	assert(DescribeDeviceRequest, "You must provide a DescribeDeviceRequest")
 	local headers = {
@@ -1665,19 +1665,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDeviceSync(DescribeDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDeviceAsync(DescribeDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDeviceAsync(DescribeDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDeviceState asynchronously, invoking a callback when done
 -- @param UpdateDeviceStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDeviceStateAsync(UpdateDeviceStateRequest, cb)
 	assert(UpdateDeviceStateRequest, "You must provide a UpdateDeviceStateRequest")
 	local headers = {
@@ -1700,19 +1701,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDeviceStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDeviceStateSync(UpdateDeviceStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDeviceStateAsync(UpdateDeviceStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDeviceStateAsync(UpdateDeviceStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnclaimDevice asynchronously, invoking a callback when done
 -- @param UnclaimDeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnclaimDeviceAsync(UnclaimDeviceRequest, cb)
 	assert(UnclaimDeviceRequest, "You must provide a UnclaimDeviceRequest")
 	local headers = {
@@ -1735,19 +1737,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnclaimDeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnclaimDeviceSync(UnclaimDeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnclaimDeviceAsync(UnclaimDeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnclaimDeviceAsync(UnclaimDeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeviceMethods asynchronously, invoking a callback when done
 -- @param GetDeviceMethodsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeviceMethodsAsync(GetDeviceMethodsRequest, cb)
 	assert(GetDeviceMethodsRequest, "You must provide a GetDeviceMethodsRequest")
 	local headers = {
@@ -1770,19 +1773,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeviceMethodsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeviceMethodsSync(GetDeviceMethodsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeviceMethodsAsync(GetDeviceMethodsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeviceMethodsAsync(GetDeviceMethodsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ClaimDevicesByClaimCode asynchronously, invoking a callback when done
 -- @param ClaimDevicesByClaimCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ClaimDevicesByClaimCodeAsync(ClaimDevicesByClaimCodeRequest, cb)
 	assert(ClaimDevicesByClaimCodeRequest, "You must provide a ClaimDevicesByClaimCodeRequest")
 	local headers = {
@@ -1805,19 +1809,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ClaimDevicesByClaimCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ClaimDevicesByClaimCodeSync(ClaimDevicesByClaimCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ClaimDevicesByClaimCodeAsync(ClaimDevicesByClaimCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ClaimDevicesByClaimCodeAsync(ClaimDevicesByClaimCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InvokeDeviceMethod asynchronously, invoking a callback when done
 -- @param InvokeDeviceMethodRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InvokeDeviceMethodAsync(InvokeDeviceMethodRequest, cb)
 	assert(InvokeDeviceMethodRequest, "You must provide a InvokeDeviceMethodRequest")
 	local headers = {
@@ -1840,19 +1845,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InvokeDeviceMethodRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InvokeDeviceMethodSync(InvokeDeviceMethodRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InvokeDeviceMethodAsync(InvokeDeviceMethodRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InvokeDeviceMethodAsync(InvokeDeviceMethodRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitiateDeviceClaim asynchronously, invoking a callback when done
 -- @param InitiateDeviceClaimRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitiateDeviceClaimAsync(InitiateDeviceClaimRequest, cb)
 	assert(InitiateDeviceClaimRequest, "You must provide a InitiateDeviceClaimRequest")
 	local headers = {
@@ -1875,19 +1881,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitiateDeviceClaimRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitiateDeviceClaimSync(InitiateDeviceClaimRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitiateDeviceClaimAsync(InitiateDeviceClaimRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitiateDeviceClaimAsync(InitiateDeviceClaimRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call FinalizeDeviceClaim asynchronously, invoking a callback when done
 -- @param FinalizeDeviceClaimRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.FinalizeDeviceClaimAsync(FinalizeDeviceClaimRequest, cb)
 	assert(FinalizeDeviceClaimRequest, "You must provide a FinalizeDeviceClaimRequest")
 	local headers = {
@@ -1910,19 +1917,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param FinalizeDeviceClaimRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.FinalizeDeviceClaimSync(FinalizeDeviceClaimRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.FinalizeDeviceClaimAsync(FinalizeDeviceClaimRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.FinalizeDeviceClaimAsync(FinalizeDeviceClaimRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDevices asynchronously, invoking a callback when done
 -- @param ListDevicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDevicesAsync(ListDevicesRequest, cb)
 	assert(ListDevicesRequest, "You must provide a ListDevicesRequest")
 	local headers = {
@@ -1945,19 +1953,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDevicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDevicesSync(ListDevicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDevicesAsync(ListDevicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDevicesAsync(ListDevicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeviceEvents asynchronously, invoking a callback when done
 -- @param ListDeviceEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeviceEventsAsync(ListDeviceEventsRequest, cb)
 	assert(ListDeviceEventsRequest, "You must provide a ListDeviceEventsRequest")
 	local headers = {
@@ -1980,12 +1989,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeviceEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeviceEventsSync(ListDeviceEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeviceEventsAsync(ListDeviceEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeviceEventsAsync(ListDeviceEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/directconnect.lua
+++ b/aws-sdk/directconnect.lua
@@ -4797,7 +4797,7 @@ end
 -- OPERATIONS
 --
 --- Call DescribeVirtualGateways asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVirtualGatewaysAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -4816,19 +4816,20 @@ end
 --- Call DescribeVirtualGateways synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVirtualGatewaysSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVirtualGatewaysAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVirtualGatewaysAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDirectConnectGatewayAssociations asynchronously, invoking a callback when done
 -- @param DescribeDirectConnectGatewayAssociationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDirectConnectGatewayAssociationsAsync(DescribeDirectConnectGatewayAssociationsRequest, cb)
 	assert(DescribeDirectConnectGatewayAssociationsRequest, "You must provide a DescribeDirectConnectGatewayAssociationsRequest")
 	local headers = {
@@ -4851,19 +4852,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDirectConnectGatewayAssociationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDirectConnectGatewayAssociationsSync(DescribeDirectConnectGatewayAssociationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDirectConnectGatewayAssociationsAsync(DescribeDirectConnectGatewayAssociationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDirectConnectGatewayAssociationsAsync(DescribeDirectConnectGatewayAssociationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBGPPeer asynchronously, invoking a callback when done
 -- @param CreateBGPPeerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBGPPeerAsync(CreateBGPPeerRequest, cb)
 	assert(CreateBGPPeerRequest, "You must provide a CreateBGPPeerRequest")
 	local headers = {
@@ -4886,19 +4888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBGPPeerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBGPPeerSync(CreateBGPPeerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBGPPeerAsync(CreateBGPPeerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBGPPeerAsync(CreateBGPPeerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AllocateHostedConnection asynchronously, invoking a callback when done
 -- @param AllocateHostedConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AllocateHostedConnectionAsync(AllocateHostedConnectionRequest, cb)
 	assert(AllocateHostedConnectionRequest, "You must provide a AllocateHostedConnectionRequest")
 	local headers = {
@@ -4921,19 +4924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AllocateHostedConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AllocateHostedConnectionSync(AllocateHostedConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AllocateHostedConnectionAsync(AllocateHostedConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AllocateHostedConnectionAsync(AllocateHostedConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateHostedConnection asynchronously, invoking a callback when done
 -- @param AssociateHostedConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateHostedConnectionAsync(AssociateHostedConnectionRequest, cb)
 	assert(AssociateHostedConnectionRequest, "You must provide a AssociateHostedConnectionRequest")
 	local headers = {
@@ -4956,19 +4960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateHostedConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateHostedConnectionSync(AssociateHostedConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateHostedConnectionAsync(AssociateHostedConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateHostedConnectionAsync(AssociateHostedConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AllocatePublicVirtualInterface asynchronously, invoking a callback when done
 -- @param AllocatePublicVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AllocatePublicVirtualInterfaceAsync(AllocatePublicVirtualInterfaceRequest, cb)
 	assert(AllocatePublicVirtualInterfaceRequest, "You must provide a AllocatePublicVirtualInterfaceRequest")
 	local headers = {
@@ -4991,19 +4996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AllocatePublicVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AllocatePublicVirtualInterfaceSync(AllocatePublicVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AllocatePublicVirtualInterfaceAsync(AllocatePublicVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AllocatePublicVirtualInterfaceAsync(AllocatePublicVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVirtualInterface asynchronously, invoking a callback when done
 -- @param DeleteVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVirtualInterfaceAsync(DeleteVirtualInterfaceRequest, cb)
 	assert(DeleteVirtualInterfaceRequest, "You must provide a DeleteVirtualInterfaceRequest")
 	local headers = {
@@ -5026,19 +5032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVirtualInterfaceSync(DeleteVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVirtualInterfaceAsync(DeleteVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVirtualInterfaceAsync(DeleteVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInterconnect asynchronously, invoking a callback when done
 -- @param CreateInterconnectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInterconnectAsync(CreateInterconnectRequest, cb)
 	assert(CreateInterconnectRequest, "You must provide a CreateInterconnectRequest")
 	local headers = {
@@ -5061,19 +5068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInterconnectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInterconnectSync(CreateInterconnectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInterconnectAsync(CreateInterconnectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInterconnectAsync(CreateInterconnectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLags asynchronously, invoking a callback when done
 -- @param DescribeLagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLagsAsync(DescribeLagsRequest, cb)
 	assert(DescribeLagsRequest, "You must provide a DescribeLagsRequest")
 	local headers = {
@@ -5096,19 +5104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLagsSync(DescribeLagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLagsAsync(DescribeLagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLagsAsync(DescribeLagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInterconnect asynchronously, invoking a callback when done
 -- @param DeleteInterconnectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInterconnectAsync(DeleteInterconnectRequest, cb)
 	assert(DeleteInterconnectRequest, "You must provide a DeleteInterconnectRequest")
 	local headers = {
@@ -5131,19 +5140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInterconnectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInterconnectSync(DeleteInterconnectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInterconnectAsync(DeleteInterconnectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInterconnectAsync(DeleteInterconnectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBGPPeer asynchronously, invoking a callback when done
 -- @param DeleteBGPPeerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBGPPeerAsync(DeleteBGPPeerRequest, cb)
 	assert(DeleteBGPPeerRequest, "You must provide a DeleteBGPPeerRequest")
 	local headers = {
@@ -5166,19 +5176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBGPPeerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBGPPeerSync(DeleteBGPPeerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBGPPeerAsync(DeleteBGPPeerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBGPPeerAsync(DeleteBGPPeerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDirectConnectGatewayAssociation asynchronously, invoking a callback when done
 -- @param DeleteDirectConnectGatewayAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDirectConnectGatewayAssociationAsync(DeleteDirectConnectGatewayAssociationRequest, cb)
 	assert(DeleteDirectConnectGatewayAssociationRequest, "You must provide a DeleteDirectConnectGatewayAssociationRequest")
 	local headers = {
@@ -5201,19 +5212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDirectConnectGatewayAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDirectConnectGatewayAssociationSync(DeleteDirectConnectGatewayAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDirectConnectGatewayAssociationAsync(DeleteDirectConnectGatewayAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDirectConnectGatewayAssociationAsync(DeleteDirectConnectGatewayAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDirectConnectGatewayAttachments asynchronously, invoking a callback when done
 -- @param DescribeDirectConnectGatewayAttachmentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDirectConnectGatewayAttachmentsAsync(DescribeDirectConnectGatewayAttachmentsRequest, cb)
 	assert(DescribeDirectConnectGatewayAttachmentsRequest, "You must provide a DescribeDirectConnectGatewayAttachmentsRequest")
 	local headers = {
@@ -5236,19 +5248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDirectConnectGatewayAttachmentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDirectConnectGatewayAttachmentsSync(DescribeDirectConnectGatewayAttachmentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDirectConnectGatewayAttachmentsAsync(DescribeDirectConnectGatewayAttachmentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDirectConnectGatewayAttachmentsAsync(DescribeDirectConnectGatewayAttachmentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AllocatePrivateVirtualInterface asynchronously, invoking a callback when done
 -- @param AllocatePrivateVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AllocatePrivateVirtualInterfaceAsync(AllocatePrivateVirtualInterfaceRequest, cb)
 	assert(AllocatePrivateVirtualInterfaceRequest, "You must provide a AllocatePrivateVirtualInterfaceRequest")
 	local headers = {
@@ -5271,19 +5284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AllocatePrivateVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AllocatePrivateVirtualInterfaceSync(AllocatePrivateVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AllocatePrivateVirtualInterfaceAsync(AllocatePrivateVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AllocatePrivateVirtualInterfaceAsync(AllocatePrivateVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateConnectionWithLag asynchronously, invoking a callback when done
 -- @param AssociateConnectionWithLagRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateConnectionWithLagAsync(AssociateConnectionWithLagRequest, cb)
 	assert(AssociateConnectionWithLagRequest, "You must provide a AssociateConnectionWithLagRequest")
 	local headers = {
@@ -5306,19 +5320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateConnectionWithLagRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateConnectionWithLagSync(AssociateConnectionWithLagRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateConnectionWithLagAsync(AssociateConnectionWithLagRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateConnectionWithLagAsync(AssociateConnectionWithLagRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLag asynchronously, invoking a callback when done
 -- @param CreateLagRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLagAsync(CreateLagRequest, cb)
 	assert(CreateLagRequest, "You must provide a CreateLagRequest")
 	local headers = {
@@ -5341,19 +5356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLagRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLagSync(CreateLagRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLagAsync(CreateLagRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLagAsync(CreateLagRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmPublicVirtualInterface asynchronously, invoking a callback when done
 -- @param ConfirmPublicVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmPublicVirtualInterfaceAsync(ConfirmPublicVirtualInterfaceRequest, cb)
 	assert(ConfirmPublicVirtualInterfaceRequest, "You must provide a ConfirmPublicVirtualInterfaceRequest")
 	local headers = {
@@ -5376,19 +5392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmPublicVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmPublicVirtualInterfaceSync(ConfirmPublicVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmPublicVirtualInterfaceAsync(ConfirmPublicVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmPublicVirtualInterfaceAsync(ConfirmPublicVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLoa asynchronously, invoking a callback when done
 -- @param DescribeLoaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLoaAsync(DescribeLoaRequest, cb)
 	assert(DescribeLoaRequest, "You must provide a DescribeLoaRequest")
 	local headers = {
@@ -5411,19 +5428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLoaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLoaSync(DescribeLoaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLoaAsync(DescribeLoaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLoaAsync(DescribeLoaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHostedConnections asynchronously, invoking a callback when done
 -- @param DescribeHostedConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHostedConnectionsAsync(DescribeHostedConnectionsRequest, cb)
 	assert(DescribeHostedConnectionsRequest, "You must provide a DescribeHostedConnectionsRequest")
 	local headers = {
@@ -5446,19 +5464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHostedConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHostedConnectionsSync(DescribeHostedConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHostedConnectionsAsync(DescribeHostedConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHostedConnectionsAsync(DescribeHostedConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateVirtualInterface asynchronously, invoking a callback when done
 -- @param AssociateVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateVirtualInterfaceAsync(AssociateVirtualInterfaceRequest, cb)
 	assert(AssociateVirtualInterfaceRequest, "You must provide a AssociateVirtualInterfaceRequest")
 	local headers = {
@@ -5481,19 +5500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateVirtualInterfaceSync(AssociateVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateVirtualInterfaceAsync(AssociateVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateVirtualInterfaceAsync(AssociateVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVirtualInterfaces asynchronously, invoking a callback when done
 -- @param DescribeVirtualInterfacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVirtualInterfacesAsync(DescribeVirtualInterfacesRequest, cb)
 	assert(DescribeVirtualInterfacesRequest, "You must provide a DescribeVirtualInterfacesRequest")
 	local headers = {
@@ -5516,19 +5536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVirtualInterfacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVirtualInterfacesSync(DescribeVirtualInterfacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVirtualInterfacesAsync(DescribeVirtualInterfacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVirtualInterfacesAsync(DescribeVirtualInterfacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDirectConnectGateway asynchronously, invoking a callback when done
 -- @param CreateDirectConnectGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDirectConnectGatewayAsync(CreateDirectConnectGatewayRequest, cb)
 	assert(CreateDirectConnectGatewayRequest, "You must provide a CreateDirectConnectGatewayRequest")
 	local headers = {
@@ -5551,19 +5572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDirectConnectGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDirectConnectGatewaySync(CreateDirectConnectGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDirectConnectGatewayAsync(CreateDirectConnectGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDirectConnectGatewayAsync(CreateDirectConnectGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmPrivateVirtualInterface asynchronously, invoking a callback when done
 -- @param ConfirmPrivateVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmPrivateVirtualInterfaceAsync(ConfirmPrivateVirtualInterfaceRequest, cb)
 	assert(ConfirmPrivateVirtualInterfaceRequest, "You must provide a ConfirmPrivateVirtualInterfaceRequest")
 	local headers = {
@@ -5586,19 +5608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmPrivateVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmPrivateVirtualInterfaceSync(ConfirmPrivateVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmPrivateVirtualInterfaceAsync(ConfirmPrivateVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmPrivateVirtualInterfaceAsync(ConfirmPrivateVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateConnectionFromLag asynchronously, invoking a callback when done
 -- @param DisassociateConnectionFromLagRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateConnectionFromLagAsync(DisassociateConnectionFromLagRequest, cb)
 	assert(DisassociateConnectionFromLagRequest, "You must provide a DisassociateConnectionFromLagRequest")
 	local headers = {
@@ -5621,19 +5644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateConnectionFromLagRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateConnectionFromLagSync(DisassociateConnectionFromLagRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateConnectionFromLagAsync(DisassociateConnectionFromLagRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateConnectionFromLagAsync(DisassociateConnectionFromLagRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDirectConnectGateway asynchronously, invoking a callback when done
 -- @param DeleteDirectConnectGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDirectConnectGatewayAsync(DeleteDirectConnectGatewayRequest, cb)
 	assert(DeleteDirectConnectGatewayRequest, "You must provide a DeleteDirectConnectGatewayRequest")
 	local headers = {
@@ -5656,19 +5680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDirectConnectGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDirectConnectGatewaySync(DeleteDirectConnectGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDirectConnectGatewayAsync(DeleteDirectConnectGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDirectConnectGatewayAsync(DeleteDirectConnectGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmConnection asynchronously, invoking a callback when done
 -- @param ConfirmConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmConnectionAsync(ConfirmConnectionRequest, cb)
 	assert(ConfirmConnectionRequest, "You must provide a ConfirmConnectionRequest")
 	local headers = {
@@ -5691,19 +5716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmConnectionSync(ConfirmConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmConnectionAsync(ConfirmConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmConnectionAsync(ConfirmConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInterconnects asynchronously, invoking a callback when done
 -- @param DescribeInterconnectsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInterconnectsAsync(DescribeInterconnectsRequest, cb)
 	assert(DescribeInterconnectsRequest, "You must provide a DescribeInterconnectsRequest")
 	local headers = {
@@ -5726,19 +5752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInterconnectsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInterconnectsSync(DescribeInterconnectsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInterconnectsAsync(DescribeInterconnectsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInterconnectsAsync(DescribeInterconnectsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsRequest, cb)
 	assert(DescribeTagsRequest, "You must provide a DescribeTagsRequest")
 	local headers = {
@@ -5761,19 +5788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConnections asynchronously, invoking a callback when done
 -- @param DescribeConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConnectionsAsync(DescribeConnectionsRequest, cb)
 	assert(DescribeConnectionsRequest, "You must provide a DescribeConnectionsRequest")
 	local headers = {
@@ -5796,19 +5824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConnectionsSync(DescribeConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConnectionsAsync(DescribeConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConnectionsAsync(DescribeConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePublicVirtualInterface asynchronously, invoking a callback when done
 -- @param CreatePublicVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePublicVirtualInterfaceAsync(CreatePublicVirtualInterfaceRequest, cb)
 	assert(CreatePublicVirtualInterfaceRequest, "You must provide a CreatePublicVirtualInterfaceRequest")
 	local headers = {
@@ -5831,19 +5860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePublicVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePublicVirtualInterfaceSync(CreatePublicVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePublicVirtualInterfaceAsync(CreatePublicVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePublicVirtualInterfaceAsync(CreatePublicVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConnection asynchronously, invoking a callback when done
 -- @param CreateConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConnectionAsync(CreateConnectionRequest, cb)
 	assert(CreateConnectionRequest, "You must provide a CreateConnectionRequest")
 	local headers = {
@@ -5866,19 +5896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConnectionSync(CreateConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConnectionAsync(CreateConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConnectionAsync(CreateConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -5901,18 +5932,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLocations asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLocationsAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -5931,19 +5963,20 @@ end
 --- Call DescribeLocations synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLocationsSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLocationsAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLocationsAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -5966,19 +5999,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePrivateVirtualInterface asynchronously, invoking a callback when done
 -- @param CreatePrivateVirtualInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePrivateVirtualInterfaceAsync(CreatePrivateVirtualInterfaceRequest, cb)
 	assert(CreatePrivateVirtualInterfaceRequest, "You must provide a CreatePrivateVirtualInterfaceRequest")
 	local headers = {
@@ -6001,19 +6035,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePrivateVirtualInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePrivateVirtualInterfaceSync(CreatePrivateVirtualInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePrivateVirtualInterfaceAsync(CreatePrivateVirtualInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePrivateVirtualInterfaceAsync(CreatePrivateVirtualInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConnection asynchronously, invoking a callback when done
 -- @param DeleteConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConnectionAsync(DeleteConnectionRequest, cb)
 	assert(DeleteConnectionRequest, "You must provide a DeleteConnectionRequest")
 	local headers = {
@@ -6036,19 +6071,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConnectionSync(DeleteConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConnectionAsync(DeleteConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConnectionAsync(DeleteConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDirectConnectGateways asynchronously, invoking a callback when done
 -- @param DescribeDirectConnectGatewaysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDirectConnectGatewaysAsync(DescribeDirectConnectGatewaysRequest, cb)
 	assert(DescribeDirectConnectGatewaysRequest, "You must provide a DescribeDirectConnectGatewaysRequest")
 	local headers = {
@@ -6071,19 +6107,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDirectConnectGatewaysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDirectConnectGatewaysSync(DescribeDirectConnectGatewaysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDirectConnectGatewaysAsync(DescribeDirectConnectGatewaysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDirectConnectGatewaysAsync(DescribeDirectConnectGatewaysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLag asynchronously, invoking a callback when done
 -- @param DeleteLagRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLagAsync(DeleteLagRequest, cb)
 	assert(DeleteLagRequest, "You must provide a DeleteLagRequest")
 	local headers = {
@@ -6106,19 +6143,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLagRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLagSync(DeleteLagRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLagAsync(DeleteLagRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLagAsync(DeleteLagRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDirectConnectGatewayAssociation asynchronously, invoking a callback when done
 -- @param CreateDirectConnectGatewayAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDirectConnectGatewayAssociationAsync(CreateDirectConnectGatewayAssociationRequest, cb)
 	assert(CreateDirectConnectGatewayAssociationRequest, "You must provide a CreateDirectConnectGatewayAssociationRequest")
 	local headers = {
@@ -6141,19 +6179,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDirectConnectGatewayAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDirectConnectGatewayAssociationSync(CreateDirectConnectGatewayAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDirectConnectGatewayAssociationAsync(CreateDirectConnectGatewayAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDirectConnectGatewayAssociationAsync(CreateDirectConnectGatewayAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateVirtualInterfaceAttributes asynchronously, invoking a callback when done
 -- @param UpdateVirtualInterfaceAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateVirtualInterfaceAttributesAsync(UpdateVirtualInterfaceAttributesRequest, cb)
 	assert(UpdateVirtualInterfaceAttributesRequest, "You must provide a UpdateVirtualInterfaceAttributesRequest")
 	local headers = {
@@ -6176,19 +6215,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateVirtualInterfaceAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateVirtualInterfaceAttributesSync(UpdateVirtualInterfaceAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateVirtualInterfaceAttributesAsync(UpdateVirtualInterfaceAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateVirtualInterfaceAttributesAsync(UpdateVirtualInterfaceAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateLag asynchronously, invoking a callback when done
 -- @param UpdateLagRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateLagAsync(UpdateLagRequest, cb)
 	assert(UpdateLagRequest, "You must provide a UpdateLagRequest")
 	local headers = {
@@ -6211,12 +6251,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateLagRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateLagSync(UpdateLagRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateLagAsync(UpdateLagRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateLagAsync(UpdateLagRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/discovery.lua
+++ b/aws-sdk/discovery.lua
@@ -3242,7 +3242,7 @@ end
 --
 --- Call DeleteTags asynchronously, invoking a callback when done
 -- @param DeleteTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsAsync(DeleteTagsRequest, cb)
 	assert(DeleteTagsRequest, "You must provide a DeleteTagsRequest")
 	local headers = {
@@ -3265,19 +3265,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsSync(DeleteTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopDataCollectionByAgentIds asynchronously, invoking a callback when done
 -- @param StopDataCollectionByAgentIdsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopDataCollectionByAgentIdsAsync(StopDataCollectionByAgentIdsRequest, cb)
 	assert(StopDataCollectionByAgentIdsRequest, "You must provide a StopDataCollectionByAgentIdsRequest")
 	local headers = {
@@ -3300,19 +3301,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopDataCollectionByAgentIdsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopDataCollectionByAgentIdsSync(StopDataCollectionByAgentIdsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopDataCollectionByAgentIdsAsync(StopDataCollectionByAgentIdsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopDataCollectionByAgentIdsAsync(StopDataCollectionByAgentIdsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartDataCollectionByAgentIds asynchronously, invoking a callback when done
 -- @param StartDataCollectionByAgentIdsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartDataCollectionByAgentIdsAsync(StartDataCollectionByAgentIdsRequest, cb)
 	assert(StartDataCollectionByAgentIdsRequest, "You must provide a StartDataCollectionByAgentIdsRequest")
 	local headers = {
@@ -3335,19 +3337,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartDataCollectionByAgentIdsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartDataCollectionByAgentIdsSync(StartDataCollectionByAgentIdsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartDataCollectionByAgentIdsAsync(StartDataCollectionByAgentIdsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartDataCollectionByAgentIdsAsync(StartDataCollectionByAgentIdsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateConfigurationItemsToApplication asynchronously, invoking a callback when done
 -- @param AssociateConfigurationItemsToApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateConfigurationItemsToApplicationAsync(AssociateConfigurationItemsToApplicationRequest, cb)
 	assert(AssociateConfigurationItemsToApplicationRequest, "You must provide a AssociateConfigurationItemsToApplicationRequest")
 	local headers = {
@@ -3370,19 +3373,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateConfigurationItemsToApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateConfigurationItemsToApplicationSync(AssociateConfigurationItemsToApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateConfigurationItemsToApplicationAsync(AssociateConfigurationItemsToApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateConfigurationItemsToApplicationAsync(AssociateConfigurationItemsToApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartContinuousExport asynchronously, invoking a callback when done
 -- @param StartContinuousExportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartContinuousExportAsync(StartContinuousExportRequest, cb)
 	assert(StartContinuousExportRequest, "You must provide a StartContinuousExportRequest")
 	local headers = {
@@ -3405,19 +3409,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartContinuousExportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartContinuousExportSync(StartContinuousExportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartContinuousExportAsync(StartContinuousExportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartContinuousExportAsync(StartContinuousExportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListConfigurations asynchronously, invoking a callback when done
 -- @param ListConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListConfigurationsAsync(ListConfigurationsRequest, cb)
 	assert(ListConfigurationsRequest, "You must provide a ListConfigurationsRequest")
 	local headers = {
@@ -3440,19 +3445,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListConfigurationsSync(ListConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListConfigurationsAsync(ListConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListConfigurationsAsync(ListConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeContinuousExports asynchronously, invoking a callback when done
 -- @param DescribeContinuousExportsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeContinuousExportsAsync(DescribeContinuousExportsRequest, cb)
 	assert(DescribeContinuousExportsRequest, "You must provide a DescribeContinuousExportsRequest")
 	local headers = {
@@ -3475,19 +3481,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeContinuousExportsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeContinuousExportsSync(DescribeContinuousExportsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeContinuousExportsAsync(DescribeContinuousExportsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeContinuousExportsAsync(DescribeContinuousExportsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartExportTask asynchronously, invoking a callback when done
 -- @param StartExportTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartExportTaskAsync(StartExportTaskRequest, cb)
 	assert(StartExportTaskRequest, "You must provide a StartExportTaskRequest")
 	local headers = {
@@ -3510,19 +3517,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartExportTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartExportTaskSync(StartExportTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartExportTaskAsync(StartExportTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartExportTaskAsync(StartExportTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplications asynchronously, invoking a callback when done
 -- @param DeleteApplicationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationsAsync(DeleteApplicationsRequest, cb)
 	assert(DeleteApplicationsRequest, "You must provide a DeleteApplicationsRequest")
 	local headers = {
@@ -3545,19 +3553,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationsSync(DeleteApplicationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationsAsync(DeleteApplicationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationsAsync(DeleteApplicationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApplication asynchronously, invoking a callback when done
 -- @param CreateApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApplicationAsync(CreateApplicationRequest, cb)
 	assert(CreateApplicationRequest, "You must provide a CreateApplicationRequest")
 	local headers = {
@@ -3580,19 +3589,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApplicationSync(CreateApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApplicationAsync(CreateApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApplicationAsync(CreateApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApplication asynchronously, invoking a callback when done
 -- @param UpdateApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationAsync(UpdateApplicationRequest, cb)
 	assert(UpdateApplicationRequest, "You must provide a UpdateApplicationRequest")
 	local headers = {
@@ -3615,19 +3625,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationSync(UpdateApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationAsync(UpdateApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationAsync(UpdateApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeExportTasks asynchronously, invoking a callback when done
 -- @param DescribeExportTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeExportTasksAsync(DescribeExportTasksRequest, cb)
 	assert(DescribeExportTasksRequest, "You must provide a DescribeExportTasksRequest")
 	local headers = {
@@ -3650,19 +3661,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeExportTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeExportTasksSync(DescribeExportTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeExportTasksAsync(DescribeExportTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeExportTasksAsync(DescribeExportTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAgents asynchronously, invoking a callback when done
 -- @param DescribeAgentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAgentsAsync(DescribeAgentsRequest, cb)
 	assert(DescribeAgentsRequest, "You must provide a DescribeAgentsRequest")
 	local headers = {
@@ -3685,19 +3697,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAgentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAgentsSync(DescribeAgentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAgentsAsync(DescribeAgentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAgentsAsync(DescribeAgentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurations asynchronously, invoking a callback when done
 -- @param DescribeConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationsAsync(DescribeConfigurationsRequest, cb)
 	assert(DescribeConfigurationsRequest, "You must provide a DescribeConfigurationsRequest")
 	local headers = {
@@ -3720,19 +3733,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationsSync(DescribeConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationsAsync(DescribeConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationsAsync(DescribeConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopContinuousExport asynchronously, invoking a callback when done
 -- @param StopContinuousExportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopContinuousExportAsync(StopContinuousExportRequest, cb)
 	assert(StopContinuousExportRequest, "You must provide a StopContinuousExportRequest")
 	local headers = {
@@ -3755,19 +3769,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopContinuousExportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopContinuousExportSync(StopContinuousExportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopContinuousExportAsync(StopContinuousExportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopContinuousExportAsync(StopContinuousExportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTags asynchronously, invoking a callback when done
 -- @param CreateTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTagsAsync(CreateTagsRequest, cb)
 	assert(CreateTagsRequest, "You must provide a CreateTagsRequest")
 	local headers = {
@@ -3790,19 +3805,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTagsSync(CreateTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTagsAsync(CreateTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTagsAsync(CreateTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsRequest, cb)
 	assert(DescribeTagsRequest, "You must provide a DescribeTagsRequest")
 	local headers = {
@@ -3825,19 +3841,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDiscoverySummary asynchronously, invoking a callback when done
 -- @param GetDiscoverySummaryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDiscoverySummaryAsync(GetDiscoverySummaryRequest, cb)
 	assert(GetDiscoverySummaryRequest, "You must provide a GetDiscoverySummaryRequest")
 	local headers = {
@@ -3860,19 +3877,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDiscoverySummaryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDiscoverySummarySync(GetDiscoverySummaryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDiscoverySummaryAsync(GetDiscoverySummaryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDiscoverySummaryAsync(GetDiscoverySummaryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListServerNeighbors asynchronously, invoking a callback when done
 -- @param ListServerNeighborsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListServerNeighborsAsync(ListServerNeighborsRequest, cb)
 	assert(ListServerNeighborsRequest, "You must provide a ListServerNeighborsRequest")
 	local headers = {
@@ -3895,19 +3913,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListServerNeighborsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListServerNeighborsSync(ListServerNeighborsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListServerNeighborsAsync(ListServerNeighborsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListServerNeighborsAsync(ListServerNeighborsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateConfigurationItemsFromApplication asynchronously, invoking a callback when done
 -- @param DisassociateConfigurationItemsFromApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateConfigurationItemsFromApplicationAsync(DisassociateConfigurationItemsFromApplicationRequest, cb)
 	assert(DisassociateConfigurationItemsFromApplicationRequest, "You must provide a DisassociateConfigurationItemsFromApplicationRequest")
 	local headers = {
@@ -3930,12 +3949,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateConfigurationItemsFromApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateConfigurationItemsFromApplicationSync(DisassociateConfigurationItemsFromApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateConfigurationItemsFromApplicationAsync(DisassociateConfigurationItemsFromApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateConfigurationItemsFromApplicationAsync(DisassociateConfigurationItemsFromApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/dlm.lua
+++ b/aws-sdk/dlm.lua
@@ -1106,7 +1106,7 @@ end
 --
 --- Call DeleteLifecyclePolicy asynchronously, invoking a callback when done
 -- @param DeleteLifecyclePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLifecyclePolicyAsync(DeleteLifecyclePolicyRequest, cb)
 	assert(DeleteLifecyclePolicyRequest, "You must provide a DeleteLifecyclePolicyRequest")
 	local headers = {
@@ -1129,19 +1129,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLifecyclePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLifecyclePolicySync(DeleteLifecyclePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLifecyclePolicyAsync(DeleteLifecyclePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLifecyclePolicyAsync(DeleteLifecyclePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLifecyclePolicies asynchronously, invoking a callback when done
 -- @param GetLifecyclePoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLifecyclePoliciesAsync(GetLifecyclePoliciesRequest, cb)
 	assert(GetLifecyclePoliciesRequest, "You must provide a GetLifecyclePoliciesRequest")
 	local headers = {
@@ -1164,19 +1165,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLifecyclePoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLifecyclePoliciesSync(GetLifecyclePoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLifecyclePoliciesAsync(GetLifecyclePoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLifecyclePoliciesAsync(GetLifecyclePoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLifecyclePolicy asynchronously, invoking a callback when done
 -- @param CreateLifecyclePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLifecyclePolicyAsync(CreateLifecyclePolicyRequest, cb)
 	assert(CreateLifecyclePolicyRequest, "You must provide a CreateLifecyclePolicyRequest")
 	local headers = {
@@ -1199,19 +1201,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLifecyclePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLifecyclePolicySync(CreateLifecyclePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLifecyclePolicyAsync(CreateLifecyclePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLifecyclePolicyAsync(CreateLifecyclePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLifecyclePolicy asynchronously, invoking a callback when done
 -- @param GetLifecyclePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLifecyclePolicyAsync(GetLifecyclePolicyRequest, cb)
 	assert(GetLifecyclePolicyRequest, "You must provide a GetLifecyclePolicyRequest")
 	local headers = {
@@ -1234,19 +1237,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLifecyclePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLifecyclePolicySync(GetLifecyclePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLifecyclePolicyAsync(GetLifecyclePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLifecyclePolicyAsync(GetLifecyclePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateLifecyclePolicy asynchronously, invoking a callback when done
 -- @param UpdateLifecyclePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateLifecyclePolicyAsync(UpdateLifecyclePolicyRequest, cb)
 	assert(UpdateLifecyclePolicyRequest, "You must provide a UpdateLifecyclePolicyRequest")
 	local headers = {
@@ -1269,12 +1273,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateLifecyclePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateLifecyclePolicySync(UpdateLifecyclePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateLifecyclePolicyAsync(UpdateLifecyclePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateLifecyclePolicyAsync(UpdateLifecyclePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/dms.lua
+++ b/aws-sdk/dms.lua
@@ -6043,7 +6043,7 @@ end
 --
 --- Call RefreshSchemas asynchronously, invoking a callback when done
 -- @param RefreshSchemasMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RefreshSchemasAsync(RefreshSchemasMessage, cb)
 	assert(RefreshSchemasMessage, "You must provide a RefreshSchemasMessage")
 	local headers = {
@@ -6066,19 +6066,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RefreshSchemasMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RefreshSchemasSync(RefreshSchemasMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RefreshSchemasAsync(RefreshSchemasMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RefreshSchemasAsync(RefreshSchemasMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCertificates asynchronously, invoking a callback when done
 -- @param DescribeCertificatesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCertificatesAsync(DescribeCertificatesMessage, cb)
 	assert(DescribeCertificatesMessage, "You must provide a DescribeCertificatesMessage")
 	local headers = {
@@ -6101,19 +6102,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCertificatesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCertificatesSync(DescribeCertificatesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCertificatesAsync(DescribeCertificatesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCertificatesAsync(DescribeCertificatesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReplicationInstances asynchronously, invoking a callback when done
 -- @param DescribeReplicationInstancesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReplicationInstancesAsync(DescribeReplicationInstancesMessage, cb)
 	assert(DescribeReplicationInstancesMessage, "You must provide a DescribeReplicationInstancesMessage")
 	local headers = {
@@ -6136,19 +6138,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReplicationInstancesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReplicationInstancesSync(DescribeReplicationInstancesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReplicationInstancesAsync(DescribeReplicationInstancesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReplicationInstancesAsync(DescribeReplicationInstancesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReplicationSubnetGroup asynchronously, invoking a callback when done
 -- @param CreateReplicationSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReplicationSubnetGroupAsync(CreateReplicationSubnetGroupMessage, cb)
 	assert(CreateReplicationSubnetGroupMessage, "You must provide a CreateReplicationSubnetGroupMessage")
 	local headers = {
@@ -6171,19 +6174,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReplicationSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReplicationSubnetGroupSync(CreateReplicationSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReplicationSubnetGroupAsync(CreateReplicationSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReplicationSubnetGroupAsync(CreateReplicationSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsMessage, cb)
 	assert(DescribeEventsMessage, "You must provide a DescribeEventsMessage")
 	local headers = {
@@ -6206,19 +6210,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventSubscriptions asynchronously, invoking a callback when done
 -- @param DescribeEventSubscriptionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, cb)
 	assert(DescribeEventSubscriptionsMessage, "You must provide a DescribeEventSubscriptionsMessage")
 	local headers = {
@@ -6241,19 +6246,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventSubscriptionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventSubscriptionsSync(DescribeEventSubscriptionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReplicationTask asynchronously, invoking a callback when done
 -- @param CreateReplicationTaskMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReplicationTaskAsync(CreateReplicationTaskMessage, cb)
 	assert(CreateReplicationTaskMessage, "You must provide a CreateReplicationTaskMessage")
 	local headers = {
@@ -6276,19 +6282,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReplicationTaskMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReplicationTaskSync(CreateReplicationTaskMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReplicationTaskAsync(CreateReplicationTaskMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReplicationTaskAsync(CreateReplicationTaskMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReplicationInstance asynchronously, invoking a callback when done
 -- @param DeleteReplicationInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReplicationInstanceAsync(DeleteReplicationInstanceMessage, cb)
 	assert(DeleteReplicationInstanceMessage, "You must provide a DeleteReplicationInstanceMessage")
 	local headers = {
@@ -6311,19 +6318,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReplicationInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReplicationInstanceSync(DeleteReplicationInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReplicationInstanceAsync(DeleteReplicationInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReplicationInstanceAsync(DeleteReplicationInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyReplicationInstance asynchronously, invoking a callback when done
 -- @param ModifyReplicationInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyReplicationInstanceAsync(ModifyReplicationInstanceMessage, cb)
 	assert(ModifyReplicationInstanceMessage, "You must provide a ModifyReplicationInstanceMessage")
 	local headers = {
@@ -6346,19 +6354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyReplicationInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyReplicationInstanceSync(ModifyReplicationInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyReplicationInstanceAsync(ModifyReplicationInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyReplicationInstanceAsync(ModifyReplicationInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTableStatistics asynchronously, invoking a callback when done
 -- @param DescribeTableStatisticsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTableStatisticsAsync(DescribeTableStatisticsMessage, cb)
 	assert(DescribeTableStatisticsMessage, "You must provide a DescribeTableStatisticsMessage")
 	local headers = {
@@ -6381,19 +6390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTableStatisticsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTableStatisticsSync(DescribeTableStatisticsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTableStatisticsAsync(DescribeTableStatisticsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTableStatisticsAsync(DescribeTableStatisticsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootReplicationInstance asynchronously, invoking a callback when done
 -- @param RebootReplicationInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootReplicationInstanceAsync(RebootReplicationInstanceMessage, cb)
 	assert(RebootReplicationInstanceMessage, "You must provide a RebootReplicationInstanceMessage")
 	local headers = {
@@ -6416,19 +6426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootReplicationInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootReplicationInstanceSync(RebootReplicationInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootReplicationInstanceAsync(RebootReplicationInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootReplicationInstanceAsync(RebootReplicationInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventCategories asynchronously, invoking a callback when done
 -- @param DescribeEventCategoriesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, cb)
 	assert(DescribeEventCategoriesMessage, "You must provide a DescribeEventCategoriesMessage")
 	local headers = {
@@ -6451,19 +6462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventCategoriesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventCategoriesSync(DescribeEventCategoriesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartReplicationTask asynchronously, invoking a callback when done
 -- @param StartReplicationTaskMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartReplicationTaskAsync(StartReplicationTaskMessage, cb)
 	assert(StartReplicationTaskMessage, "You must provide a StartReplicationTaskMessage")
 	local headers = {
@@ -6486,19 +6498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartReplicationTaskMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartReplicationTaskSync(StartReplicationTaskMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartReplicationTaskAsync(StartReplicationTaskMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartReplicationTaskAsync(StartReplicationTaskMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReplicationSubnetGroup asynchronously, invoking a callback when done
 -- @param DeleteReplicationSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReplicationSubnetGroupAsync(DeleteReplicationSubnetGroupMessage, cb)
 	assert(DeleteReplicationSubnetGroupMessage, "You must provide a DeleteReplicationSubnetGroupMessage")
 	local headers = {
@@ -6521,19 +6534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReplicationSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReplicationSubnetGroupSync(DeleteReplicationSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReplicationSubnetGroupAsync(DeleteReplicationSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReplicationSubnetGroupAsync(DeleteReplicationSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToResource asynchronously, invoking a callback when done
 -- @param AddTagsToResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToResourceAsync(AddTagsToResourceMessage, cb)
 	assert(AddTagsToResourceMessage, "You must provide a AddTagsToResourceMessage")
 	local headers = {
@@ -6556,19 +6570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToResourceSync(AddTagsToResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToResourceAsync(AddTagsToResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToResourceAsync(AddTagsToResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountAttributes asynchronously, invoking a callback when done
 -- @param DescribeAccountAttributesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountAttributesAsync(DescribeAccountAttributesMessage, cb)
 	assert(DescribeAccountAttributesMessage, "You must provide a DescribeAccountAttributesMessage")
 	local headers = {
@@ -6591,19 +6606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountAttributesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountAttributesSync(DescribeAccountAttributesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountAttributesAsync(DescribeAccountAttributesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountAttributesAsync(DescribeAccountAttributesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCertificate asynchronously, invoking a callback when done
 -- @param DeleteCertificateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCertificateAsync(DeleteCertificateMessage, cb)
 	assert(DeleteCertificateMessage, "You must provide a DeleteCertificateMessage")
 	local headers = {
@@ -6626,19 +6642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCertificateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCertificateSync(DeleteCertificateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCertificateAsync(DeleteCertificateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCertificateAsync(DeleteCertificateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestConnection asynchronously, invoking a callback when done
 -- @param TestConnectionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestConnectionAsync(TestConnectionMessage, cb)
 	assert(TestConnectionMessage, "You must provide a TestConnectionMessage")
 	local headers = {
@@ -6661,19 +6678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestConnectionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestConnectionSync(TestConnectionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestConnectionAsync(TestConnectionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestConnectionAsync(TestConnectionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEndpoints asynchronously, invoking a callback when done
 -- @param DescribeEndpointsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEndpointsAsync(DescribeEndpointsMessage, cb)
 	assert(DescribeEndpointsMessage, "You must provide a DescribeEndpointsMessage")
 	local headers = {
@@ -6696,19 +6714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEndpointsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEndpointsSync(DescribeEndpointsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEndpointsAsync(DescribeEndpointsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEndpointsAsync(DescribeEndpointsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromResource asynchronously, invoking a callback when done
 -- @param RemoveTagsFromResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, cb)
 	assert(RemoveTagsFromResourceMessage, "You must provide a RemoveTagsFromResourceMessage")
 	local headers = {
@@ -6731,19 +6750,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromResourceSync(RemoveTagsFromResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEndpoint asynchronously, invoking a callback when done
 -- @param CreateEndpointMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEndpointAsync(CreateEndpointMessage, cb)
 	assert(CreateEndpointMessage, "You must provide a CreateEndpointMessage")
 	local headers = {
@@ -6766,19 +6786,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEndpointMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEndpointSync(CreateEndpointMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEndpointAsync(CreateEndpointMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEndpointAsync(CreateEndpointMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReplicationTask asynchronously, invoking a callback when done
 -- @param DeleteReplicationTaskMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReplicationTaskAsync(DeleteReplicationTaskMessage, cb)
 	assert(DeleteReplicationTaskMessage, "You must provide a DeleteReplicationTaskMessage")
 	local headers = {
@@ -6801,19 +6822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReplicationTaskMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReplicationTaskSync(DeleteReplicationTaskMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReplicationTaskAsync(DeleteReplicationTaskMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReplicationTaskAsync(DeleteReplicationTaskMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReplicationTaskAssessmentResults asynchronously, invoking a callback when done
 -- @param DescribeReplicationTaskAssessmentResultsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReplicationTaskAssessmentResultsAsync(DescribeReplicationTaskAssessmentResultsMessage, cb)
 	assert(DescribeReplicationTaskAssessmentResultsMessage, "You must provide a DescribeReplicationTaskAssessmentResultsMessage")
 	local headers = {
@@ -6836,19 +6858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReplicationTaskAssessmentResultsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReplicationTaskAssessmentResultsSync(DescribeReplicationTaskAssessmentResultsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReplicationTaskAssessmentResultsAsync(DescribeReplicationTaskAssessmentResultsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReplicationTaskAssessmentResultsAsync(DescribeReplicationTaskAssessmentResultsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRefreshSchemasStatus asynchronously, invoking a callback when done
 -- @param DescribeRefreshSchemasStatusMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRefreshSchemasStatusAsync(DescribeRefreshSchemasStatusMessage, cb)
 	assert(DescribeRefreshSchemasStatusMessage, "You must provide a DescribeRefreshSchemasStatusMessage")
 	local headers = {
@@ -6871,19 +6894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRefreshSchemasStatusMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRefreshSchemasStatusSync(DescribeRefreshSchemasStatusMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRefreshSchemasStatusAsync(DescribeRefreshSchemasStatusMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRefreshSchemasStatusAsync(DescribeRefreshSchemasStatusMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyEndpoint asynchronously, invoking a callback when done
 -- @param ModifyEndpointMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyEndpointAsync(ModifyEndpointMessage, cb)
 	assert(ModifyEndpointMessage, "You must provide a ModifyEndpointMessage")
 	local headers = {
@@ -6906,19 +6930,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyEndpointMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyEndpointSync(ModifyEndpointMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyEndpointAsync(ModifyEndpointMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyEndpointAsync(ModifyEndpointMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReloadTables asynchronously, invoking a callback when done
 -- @param ReloadTablesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReloadTablesAsync(ReloadTablesMessage, cb)
 	assert(ReloadTablesMessage, "You must provide a ReloadTablesMessage")
 	local headers = {
@@ -6941,19 +6966,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReloadTablesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReloadTablesSync(ReloadTablesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReloadTablesAsync(ReloadTablesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReloadTablesAsync(ReloadTablesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyReplicationSubnetGroup asynchronously, invoking a callback when done
 -- @param ModifyReplicationSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyReplicationSubnetGroupAsync(ModifyReplicationSubnetGroupMessage, cb)
 	assert(ModifyReplicationSubnetGroupMessage, "You must provide a ModifyReplicationSubnetGroupMessage")
 	local headers = {
@@ -6976,19 +7002,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyReplicationSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyReplicationSubnetGroupSync(ModifyReplicationSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyReplicationSubnetGroupAsync(ModifyReplicationSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyReplicationSubnetGroupAsync(ModifyReplicationSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSchemas asynchronously, invoking a callback when done
 -- @param DescribeSchemasMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSchemasAsync(DescribeSchemasMessage, cb)
 	assert(DescribeSchemasMessage, "You must provide a DescribeSchemasMessage")
 	local headers = {
@@ -7011,19 +7038,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSchemasMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSchemasSync(DescribeSchemasMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSchemasAsync(DescribeSchemasMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSchemasAsync(DescribeSchemasMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEventSubscription asynchronously, invoking a callback when done
 -- @param DeleteEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, cb)
 	assert(DeleteEventSubscriptionMessage, "You must provide a DeleteEventSubscriptionMessage")
 	local headers = {
@@ -7046,19 +7074,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEventSubscriptionSync(DeleteEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartReplicationTaskAssessment asynchronously, invoking a callback when done
 -- @param StartReplicationTaskAssessmentMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartReplicationTaskAssessmentAsync(StartReplicationTaskAssessmentMessage, cb)
 	assert(StartReplicationTaskAssessmentMessage, "You must provide a StartReplicationTaskAssessmentMessage")
 	local headers = {
@@ -7081,19 +7110,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartReplicationTaskAssessmentMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartReplicationTaskAssessmentSync(StartReplicationTaskAssessmentMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartReplicationTaskAssessmentAsync(StartReplicationTaskAssessmentMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartReplicationTaskAssessmentAsync(StartReplicationTaskAssessmentMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyEventSubscription asynchronously, invoking a callback when done
 -- @param ModifyEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, cb)
 	assert(ModifyEventSubscriptionMessage, "You must provide a ModifyEventSubscriptionMessage")
 	local headers = {
@@ -7116,19 +7146,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyEventSubscriptionSync(ModifyEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConnections asynchronously, invoking a callback when done
 -- @param DescribeConnectionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConnectionsAsync(DescribeConnectionsMessage, cb)
 	assert(DescribeConnectionsMessage, "You must provide a DescribeConnectionsMessage")
 	local headers = {
@@ -7151,19 +7182,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConnectionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConnectionsSync(DescribeConnectionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConnectionsAsync(DescribeConnectionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConnectionsAsync(DescribeConnectionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReplicationInstance asynchronously, invoking a callback when done
 -- @param CreateReplicationInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReplicationInstanceAsync(CreateReplicationInstanceMessage, cb)
 	assert(CreateReplicationInstanceMessage, "You must provide a CreateReplicationInstanceMessage")
 	local headers = {
@@ -7186,19 +7218,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReplicationInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReplicationInstanceSync(CreateReplicationInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReplicationInstanceAsync(CreateReplicationInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReplicationInstanceAsync(CreateReplicationInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReplicationInstanceTaskLogs asynchronously, invoking a callback when done
 -- @param DescribeReplicationInstanceTaskLogsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReplicationInstanceTaskLogsAsync(DescribeReplicationInstanceTaskLogsMessage, cb)
 	assert(DescribeReplicationInstanceTaskLogsMessage, "You must provide a DescribeReplicationInstanceTaskLogsMessage")
 	local headers = {
@@ -7221,19 +7254,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReplicationInstanceTaskLogsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReplicationInstanceTaskLogsSync(DescribeReplicationInstanceTaskLogsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReplicationInstanceTaskLogsAsync(DescribeReplicationInstanceTaskLogsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReplicationInstanceTaskLogsAsync(DescribeReplicationInstanceTaskLogsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportCertificate asynchronously, invoking a callback when done
 -- @param ImportCertificateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportCertificateAsync(ImportCertificateMessage, cb)
 	assert(ImportCertificateMessage, "You must provide a ImportCertificateMessage")
 	local headers = {
@@ -7256,19 +7290,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportCertificateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportCertificateSync(ImportCertificateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportCertificateAsync(ImportCertificateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportCertificateAsync(ImportCertificateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReplicationSubnetGroups asynchronously, invoking a callback when done
 -- @param DescribeReplicationSubnetGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReplicationSubnetGroupsAsync(DescribeReplicationSubnetGroupsMessage, cb)
 	assert(DescribeReplicationSubnetGroupsMessage, "You must provide a DescribeReplicationSubnetGroupsMessage")
 	local headers = {
@@ -7291,19 +7326,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReplicationSubnetGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReplicationSubnetGroupsSync(DescribeReplicationSubnetGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReplicationSubnetGroupsAsync(DescribeReplicationSubnetGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReplicationSubnetGroupsAsync(DescribeReplicationSubnetGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopReplicationTask asynchronously, invoking a callback when done
 -- @param StopReplicationTaskMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopReplicationTaskAsync(StopReplicationTaskMessage, cb)
 	assert(StopReplicationTaskMessage, "You must provide a StopReplicationTaskMessage")
 	local headers = {
@@ -7326,19 +7362,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopReplicationTaskMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopReplicationTaskSync(StopReplicationTaskMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopReplicationTaskAsync(StopReplicationTaskMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopReplicationTaskAsync(StopReplicationTaskMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEndpointTypes asynchronously, invoking a callback when done
 -- @param DescribeEndpointTypesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEndpointTypesAsync(DescribeEndpointTypesMessage, cb)
 	assert(DescribeEndpointTypesMessage, "You must provide a DescribeEndpointTypesMessage")
 	local headers = {
@@ -7361,19 +7398,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEndpointTypesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEndpointTypesSync(DescribeEndpointTypesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEndpointTypesAsync(DescribeEndpointTypesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEndpointTypesAsync(DescribeEndpointTypesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReplicationTasks asynchronously, invoking a callback when done
 -- @param DescribeReplicationTasksMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReplicationTasksAsync(DescribeReplicationTasksMessage, cb)
 	assert(DescribeReplicationTasksMessage, "You must provide a DescribeReplicationTasksMessage")
 	local headers = {
@@ -7396,19 +7434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReplicationTasksMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReplicationTasksSync(DescribeReplicationTasksMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReplicationTasksAsync(DescribeReplicationTasksMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReplicationTasksAsync(DescribeReplicationTasksMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEventSubscription asynchronously, invoking a callback when done
 -- @param CreateEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, cb)
 	assert(CreateEventSubscriptionMessage, "You must provide a CreateEventSubscriptionMessage")
 	local headers = {
@@ -7431,19 +7470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEventSubscriptionSync(CreateEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEndpoint asynchronously, invoking a callback when done
 -- @param DeleteEndpointMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEndpointAsync(DeleteEndpointMessage, cb)
 	assert(DeleteEndpointMessage, "You must provide a DeleteEndpointMessage")
 	local headers = {
@@ -7466,19 +7506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEndpointMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEndpointSync(DeleteEndpointMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEndpointAsync(DeleteEndpointMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEndpointAsync(DeleteEndpointMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOrderableReplicationInstances asynchronously, invoking a callback when done
 -- @param DescribeOrderableReplicationInstancesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOrderableReplicationInstancesAsync(DescribeOrderableReplicationInstancesMessage, cb)
 	assert(DescribeOrderableReplicationInstancesMessage, "You must provide a DescribeOrderableReplicationInstancesMessage")
 	local headers = {
@@ -7501,19 +7542,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOrderableReplicationInstancesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOrderableReplicationInstancesSync(DescribeOrderableReplicationInstancesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOrderableReplicationInstancesAsync(DescribeOrderableReplicationInstancesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOrderableReplicationInstancesAsync(DescribeOrderableReplicationInstancesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyReplicationTask asynchronously, invoking a callback when done
 -- @param ModifyReplicationTaskMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyReplicationTaskAsync(ModifyReplicationTaskMessage, cb)
 	assert(ModifyReplicationTaskMessage, "You must provide a ModifyReplicationTaskMessage")
 	local headers = {
@@ -7536,19 +7578,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyReplicationTaskMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyReplicationTaskSync(ModifyReplicationTaskMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyReplicationTaskAsync(ModifyReplicationTaskMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyReplicationTaskAsync(ModifyReplicationTaskMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceMessage, cb)
 	assert(ListTagsForResourceMessage, "You must provide a ListTagsForResourceMessage")
 	local headers = {
@@ -7571,12 +7614,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/ds.lua
+++ b/aws-sdk/ds.lua
@@ -6837,7 +6837,7 @@ end
 --
 --- Call RemoveTagsFromResource asynchronously, invoking a callback when done
 -- @param RemoveTagsFromResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, cb)
 	assert(RemoveTagsFromResourceRequest, "You must provide a RemoveTagsFromResourceRequest")
 	local headers = {
@@ -6860,19 +6860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromResourceSync(RemoveTagsFromResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableRadius asynchronously, invoking a callback when done
 -- @param DisableRadiusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableRadiusAsync(DisableRadiusRequest, cb)
 	assert(DisableRadiusRequest, "You must provide a DisableRadiusRequest")
 	local headers = {
@@ -6895,19 +6896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableRadiusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableRadiusSync(DisableRadiusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableRadiusAsync(DisableRadiusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableRadiusAsync(DisableRadiusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectSharedDirectory asynchronously, invoking a callback when done
 -- @param RejectSharedDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectSharedDirectoryAsync(RejectSharedDirectoryRequest, cb)
 	assert(RejectSharedDirectoryRequest, "You must provide a RejectSharedDirectoryRequest")
 	local headers = {
@@ -6930,19 +6932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectSharedDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectSharedDirectorySync(RejectSharedDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectSharedDirectoryAsync(RejectSharedDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectSharedDirectoryAsync(RejectSharedDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptSharedDirectory asynchronously, invoking a callback when done
 -- @param AcceptSharedDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptSharedDirectoryAsync(AcceptSharedDirectoryRequest, cb)
 	assert(AcceptSharedDirectoryRequest, "You must provide a AcceptSharedDirectoryRequest")
 	local headers = {
@@ -6965,19 +6968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptSharedDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptSharedDirectorySync(AcceptSharedDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptSharedDirectoryAsync(AcceptSharedDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptSharedDirectoryAsync(AcceptSharedDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateComputer asynchronously, invoking a callback when done
 -- @param CreateComputerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateComputerAsync(CreateComputerRequest, cb)
 	assert(CreateComputerRequest, "You must provide a CreateComputerRequest")
 	local headers = {
@@ -7000,19 +7004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateComputerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateComputerSync(CreateComputerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateComputerAsync(CreateComputerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateComputerAsync(CreateComputerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableRadius asynchronously, invoking a callback when done
 -- @param EnableRadiusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableRadiusAsync(EnableRadiusRequest, cb)
 	assert(EnableRadiusRequest, "You must provide a EnableRadiusRequest")
 	local headers = {
@@ -7035,19 +7040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableRadiusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableRadiusSync(EnableRadiusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableRadiusAsync(EnableRadiusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableRadiusAsync(EnableRadiusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLogSubscriptions asynchronously, invoking a callback when done
 -- @param ListLogSubscriptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLogSubscriptionsAsync(ListLogSubscriptionsRequest, cb)
 	assert(ListLogSubscriptionsRequest, "You must provide a ListLogSubscriptionsRequest")
 	local headers = {
@@ -7070,19 +7076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLogSubscriptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLogSubscriptionsSync(ListLogSubscriptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLogSubscriptionsAsync(ListLogSubscriptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLogSubscriptionsAsync(ListLogSubscriptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConditionalForwarder asynchronously, invoking a callback when done
 -- @param DeleteConditionalForwarderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConditionalForwarderAsync(DeleteConditionalForwarderRequest, cb)
 	assert(DeleteConditionalForwarderRequest, "You must provide a DeleteConditionalForwarderRequest")
 	local headers = {
@@ -7105,19 +7112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConditionalForwarderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConditionalForwarderSync(DeleteConditionalForwarderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConditionalForwarderAsync(DeleteConditionalForwarderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConditionalForwarderAsync(DeleteConditionalForwarderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDirectory asynchronously, invoking a callback when done
 -- @param CreateDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDirectoryAsync(CreateDirectoryRequest, cb)
 	assert(CreateDirectoryRequest, "You must provide a CreateDirectoryRequest")
 	local headers = {
@@ -7140,19 +7148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDirectorySync(CreateDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDirectoryAsync(CreateDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDirectoryAsync(CreateDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetUserPassword asynchronously, invoking a callback when done
 -- @param ResetUserPasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetUserPasswordAsync(ResetUserPasswordRequest, cb)
 	assert(ResetUserPasswordRequest, "You must provide a ResetUserPasswordRequest")
 	local headers = {
@@ -7175,19 +7184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetUserPasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetUserPasswordSync(ResetUserPasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetUserPasswordAsync(ResetUserPasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetUserPasswordAsync(ResetUserPasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTrust asynchronously, invoking a callback when done
 -- @param UpdateTrustRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTrustAsync(UpdateTrustRequest, cb)
 	assert(UpdateTrustRequest, "You must provide a UpdateTrustRequest")
 	local headers = {
@@ -7210,19 +7220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTrustRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTrustSync(UpdateTrustRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTrustAsync(UpdateTrustRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTrustAsync(UpdateTrustRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSnapshots asynchronously, invoking a callback when done
 -- @param DescribeSnapshotsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSnapshotsAsync(DescribeSnapshotsRequest, cb)
 	assert(DescribeSnapshotsRequest, "You must provide a DescribeSnapshotsRequest")
 	local headers = {
@@ -7245,19 +7256,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSnapshotsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSnapshotsSync(DescribeSnapshotsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSnapshotsAsync(DescribeSnapshotsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSnapshotsAsync(DescribeSnapshotsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call VerifyTrust asynchronously, invoking a callback when done
 -- @param VerifyTrustRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.VerifyTrustAsync(VerifyTrustRequest, cb)
 	assert(VerifyTrustRequest, "You must provide a VerifyTrustRequest")
 	local headers = {
@@ -7280,19 +7292,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param VerifyTrustRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.VerifyTrustSync(VerifyTrustRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.VerifyTrustAsync(VerifyTrustRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.VerifyTrustAsync(VerifyTrustRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSnapshot asynchronously, invoking a callback when done
 -- @param DeleteSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSnapshotAsync(DeleteSnapshotRequest, cb)
 	assert(DeleteSnapshotRequest, "You must provide a DeleteSnapshotRequest")
 	local headers = {
@@ -7315,19 +7328,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSnapshotSync(DeleteSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSnapshotAsync(DeleteSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSnapshotAsync(DeleteSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRadius asynchronously, invoking a callback when done
 -- @param UpdateRadiusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRadiusAsync(UpdateRadiusRequest, cb)
 	assert(UpdateRadiusRequest, "You must provide a UpdateRadiusRequest")
 	local headers = {
@@ -7350,19 +7364,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRadiusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRadiusSync(UpdateRadiusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRadiusAsync(UpdateRadiusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRadiusAsync(UpdateRadiusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDomainControllers asynchronously, invoking a callback when done
 -- @param DescribeDomainControllersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDomainControllersAsync(DescribeDomainControllersRequest, cb)
 	assert(DescribeDomainControllersRequest, "You must provide a DescribeDomainControllersRequest")
 	local headers = {
@@ -7385,19 +7400,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDomainControllersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDomainControllersSync(DescribeDomainControllersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDomainControllersAsync(DescribeDomainControllersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDomainControllersAsync(DescribeDomainControllersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToResource asynchronously, invoking a callback when done
 -- @param AddTagsToResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToResourceAsync(AddTagsToResourceRequest, cb)
 	assert(AddTagsToResourceRequest, "You must provide a AddTagsToResourceRequest")
 	local headers = {
@@ -7420,19 +7436,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToResourceSync(AddTagsToResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToResourceAsync(AddTagsToResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToResourceAsync(AddTagsToResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConditionalForwarders asynchronously, invoking a callback when done
 -- @param DescribeConditionalForwardersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConditionalForwardersAsync(DescribeConditionalForwardersRequest, cb)
 	assert(DescribeConditionalForwardersRequest, "You must provide a DescribeConditionalForwardersRequest")
 	local headers = {
@@ -7455,19 +7472,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConditionalForwardersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConditionalForwardersSync(DescribeConditionalForwardersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConditionalForwardersAsync(DescribeConditionalForwardersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConditionalForwardersAsync(DescribeConditionalForwardersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventTopics asynchronously, invoking a callback when done
 -- @param DescribeEventTopicsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventTopicsAsync(DescribeEventTopicsRequest, cb)
 	assert(DescribeEventTopicsRequest, "You must provide a DescribeEventTopicsRequest")
 	local headers = {
@@ -7490,19 +7508,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventTopicsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventTopicsSync(DescribeEventTopicsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventTopicsAsync(DescribeEventTopicsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventTopicsAsync(DescribeEventTopicsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLogSubscription asynchronously, invoking a callback when done
 -- @param DeleteLogSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLogSubscriptionAsync(DeleteLogSubscriptionRequest, cb)
 	assert(DeleteLogSubscriptionRequest, "You must provide a DeleteLogSubscriptionRequest")
 	local headers = {
@@ -7525,19 +7544,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLogSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLogSubscriptionSync(DeleteLogSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLogSubscriptionAsync(DeleteLogSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLogSubscriptionAsync(DeleteLogSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableSso asynchronously, invoking a callback when done
 -- @param EnableSsoRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableSsoAsync(EnableSsoRequest, cb)
 	assert(EnableSsoRequest, "You must provide a EnableSsoRequest")
 	local headers = {
@@ -7560,19 +7580,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableSsoRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableSsoSync(EnableSsoRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableSsoAsync(EnableSsoRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableSsoAsync(EnableSsoRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIpRoutes asynchronously, invoking a callback when done
 -- @param ListIpRoutesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIpRoutesAsync(ListIpRoutesRequest, cb)
 	assert(ListIpRoutesRequest, "You must provide a ListIpRoutesRequest")
 	local headers = {
@@ -7595,19 +7616,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIpRoutesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIpRoutesSync(ListIpRoutesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIpRoutesAsync(ListIpRoutesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIpRoutesAsync(ListIpRoutesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveIpRoutes asynchronously, invoking a callback when done
 -- @param RemoveIpRoutesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveIpRoutesAsync(RemoveIpRoutesRequest, cb)
 	assert(RemoveIpRoutesRequest, "You must provide a RemoveIpRoutesRequest")
 	local headers = {
@@ -7630,19 +7652,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveIpRoutesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveIpRoutesSync(RemoveIpRoutesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveIpRoutesAsync(RemoveIpRoutesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveIpRoutesAsync(RemoveIpRoutesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAlias asynchronously, invoking a callback when done
 -- @param CreateAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAliasAsync(CreateAliasRequest, cb)
 	assert(CreateAliasRequest, "You must provide a CreateAliasRequest")
 	local headers = {
@@ -7665,19 +7688,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAliasSync(CreateAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAliasAsync(CreateAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAliasAsync(CreateAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConnectDirectory asynchronously, invoking a callback when done
 -- @param ConnectDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConnectDirectoryAsync(ConnectDirectoryRequest, cb)
 	assert(ConnectDirectoryRequest, "You must provide a ConnectDirectoryRequest")
 	local headers = {
@@ -7700,19 +7724,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConnectDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConnectDirectorySync(ConnectDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConnectDirectoryAsync(ConnectDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConnectDirectoryAsync(ConnectDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDirectory asynchronously, invoking a callback when done
 -- @param DeleteDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDirectoryAsync(DeleteDirectoryRequest, cb)
 	assert(DeleteDirectoryRequest, "You must provide a DeleteDirectoryRequest")
 	local headers = {
@@ -7735,19 +7760,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDirectorySync(DeleteDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDirectoryAsync(DeleteDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDirectoryAsync(DeleteDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddIpRoutes asynchronously, invoking a callback when done
 -- @param AddIpRoutesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddIpRoutesAsync(AddIpRoutesRequest, cb)
 	assert(AddIpRoutesRequest, "You must provide a AddIpRoutesRequest")
 	local headers = {
@@ -7770,19 +7796,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddIpRoutesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddIpRoutesSync(AddIpRoutesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddIpRoutesAsync(AddIpRoutesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddIpRoutesAsync(AddIpRoutesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLogSubscription asynchronously, invoking a callback when done
 -- @param CreateLogSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLogSubscriptionAsync(CreateLogSubscriptionRequest, cb)
 	assert(CreateLogSubscriptionRequest, "You must provide a CreateLogSubscriptionRequest")
 	local headers = {
@@ -7805,19 +7832,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLogSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLogSubscriptionSync(CreateLogSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLogSubscriptionAsync(CreateLogSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLogSubscriptionAsync(CreateLogSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelSchemaExtension asynchronously, invoking a callback when done
 -- @param CancelSchemaExtensionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelSchemaExtensionAsync(CancelSchemaExtensionRequest, cb)
 	assert(CancelSchemaExtensionRequest, "You must provide a CancelSchemaExtensionRequest")
 	local headers = {
@@ -7840,19 +7868,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelSchemaExtensionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelSchemaExtensionSync(CancelSchemaExtensionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelSchemaExtensionAsync(CancelSchemaExtensionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelSchemaExtensionAsync(CancelSchemaExtensionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConditionalForwarder asynchronously, invoking a callback when done
 -- @param CreateConditionalForwarderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConditionalForwarderAsync(CreateConditionalForwarderRequest, cb)
 	assert(CreateConditionalForwarderRequest, "You must provide a CreateConditionalForwarderRequest")
 	local headers = {
@@ -7875,19 +7904,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConditionalForwarderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConditionalForwarderSync(CreateConditionalForwarderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConditionalForwarderAsync(CreateConditionalForwarderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConditionalForwarderAsync(CreateConditionalForwarderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreFromSnapshot asynchronously, invoking a callback when done
 -- @param RestoreFromSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreFromSnapshotAsync(RestoreFromSnapshotRequest, cb)
 	assert(RestoreFromSnapshotRequest, "You must provide a RestoreFromSnapshotRequest")
 	local headers = {
@@ -7910,19 +7940,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreFromSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreFromSnapshotSync(RestoreFromSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreFromSnapshotAsync(RestoreFromSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreFromSnapshotAsync(RestoreFromSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSharedDirectories asynchronously, invoking a callback when done
 -- @param DescribeSharedDirectoriesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSharedDirectoriesAsync(DescribeSharedDirectoriesRequest, cb)
 	assert(DescribeSharedDirectoriesRequest, "You must provide a DescribeSharedDirectoriesRequest")
 	local headers = {
@@ -7945,19 +7976,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSharedDirectoriesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSharedDirectoriesSync(DescribeSharedDirectoriesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSharedDirectoriesAsync(DescribeSharedDirectoriesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSharedDirectoriesAsync(DescribeSharedDirectoriesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSchemaExtensions asynchronously, invoking a callback when done
 -- @param ListSchemaExtensionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSchemaExtensionsAsync(ListSchemaExtensionsRequest, cb)
 	assert(ListSchemaExtensionsRequest, "You must provide a ListSchemaExtensionsRequest")
 	local headers = {
@@ -7980,19 +8012,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSchemaExtensionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSchemaExtensionsSync(ListSchemaExtensionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSchemaExtensionsAsync(ListSchemaExtensionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSchemaExtensionsAsync(ListSchemaExtensionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTrusts asynchronously, invoking a callback when done
 -- @param DescribeTrustsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTrustsAsync(DescribeTrustsRequest, cb)
 	assert(DescribeTrustsRequest, "You must provide a DescribeTrustsRequest")
 	local headers = {
@@ -8015,19 +8048,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTrustsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTrustsSync(DescribeTrustsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTrustsAsync(DescribeTrustsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTrustsAsync(DescribeTrustsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnshareDirectory asynchronously, invoking a callback when done
 -- @param UnshareDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnshareDirectoryAsync(UnshareDirectoryRequest, cb)
 	assert(UnshareDirectoryRequest, "You must provide a UnshareDirectoryRequest")
 	local headers = {
@@ -8050,19 +8084,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnshareDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnshareDirectorySync(UnshareDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnshareDirectoryAsync(UnshareDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnshareDirectoryAsync(UnshareDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterEventTopic asynchronously, invoking a callback when done
 -- @param DeregisterEventTopicRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterEventTopicAsync(DeregisterEventTopicRequest, cb)
 	assert(DeregisterEventTopicRequest, "You must provide a DeregisterEventTopicRequest")
 	local headers = {
@@ -8085,19 +8120,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterEventTopicRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterEventTopicSync(DeregisterEventTopicRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterEventTopicAsync(DeregisterEventTopicRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterEventTopicAsync(DeregisterEventTopicRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConditionalForwarder asynchronously, invoking a callback when done
 -- @param UpdateConditionalForwarderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConditionalForwarderAsync(UpdateConditionalForwarderRequest, cb)
 	assert(UpdateConditionalForwarderRequest, "You must provide a UpdateConditionalForwarderRequest")
 	local headers = {
@@ -8120,19 +8156,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConditionalForwarderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConditionalForwarderSync(UpdateConditionalForwarderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConditionalForwarderAsync(UpdateConditionalForwarderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConditionalForwarderAsync(UpdateConditionalForwarderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTrust asynchronously, invoking a callback when done
 -- @param CreateTrustRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTrustAsync(CreateTrustRequest, cb)
 	assert(CreateTrustRequest, "You must provide a CreateTrustRequest")
 	local headers = {
@@ -8155,19 +8192,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTrustRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTrustSync(CreateTrustRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTrustAsync(CreateTrustRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTrustAsync(CreateTrustRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDirectoryLimits asynchronously, invoking a callback when done
 -- @param GetDirectoryLimitsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDirectoryLimitsAsync(GetDirectoryLimitsRequest, cb)
 	assert(GetDirectoryLimitsRequest, "You must provide a GetDirectoryLimitsRequest")
 	local headers = {
@@ -8190,19 +8228,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDirectoryLimitsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDirectoryLimitsSync(GetDirectoryLimitsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDirectoryLimitsAsync(GetDirectoryLimitsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDirectoryLimitsAsync(GetDirectoryLimitsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMicrosoftAD asynchronously, invoking a callback when done
 -- @param CreateMicrosoftADRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMicrosoftADAsync(CreateMicrosoftADRequest, cb)
 	assert(CreateMicrosoftADRequest, "You must provide a CreateMicrosoftADRequest")
 	local headers = {
@@ -8225,19 +8264,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMicrosoftADRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMicrosoftADSync(CreateMicrosoftADRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMicrosoftADAsync(CreateMicrosoftADRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMicrosoftADAsync(CreateMicrosoftADRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterEventTopic asynchronously, invoking a callback when done
 -- @param RegisterEventTopicRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterEventTopicAsync(RegisterEventTopicRequest, cb)
 	assert(RegisterEventTopicRequest, "You must provide a RegisterEventTopicRequest")
 	local headers = {
@@ -8260,19 +8300,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterEventTopicRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterEventTopicSync(RegisterEventTopicRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterEventTopicAsync(RegisterEventTopicRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterEventTopicAsync(RegisterEventTopicRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSnapshotLimits asynchronously, invoking a callback when done
 -- @param GetSnapshotLimitsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSnapshotLimitsAsync(GetSnapshotLimitsRequest, cb)
 	assert(GetSnapshotLimitsRequest, "You must provide a GetSnapshotLimitsRequest")
 	local headers = {
@@ -8295,19 +8336,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSnapshotLimitsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSnapshotLimitsSync(GetSnapshotLimitsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSnapshotLimitsAsync(GetSnapshotLimitsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSnapshotLimitsAsync(GetSnapshotLimitsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTrust asynchronously, invoking a callback when done
 -- @param DeleteTrustRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTrustAsync(DeleteTrustRequest, cb)
 	assert(DeleteTrustRequest, "You must provide a DeleteTrustRequest")
 	local headers = {
@@ -8330,19 +8372,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTrustRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTrustSync(DeleteTrustRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTrustAsync(DeleteTrustRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTrustAsync(DeleteTrustRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ShareDirectory asynchronously, invoking a callback when done
 -- @param ShareDirectoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ShareDirectoryAsync(ShareDirectoryRequest, cb)
 	assert(ShareDirectoryRequest, "You must provide a ShareDirectoryRequest")
 	local headers = {
@@ -8365,19 +8408,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ShareDirectoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ShareDirectorySync(ShareDirectoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ShareDirectoryAsync(ShareDirectoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ShareDirectoryAsync(ShareDirectoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateNumberOfDomainControllers asynchronously, invoking a callback when done
 -- @param UpdateNumberOfDomainControllersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateNumberOfDomainControllersAsync(UpdateNumberOfDomainControllersRequest, cb)
 	assert(UpdateNumberOfDomainControllersRequest, "You must provide a UpdateNumberOfDomainControllersRequest")
 	local headers = {
@@ -8400,19 +8444,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateNumberOfDomainControllersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateNumberOfDomainControllersSync(UpdateNumberOfDomainControllersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateNumberOfDomainControllersAsync(UpdateNumberOfDomainControllersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateNumberOfDomainControllersAsync(UpdateNumberOfDomainControllersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDirectories asynchronously, invoking a callback when done
 -- @param DescribeDirectoriesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDirectoriesAsync(DescribeDirectoriesRequest, cb)
 	assert(DescribeDirectoriesRequest, "You must provide a DescribeDirectoriesRequest")
 	local headers = {
@@ -8435,19 +8480,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDirectoriesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDirectoriesSync(DescribeDirectoriesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDirectoriesAsync(DescribeDirectoriesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDirectoriesAsync(DescribeDirectoriesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSchemaExtension asynchronously, invoking a callback when done
 -- @param StartSchemaExtensionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSchemaExtensionAsync(StartSchemaExtensionRequest, cb)
 	assert(StartSchemaExtensionRequest, "You must provide a StartSchemaExtensionRequest")
 	local headers = {
@@ -8470,19 +8516,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSchemaExtensionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSchemaExtensionSync(StartSchemaExtensionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSchemaExtensionAsync(StartSchemaExtensionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSchemaExtensionAsync(StartSchemaExtensionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -8505,19 +8552,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSnapshot asynchronously, invoking a callback when done
 -- @param CreateSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSnapshotAsync(CreateSnapshotRequest, cb)
 	assert(CreateSnapshotRequest, "You must provide a CreateSnapshotRequest")
 	local headers = {
@@ -8540,19 +8588,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSnapshotSync(CreateSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSnapshotAsync(CreateSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSnapshotAsync(CreateSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableSso asynchronously, invoking a callback when done
 -- @param DisableSsoRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableSsoAsync(DisableSsoRequest, cb)
 	assert(DisableSsoRequest, "You must provide a DisableSsoRequest")
 	local headers = {
@@ -8575,12 +8624,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableSsoRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableSsoSync(DisableSsoRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableSsoAsync(DisableSsoRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableSsoAsync(DisableSsoRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/dynamodb.lua
+++ b/aws-sdk/dynamodb.lua
@@ -7550,7 +7550,7 @@ end
 --
 --- Call DescribeContinuousBackups asynchronously, invoking a callback when done
 -- @param DescribeContinuousBackupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeContinuousBackupsAsync(DescribeContinuousBackupsInput, cb)
 	assert(DescribeContinuousBackupsInput, "You must provide a DescribeContinuousBackupsInput")
 	local headers = {
@@ -7573,19 +7573,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeContinuousBackupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeContinuousBackupsSync(DescribeContinuousBackupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeContinuousBackupsAsync(DescribeContinuousBackupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeContinuousBackupsAsync(DescribeContinuousBackupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateContinuousBackups asynchronously, invoking a callback when done
 -- @param UpdateContinuousBackupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateContinuousBackupsAsync(UpdateContinuousBackupsInput, cb)
 	assert(UpdateContinuousBackupsInput, "You must provide a UpdateContinuousBackupsInput")
 	local headers = {
@@ -7608,19 +7609,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateContinuousBackupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateContinuousBackupsSync(UpdateContinuousBackupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateContinuousBackupsAsync(UpdateContinuousBackupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateContinuousBackupsAsync(UpdateContinuousBackupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBackup asynchronously, invoking a callback when done
 -- @param DescribeBackupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBackupAsync(DescribeBackupInput, cb)
 	assert(DescribeBackupInput, "You must provide a DescribeBackupInput")
 	local headers = {
@@ -7643,19 +7645,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBackupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBackupSync(DescribeBackupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBackupAsync(DescribeBackupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBackupAsync(DescribeBackupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTimeToLive asynchronously, invoking a callback when done
 -- @param DescribeTimeToLiveInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTimeToLiveAsync(DescribeTimeToLiveInput, cb)
 	assert(DescribeTimeToLiveInput, "You must provide a DescribeTimeToLiveInput")
 	local headers = {
@@ -7678,19 +7681,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTimeToLiveInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTimeToLiveSync(DescribeTimeToLiveInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTimeToLiveAsync(DescribeTimeToLiveInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTimeToLiveAsync(DescribeTimeToLiveInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBackup asynchronously, invoking a callback when done
 -- @param DeleteBackupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBackupAsync(DeleteBackupInput, cb)
 	assert(DeleteBackupInput, "You must provide a DeleteBackupInput")
 	local headers = {
@@ -7713,19 +7717,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBackupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBackupSync(DeleteBackupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBackupAsync(DeleteBackupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBackupAsync(DeleteBackupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGlobalTable asynchronously, invoking a callback when done
 -- @param DescribeGlobalTableInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGlobalTableAsync(DescribeGlobalTableInput, cb)
 	assert(DescribeGlobalTableInput, "You must provide a DescribeGlobalTableInput")
 	local headers = {
@@ -7748,19 +7753,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGlobalTableInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGlobalTableSync(DescribeGlobalTableInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGlobalTableAsync(DescribeGlobalTableInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGlobalTableAsync(DescribeGlobalTableInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTable asynchronously, invoking a callback when done
 -- @param CreateTableInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTableAsync(CreateTableInput, cb)
 	assert(CreateTableInput, "You must provide a CreateTableInput")
 	local headers = {
@@ -7783,19 +7789,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTableInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTableSync(CreateTableInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTableAsync(CreateTableInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTableAsync(CreateTableInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreTableFromBackup asynchronously, invoking a callback when done
 -- @param RestoreTableFromBackupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreTableFromBackupAsync(RestoreTableFromBackupInput, cb)
 	assert(RestoreTableFromBackupInput, "You must provide a RestoreTableFromBackupInput")
 	local headers = {
@@ -7818,19 +7825,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreTableFromBackupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreTableFromBackupSync(RestoreTableFromBackupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreTableFromBackupAsync(RestoreTableFromBackupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreTableFromBackupAsync(RestoreTableFromBackupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTimeToLive asynchronously, invoking a callback when done
 -- @param UpdateTimeToLiveInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTimeToLiveAsync(UpdateTimeToLiveInput, cb)
 	assert(UpdateTimeToLiveInput, "You must provide a UpdateTimeToLiveInput")
 	local headers = {
@@ -7853,19 +7861,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTimeToLiveInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTimeToLiveSync(UpdateTimeToLiveInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTimeToLiveAsync(UpdateTimeToLiveInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTimeToLiveAsync(UpdateTimeToLiveInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTable asynchronously, invoking a callback when done
 -- @param UpdateTableInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTableAsync(UpdateTableInput, cb)
 	assert(UpdateTableInput, "You must provide a UpdateTableInput")
 	local headers = {
@@ -7888,19 +7897,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTableInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTableSync(UpdateTableInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTableAsync(UpdateTableInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTableAsync(UpdateTableInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLimits asynchronously, invoking a callback when done
 -- @param DescribeLimitsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLimitsAsync(DescribeLimitsInput, cb)
 	assert(DescribeLimitsInput, "You must provide a DescribeLimitsInput")
 	local headers = {
@@ -7923,19 +7933,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLimitsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLimitsSync(DescribeLimitsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLimitsAsync(DescribeLimitsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLimitsAsync(DescribeLimitsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBackup asynchronously, invoking a callback when done
 -- @param CreateBackupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBackupAsync(CreateBackupInput, cb)
 	assert(CreateBackupInput, "You must provide a CreateBackupInput")
 	local headers = {
@@ -7958,19 +7969,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBackupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBackupSync(CreateBackupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBackupAsync(CreateBackupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBackupAsync(CreateBackupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchWriteItem asynchronously, invoking a callback when done
 -- @param BatchWriteItemInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchWriteItemAsync(BatchWriteItemInput, cb)
 	assert(BatchWriteItemInput, "You must provide a BatchWriteItemInput")
 	local headers = {
@@ -7993,19 +8005,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchWriteItemInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchWriteItemSync(BatchWriteItemInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchWriteItemAsync(BatchWriteItemInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchWriteItemAsync(BatchWriteItemInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEndpoints asynchronously, invoking a callback when done
 -- @param DescribeEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEndpointsAsync(DescribeEndpointsRequest, cb)
 	assert(DescribeEndpointsRequest, "You must provide a DescribeEndpointsRequest")
 	local headers = {
@@ -8028,19 +8041,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEndpointsSync(DescribeEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEndpointsAsync(DescribeEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEndpointsAsync(DescribeEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceInput, cb)
 	assert(TagResourceInput, "You must provide a TagResourceInput")
 	local headers = {
@@ -8063,19 +8077,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreTableToPointInTime asynchronously, invoking a callback when done
 -- @param RestoreTableToPointInTimeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreTableToPointInTimeAsync(RestoreTableToPointInTimeInput, cb)
 	assert(RestoreTableToPointInTimeInput, "You must provide a RestoreTableToPointInTimeInput")
 	local headers = {
@@ -8098,19 +8113,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreTableToPointInTimeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreTableToPointInTimeSync(RestoreTableToPointInTimeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreTableToPointInTimeAsync(RestoreTableToPointInTimeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreTableToPointInTimeAsync(RestoreTableToPointInTimeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsOfResource asynchronously, invoking a callback when done
 -- @param ListTagsOfResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsOfResourceAsync(ListTagsOfResourceInput, cb)
 	assert(ListTagsOfResourceInput, "You must provide a ListTagsOfResourceInput")
 	local headers = {
@@ -8133,19 +8149,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsOfResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsOfResourceSync(ListTagsOfResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsOfResourceAsync(ListTagsOfResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsOfResourceAsync(ListTagsOfResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteItem asynchronously, invoking a callback when done
 -- @param DeleteItemInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteItemAsync(DeleteItemInput, cb)
 	assert(DeleteItemInput, "You must provide a DeleteItemInput")
 	local headers = {
@@ -8168,19 +8185,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteItemInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteItemSync(DeleteItemInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteItemAsync(DeleteItemInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteItemAsync(DeleteItemInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGlobalTables asynchronously, invoking a callback when done
 -- @param ListGlobalTablesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGlobalTablesAsync(ListGlobalTablesInput, cb)
 	assert(ListGlobalTablesInput, "You must provide a ListGlobalTablesInput")
 	local headers = {
@@ -8203,19 +8221,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGlobalTablesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGlobalTablesSync(ListGlobalTablesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGlobalTablesAsync(ListGlobalTablesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGlobalTablesAsync(ListGlobalTablesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateItem asynchronously, invoking a callback when done
 -- @param UpdateItemInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateItemAsync(UpdateItemInput, cb)
 	assert(UpdateItemInput, "You must provide a UpdateItemInput")
 	local headers = {
@@ -8238,19 +8257,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateItemInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateItemSync(UpdateItemInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateItemAsync(UpdateItemInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateItemAsync(UpdateItemInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetItem asynchronously, invoking a callback when done
 -- @param BatchGetItemInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetItemAsync(BatchGetItemInput, cb)
 	assert(BatchGetItemInput, "You must provide a BatchGetItemInput")
 	local headers = {
@@ -8273,19 +8293,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetItemInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetItemSync(BatchGetItemInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetItemAsync(BatchGetItemInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetItemAsync(BatchGetItemInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGlobalTableSettings asynchronously, invoking a callback when done
 -- @param DescribeGlobalTableSettingsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGlobalTableSettingsAsync(DescribeGlobalTableSettingsInput, cb)
 	assert(DescribeGlobalTableSettingsInput, "You must provide a DescribeGlobalTableSettingsInput")
 	local headers = {
@@ -8308,19 +8329,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGlobalTableSettingsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGlobalTableSettingsSync(DescribeGlobalTableSettingsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGlobalTableSettingsAsync(DescribeGlobalTableSettingsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGlobalTableSettingsAsync(DescribeGlobalTableSettingsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTable asynchronously, invoking a callback when done
 -- @param DescribeTableInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTableAsync(DescribeTableInput, cb)
 	assert(DescribeTableInput, "You must provide a DescribeTableInput")
 	local headers = {
@@ -8343,19 +8365,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTableInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTableSync(DescribeTableInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTableAsync(DescribeTableInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTableAsync(DescribeTableInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTables asynchronously, invoking a callback when done
 -- @param ListTablesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTablesAsync(ListTablesInput, cb)
 	assert(ListTablesInput, "You must provide a ListTablesInput")
 	local headers = {
@@ -8378,19 +8401,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTablesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTablesSync(ListTablesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTablesAsync(ListTablesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTablesAsync(ListTablesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Query asynchronously, invoking a callback when done
 -- @param QueryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.QueryAsync(QueryInput, cb)
 	assert(QueryInput, "You must provide a QueryInput")
 	local headers = {
@@ -8413,19 +8437,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param QueryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.QuerySync(QueryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.QueryAsync(QueryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.QueryAsync(QueryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTable asynchronously, invoking a callback when done
 -- @param DeleteTableInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTableAsync(DeleteTableInput, cb)
 	assert(DeleteTableInput, "You must provide a DeleteTableInput")
 	local headers = {
@@ -8448,19 +8473,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTableInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTableSync(DeleteTableInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTableAsync(DeleteTableInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTableAsync(DeleteTableInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceInput, cb)
 	assert(UntagResourceInput, "You must provide a UntagResourceInput")
 	local headers = {
@@ -8483,19 +8509,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Scan asynchronously, invoking a callback when done
 -- @param ScanInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ScanAsync(ScanInput, cb)
 	assert(ScanInput, "You must provide a ScanInput")
 	local headers = {
@@ -8518,19 +8545,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ScanInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ScanSync(ScanInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ScanAsync(ScanInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ScanAsync(ScanInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGlobalTable asynchronously, invoking a callback when done
 -- @param UpdateGlobalTableInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGlobalTableAsync(UpdateGlobalTableInput, cb)
 	assert(UpdateGlobalTableInput, "You must provide a UpdateGlobalTableInput")
 	local headers = {
@@ -8553,19 +8581,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGlobalTableInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGlobalTableSync(UpdateGlobalTableInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGlobalTableAsync(UpdateGlobalTableInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGlobalTableAsync(UpdateGlobalTableInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBackups asynchronously, invoking a callback when done
 -- @param ListBackupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBackupsAsync(ListBackupsInput, cb)
 	assert(ListBackupsInput, "You must provide a ListBackupsInput")
 	local headers = {
@@ -8588,19 +8617,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBackupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBackupsSync(ListBackupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBackupsAsync(ListBackupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBackupsAsync(ListBackupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGlobalTableSettings asynchronously, invoking a callback when done
 -- @param UpdateGlobalTableSettingsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGlobalTableSettingsAsync(UpdateGlobalTableSettingsInput, cb)
 	assert(UpdateGlobalTableSettingsInput, "You must provide a UpdateGlobalTableSettingsInput")
 	local headers = {
@@ -8623,19 +8653,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGlobalTableSettingsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGlobalTableSettingsSync(UpdateGlobalTableSettingsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGlobalTableSettingsAsync(UpdateGlobalTableSettingsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGlobalTableSettingsAsync(UpdateGlobalTableSettingsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGlobalTable asynchronously, invoking a callback when done
 -- @param CreateGlobalTableInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGlobalTableAsync(CreateGlobalTableInput, cb)
 	assert(CreateGlobalTableInput, "You must provide a CreateGlobalTableInput")
 	local headers = {
@@ -8658,19 +8689,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGlobalTableInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGlobalTableSync(CreateGlobalTableInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGlobalTableAsync(CreateGlobalTableInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGlobalTableAsync(CreateGlobalTableInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetItem asynchronously, invoking a callback when done
 -- @param GetItemInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetItemAsync(GetItemInput, cb)
 	assert(GetItemInput, "You must provide a GetItemInput")
 	local headers = {
@@ -8693,19 +8725,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetItemInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetItemSync(GetItemInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetItemAsync(GetItemInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetItemAsync(GetItemInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutItem asynchronously, invoking a callback when done
 -- @param PutItemInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutItemAsync(PutItemInput, cb)
 	assert(PutItemInput, "You must provide a PutItemInput")
 	local headers = {
@@ -8728,12 +8761,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutItemInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutItemSync(PutItemInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutItemAsync(PutItemInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutItemAsync(PutItemInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/ec2.lua
+++ b/aws-sdk/ec2.lua
@@ -43280,7 +43280,7 @@ end
 --
 --- Call DeleteTags asynchronously, invoking a callback when done
 -- @param DeleteTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsAsync(DeleteTagsRequest, cb)
 	assert(DeleteTagsRequest, "You must provide a DeleteTagsRequest")
 	local headers = {
@@ -43303,19 +43303,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsSync(DeleteTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetSnapshotAttribute asynchronously, invoking a callback when done
 -- @param ResetSnapshotAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetSnapshotAttributeAsync(ResetSnapshotAttributeRequest, cb)
 	assert(ResetSnapshotAttributeRequest, "You must provide a ResetSnapshotAttributeRequest")
 	local headers = {
@@ -43338,19 +43339,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetSnapshotAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetSnapshotAttributeSync(ResetSnapshotAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetSnapshotAttributeAsync(ResetSnapshotAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetSnapshotAttributeAsync(ResetSnapshotAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCustomerGateways asynchronously, invoking a callback when done
 -- @param DescribeCustomerGatewaysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCustomerGatewaysAsync(DescribeCustomerGatewaysRequest, cb)
 	assert(DescribeCustomerGatewaysRequest, "You must provide a DescribeCustomerGatewaysRequest")
 	local headers = {
@@ -43373,19 +43375,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCustomerGatewaysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCustomerGatewaysSync(DescribeCustomerGatewaysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCustomerGatewaysAsync(DescribeCustomerGatewaysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCustomerGatewaysAsync(DescribeCustomerGatewaysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReplaceIamInstanceProfileAssociation asynchronously, invoking a callback when done
 -- @param ReplaceIamInstanceProfileAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReplaceIamInstanceProfileAssociationAsync(ReplaceIamInstanceProfileAssociationRequest, cb)
 	assert(ReplaceIamInstanceProfileAssociationRequest, "You must provide a ReplaceIamInstanceProfileAssociationRequest")
 	local headers = {
@@ -43408,19 +43411,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReplaceIamInstanceProfileAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReplaceIamInstanceProfileAssociationSync(ReplaceIamInstanceProfileAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReplaceIamInstanceProfileAssociationAsync(ReplaceIamInstanceProfileAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReplaceIamInstanceProfileAssociationAsync(ReplaceIamInstanceProfileAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableVpcClassicLinkDnsSupport asynchronously, invoking a callback when done
 -- @param EnableVpcClassicLinkDnsSupportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableVpcClassicLinkDnsSupportAsync(EnableVpcClassicLinkDnsSupportRequest, cb)
 	assert(EnableVpcClassicLinkDnsSupportRequest, "You must provide a EnableVpcClassicLinkDnsSupportRequest")
 	local headers = {
@@ -43443,19 +43447,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableVpcClassicLinkDnsSupportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableVpcClassicLinkDnsSupportSync(EnableVpcClassicLinkDnsSupportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableVpcClassicLinkDnsSupportAsync(EnableVpcClassicLinkDnsSupportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableVpcClassicLinkDnsSupportAsync(EnableVpcClassicLinkDnsSupportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNetworkAcls asynchronously, invoking a callback when done
 -- @param DescribeNetworkAclsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNetworkAclsAsync(DescribeNetworkAclsRequest, cb)
 	assert(DescribeNetworkAclsRequest, "You must provide a DescribeNetworkAclsRequest")
 	local headers = {
@@ -43478,19 +43483,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNetworkAclsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNetworkAclsSync(DescribeNetworkAclsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNetworkAclsAsync(DescribeNetworkAclsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNetworkAclsAsync(DescribeNetworkAclsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AdvertiseByoipCidr asynchronously, invoking a callback when done
 -- @param AdvertiseByoipCidrRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AdvertiseByoipCidrAsync(AdvertiseByoipCidrRequest, cb)
 	assert(AdvertiseByoipCidrRequest, "You must provide a AdvertiseByoipCidrRequest")
 	local headers = {
@@ -43513,19 +43519,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AdvertiseByoipCidrRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AdvertiseByoipCidrSync(AdvertiseByoipCidrRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AdvertiseByoipCidrAsync(AdvertiseByoipCidrRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AdvertiseByoipCidrAsync(AdvertiseByoipCidrRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelConversionTask asynchronously, invoking a callback when done
 -- @param CancelConversionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelConversionTaskAsync(CancelConversionRequest, cb)
 	assert(CancelConversionRequest, "You must provide a CancelConversionRequest")
 	local headers = {
@@ -43548,19 +43555,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelConversionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelConversionTaskSync(CancelConversionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelConversionTaskAsync(CancelConversionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelConversionTaskAsync(CancelConversionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelImportTask asynchronously, invoking a callback when done
 -- @param CancelImportTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelImportTaskAsync(CancelImportTaskRequest, cb)
 	assert(CancelImportTaskRequest, "You must provide a CancelImportTaskRequest")
 	local headers = {
@@ -43583,19 +43591,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelImportTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelImportTaskSync(CancelImportTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelImportTaskAsync(CancelImportTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelImportTaskAsync(CancelImportTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpnConnectionRoute asynchronously, invoking a callback when done
 -- @param CreateVpnConnectionRouteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpnConnectionRouteAsync(CreateVpnConnectionRouteRequest, cb)
 	assert(CreateVpnConnectionRouteRequest, "You must provide a CreateVpnConnectionRouteRequest")
 	local headers = {
@@ -43618,19 +43627,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpnConnectionRouteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpnConnectionRouteSync(CreateVpnConnectionRouteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpnConnectionRouteAsync(CreateVpnConnectionRouteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpnConnectionRouteAsync(CreateVpnConnectionRouteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpcEndpointConnectionNotification asynchronously, invoking a callback when done
 -- @param CreateVpcEndpointConnectionNotificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcEndpointConnectionNotificationAsync(CreateVpcEndpointConnectionNotificationRequest, cb)
 	assert(CreateVpcEndpointConnectionNotificationRequest, "You must provide a CreateVpcEndpointConnectionNotificationRequest")
 	local headers = {
@@ -43653,19 +43663,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcEndpointConnectionNotificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcEndpointConnectionNotificationSync(CreateVpcEndpointConnectionNotificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcEndpointConnectionNotificationAsync(CreateVpcEndpointConnectionNotificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcEndpointConnectionNotificationAsync(CreateVpcEndpointConnectionNotificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRouteTables asynchronously, invoking a callback when done
 -- @param DescribeRouteTablesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRouteTablesAsync(DescribeRouteTablesRequest, cb)
 	assert(DescribeRouteTablesRequest, "You must provide a DescribeRouteTablesRequest")
 	local headers = {
@@ -43688,19 +43699,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRouteTablesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRouteTablesSync(DescribeRouteTablesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRouteTablesAsync(DescribeRouteTablesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRouteTablesAsync(DescribeRouteTablesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetImageAttribute asynchronously, invoking a callback when done
 -- @param ResetImageAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetImageAttributeAsync(ResetImageAttributeRequest, cb)
 	assert(ResetImageAttributeRequest, "You must provide a ResetImageAttributeRequest")
 	local headers = {
@@ -43723,19 +43735,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetImageAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetImageAttributeSync(ResetImageAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetImageAttributeAsync(ResetImageAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetImageAttributeAsync(ResetImageAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRouteTable asynchronously, invoking a callback when done
 -- @param CreateRouteTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRouteTableAsync(CreateRouteTableRequest, cb)
 	assert(CreateRouteTableRequest, "You must provide a CreateRouteTableRequest")
 	local headers = {
@@ -43758,19 +43771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRouteTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRouteTableSync(CreateRouteTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRouteTableAsync(CreateRouteTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRouteTableAsync(CreateRouteTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReplaceRouteTableAssociation asynchronously, invoking a callback when done
 -- @param ReplaceRouteTableAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReplaceRouteTableAssociationAsync(ReplaceRouteTableAssociationRequest, cb)
 	assert(ReplaceRouteTableAssociationRequest, "You must provide a ReplaceRouteTableAssociationRequest")
 	local headers = {
@@ -43793,19 +43807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReplaceRouteTableAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReplaceRouteTableAssociationSync(ReplaceRouteTableAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReplaceRouteTableAssociationAsync(ReplaceRouteTableAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReplaceRouteTableAssociationAsync(ReplaceRouteTableAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpcEndpoint asynchronously, invoking a callback when done
 -- @param CreateVpcEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcEndpointAsync(CreateVpcEndpointRequest, cb)
 	assert(CreateVpcEndpointRequest, "You must provide a CreateVpcEndpointRequest")
 	local headers = {
@@ -43828,19 +43843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcEndpointSync(CreateVpcEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcEndpointAsync(CreateVpcEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcEndpointAsync(CreateVpcEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeScheduledInstanceAvailability asynchronously, invoking a callback when done
 -- @param DescribeScheduledInstanceAvailabilityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScheduledInstanceAvailabilityAsync(DescribeScheduledInstanceAvailabilityRequest, cb)
 	assert(DescribeScheduledInstanceAvailabilityRequest, "You must provide a DescribeScheduledInstanceAvailabilityRequest")
 	local headers = {
@@ -43863,19 +43879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScheduledInstanceAvailabilityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScheduledInstanceAvailabilitySync(DescribeScheduledInstanceAvailabilityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScheduledInstanceAvailabilityAsync(DescribeScheduledInstanceAvailabilityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScheduledInstanceAvailabilityAsync(DescribeScheduledInstanceAvailabilityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCapacityReservations asynchronously, invoking a callback when done
 -- @param DescribeCapacityReservationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCapacityReservationsAsync(DescribeCapacityReservationsRequest, cb)
 	assert(DescribeCapacityReservationsRequest, "You must provide a DescribeCapacityReservationsRequest")
 	local headers = {
@@ -43898,19 +43915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCapacityReservationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCapacityReservationsSync(DescribeCapacityReservationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCapacityReservationsAsync(DescribeCapacityReservationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCapacityReservationsAsync(DescribeCapacityReservationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterImage asynchronously, invoking a callback when done
 -- @param RegisterImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterImageAsync(RegisterImageRequest, cb)
 	assert(RegisterImageRequest, "You must provide a RegisterImageRequest")
 	local headers = {
@@ -43933,19 +43951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterImageSync(RegisterImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterImageAsync(RegisterImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterImageAsync(RegisterImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateDhcpOptions asynchronously, invoking a callback when done
 -- @param AssociateDhcpOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateDhcpOptionsAsync(AssociateDhcpOptionsRequest, cb)
 	assert(AssociateDhcpOptionsRequest, "You must provide a AssociateDhcpOptionsRequest")
 	local headers = {
@@ -43968,19 +43987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateDhcpOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateDhcpOptionsSync(AssociateDhcpOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateDhcpOptionsAsync(AssociateDhcpOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateDhcpOptionsAsync(AssociateDhcpOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVpcEndpointServicePermissions asynchronously, invoking a callback when done
 -- @param ModifyVpcEndpointServicePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVpcEndpointServicePermissionsAsync(ModifyVpcEndpointServicePermissionsRequest, cb)
 	assert(ModifyVpcEndpointServicePermissionsRequest, "You must provide a ModifyVpcEndpointServicePermissionsRequest")
 	local headers = {
@@ -44003,19 +44023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVpcEndpointServicePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVpcEndpointServicePermissionsSync(ModifyVpcEndpointServicePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVpcEndpointServicePermissionsAsync(ModifyVpcEndpointServicePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVpcEndpointServicePermissionsAsync(ModifyVpcEndpointServicePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportKeyPair asynchronously, invoking a callback when done
 -- @param ImportKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportKeyPairAsync(ImportKeyPairRequest, cb)
 	assert(ImportKeyPairRequest, "You must provide a ImportKeyPairRequest")
 	local headers = {
@@ -44038,19 +44059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportKeyPairSync(ImportKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportKeyPairAsync(ImportKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportKeyPairAsync(ImportKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAvailabilityZones asynchronously, invoking a callback when done
 -- @param DescribeAvailabilityZonesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAvailabilityZonesAsync(DescribeAvailabilityZonesRequest, cb)
 	assert(DescribeAvailabilityZonesRequest, "You must provide a DescribeAvailabilityZonesRequest")
 	local headers = {
@@ -44073,19 +44095,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAvailabilityZonesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAvailabilityZonesSync(DescribeAvailabilityZonesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAvailabilityZonesAsync(DescribeAvailabilityZonesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAvailabilityZonesAsync(DescribeAvailabilityZonesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RequestSpotInstances asynchronously, invoking a callback when done
 -- @param RequestSpotInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RequestSpotInstancesAsync(RequestSpotInstancesRequest, cb)
 	assert(RequestSpotInstancesRequest, "You must provide a RequestSpotInstancesRequest")
 	local headers = {
@@ -44108,19 +44131,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RequestSpotInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RequestSpotInstancesSync(RequestSpotInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RequestSpotInstancesAsync(RequestSpotInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RequestSpotInstancesAsync(RequestSpotInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSnapshots asynchronously, invoking a callback when done
 -- @param DescribeSnapshotsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSnapshotsAsync(DescribeSnapshotsRequest, cb)
 	assert(DescribeSnapshotsRequest, "You must provide a DescribeSnapshotsRequest")
 	local headers = {
@@ -44143,19 +44167,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSnapshotsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSnapshotsSync(DescribeSnapshotsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSnapshotsAsync(DescribeSnapshotsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSnapshotsAsync(DescribeSnapshotsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptVpcPeeringConnection asynchronously, invoking a callback when done
 -- @param AcceptVpcPeeringConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptVpcPeeringConnectionAsync(AcceptVpcPeeringConnectionRequest, cb)
 	assert(AcceptVpcPeeringConnectionRequest, "You must provide a AcceptVpcPeeringConnectionRequest")
 	local headers = {
@@ -44178,19 +44203,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptVpcPeeringConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptVpcPeeringConnectionSync(AcceptVpcPeeringConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptVpcPeeringConnectionAsync(AcceptVpcPeeringConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptVpcPeeringConnectionAsync(AcceptVpcPeeringConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedInstancesModifications asynchronously, invoking a callback when done
 -- @param DescribeReservedInstancesModificationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedInstancesModificationsAsync(DescribeReservedInstancesModificationsRequest, cb)
 	assert(DescribeReservedInstancesModificationsRequest, "You must provide a DescribeReservedInstancesModificationsRequest")
 	local headers = {
@@ -44213,19 +44239,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedInstancesModificationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedInstancesModificationsSync(DescribeReservedInstancesModificationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedInstancesModificationsAsync(DescribeReservedInstancesModificationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedInstancesModificationsAsync(DescribeReservedInstancesModificationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPasswordData asynchronously, invoking a callback when done
 -- @param GetPasswordDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPasswordDataAsync(GetPasswordDataRequest, cb)
 	assert(GetPasswordDataRequest, "You must provide a GetPasswordDataRequest")
 	local headers = {
@@ -44248,19 +44275,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPasswordDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPasswordDataSync(GetPasswordDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPasswordDataAsync(GetPasswordDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPasswordDataAsync(GetPasswordDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImportSnapshotTasks asynchronously, invoking a callback when done
 -- @param DescribeImportSnapshotTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImportSnapshotTasksAsync(DescribeImportSnapshotTasksRequest, cb)
 	assert(DescribeImportSnapshotTasksRequest, "You must provide a DescribeImportSnapshotTasksRequest")
 	local headers = {
@@ -44283,19 +44311,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImportSnapshotTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImportSnapshotTasksSync(DescribeImportSnapshotTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImportSnapshotTasksAsync(DescribeImportSnapshotTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImportSnapshotTasksAsync(DescribeImportSnapshotTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNetworkInterfacePermission asynchronously, invoking a callback when done
 -- @param CreateNetworkInterfacePermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNetworkInterfacePermissionAsync(CreateNetworkInterfacePermissionRequest, cb)
 	assert(CreateNetworkInterfacePermissionRequest, "You must provide a CreateNetworkInterfacePermissionRequest")
 	local headers = {
@@ -44318,19 +44347,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNetworkInterfacePermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNetworkInterfacePermissionSync(CreateNetworkInterfacePermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNetworkInterfacePermissionAsync(CreateNetworkInterfacePermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNetworkInterfacePermissionAsync(CreateNetworkInterfacePermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpnConnection asynchronously, invoking a callback when done
 -- @param DeleteVpnConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpnConnectionAsync(DeleteVpnConnectionRequest, cb)
 	assert(DeleteVpnConnectionRequest, "You must provide a DeleteVpnConnectionRequest")
 	local headers = {
@@ -44353,19 +44383,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpnConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpnConnectionSync(DeleteVpnConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpnConnectionAsync(DeleteVpnConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpnConnectionAsync(DeleteVpnConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachVpnGateway asynchronously, invoking a callback when done
 -- @param AttachVpnGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachVpnGatewayAsync(AttachVpnGatewayRequest, cb)
 	assert(AttachVpnGatewayRequest, "You must provide a AttachVpnGatewayRequest")
 	local headers = {
@@ -44388,19 +44419,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachVpnGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachVpnGatewaySync(AttachVpnGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachVpnGatewayAsync(AttachVpnGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachVpnGatewayAsync(AttachVpnGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLaunchTemplate asynchronously, invoking a callback when done
 -- @param DeleteLaunchTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLaunchTemplateAsync(DeleteLaunchTemplateRequest, cb)
 	assert(DeleteLaunchTemplateRequest, "You must provide a DeleteLaunchTemplateRequest")
 	local headers = {
@@ -44423,19 +44455,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLaunchTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLaunchTemplateSync(DeleteLaunchTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLaunchTemplateAsync(DeleteLaunchTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLaunchTemplateAsync(DeleteLaunchTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportImage asynchronously, invoking a callback when done
 -- @param ImportImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportImageAsync(ImportImageRequest, cb)
 	assert(ImportImageRequest, "You must provide a ImportImageRequest")
 	local headers = {
@@ -44458,19 +44491,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportImageSync(ImportImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportImageAsync(ImportImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportImageAsync(ImportImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImageAttribute asynchronously, invoking a callback when done
 -- @param DescribeImageAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImageAttributeAsync(DescribeImageAttributeRequest, cb)
 	assert(DescribeImageAttributeRequest, "You must provide a DescribeImageAttributeRequest")
 	local headers = {
@@ -44493,19 +44527,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImageAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImageAttributeSync(DescribeImageAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImageAttributeAsync(DescribeImageAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImageAttributeAsync(DescribeImageAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAddresses asynchronously, invoking a callback when done
 -- @param DescribeAddressesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAddressesAsync(DescribeAddressesRequest, cb)
 	assert(DescribeAddressesRequest, "You must provide a DescribeAddressesRequest")
 	local headers = {
@@ -44528,19 +44563,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAddressesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAddressesSync(DescribeAddressesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAddressesAsync(DescribeAddressesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAddressesAsync(DescribeAddressesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateIamInstanceProfile asynchronously, invoking a callback when done
 -- @param DisassociateIamInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateIamInstanceProfileAsync(DisassociateIamInstanceProfileRequest, cb)
 	assert(DisassociateIamInstanceProfileRequest, "You must provide a DisassociateIamInstanceProfileRequest")
 	local headers = {
@@ -44563,19 +44599,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateIamInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateIamInstanceProfileSync(DisassociateIamInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateIamInstanceProfileAsync(DisassociateIamInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateIamInstanceProfileAsync(DisassociateIamInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateIamInstanceProfile asynchronously, invoking a callback when done
 -- @param AssociateIamInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateIamInstanceProfileAsync(AssociateIamInstanceProfileRequest, cb)
 	assert(AssociateIamInstanceProfileRequest, "You must provide a AssociateIamInstanceProfileRequest")
 	local headers = {
@@ -44598,19 +44635,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateIamInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateIamInstanceProfileSync(AssociateIamInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateIamInstanceProfileAsync(AssociateIamInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateIamInstanceProfileAsync(AssociateIamInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseHostReservation asynchronously, invoking a callback when done
 -- @param PurchaseHostReservationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseHostReservationAsync(PurchaseHostReservationRequest, cb)
 	assert(PurchaseHostReservationRequest, "You must provide a PurchaseHostReservationRequest")
 	local headers = {
@@ -44633,19 +44671,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseHostReservationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseHostReservationSync(PurchaseHostReservationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseHostReservationAsync(PurchaseHostReservationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseHostReservationAsync(PurchaseHostReservationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BundleInstance asynchronously, invoking a callback when done
 -- @param BundleInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BundleInstanceAsync(BundleInstanceRequest, cb)
 	assert(BundleInstanceRequest, "You must provide a BundleInstanceRequest")
 	local headers = {
@@ -44668,19 +44707,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BundleInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BundleInstanceSync(BundleInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BundleInstanceAsync(BundleInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BundleInstanceAsync(BundleInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedInstances asynchronously, invoking a callback when done
 -- @param DescribeReservedInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedInstancesAsync(DescribeReservedInstancesRequest, cb)
 	assert(DescribeReservedInstancesRequest, "You must provide a DescribeReservedInstancesRequest")
 	local headers = {
@@ -44703,19 +44743,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedInstancesSync(DescribeReservedInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedInstancesAsync(DescribeReservedInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedInstancesAsync(DescribeReservedInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNetworkAcl asynchronously, invoking a callback when done
 -- @param CreateNetworkAclRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNetworkAclAsync(CreateNetworkAclRequest, cb)
 	assert(CreateNetworkAclRequest, "You must provide a CreateNetworkAclRequest")
 	local headers = {
@@ -44738,19 +44779,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNetworkAclRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNetworkAclSync(CreateNetworkAclRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNetworkAclAsync(CreateNetworkAclRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNetworkAclAsync(CreateNetworkAclRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateImage asynchronously, invoking a callback when done
 -- @param CreateImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateImageAsync(CreateImageRequest, cb)
 	assert(CreateImageRequest, "You must provide a CreateImageRequest")
 	local headers = {
@@ -44773,19 +44815,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateImageSync(CreateImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateImageAsync(CreateImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateImageAsync(CreateImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyHosts asynchronously, invoking a callback when done
 -- @param ModifyHostsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyHostsAsync(ModifyHostsRequest, cb)
 	assert(ModifyHostsRequest, "You must provide a ModifyHostsRequest")
 	local headers = {
@@ -44808,19 +44851,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyHostsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyHostsSync(ModifyHostsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyHostsAsync(ModifyHostsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyHostsAsync(ModifyHostsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFleet asynchronously, invoking a callback when done
 -- @param CreateFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFleetAsync(CreateFleetRequest, cb)
 	assert(CreateFleetRequest, "You must provide a CreateFleetRequest")
 	local headers = {
@@ -44843,19 +44887,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFleetSync(CreateFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFleetAsync(CreateFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFleetAsync(CreateFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootInstances asynchronously, invoking a callback when done
 -- @param RebootInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootInstancesAsync(RebootInstancesRequest, cb)
 	assert(RebootInstancesRequest, "You must provide a RebootInstancesRequest")
 	local headers = {
@@ -44878,19 +44923,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootInstancesSync(RebootInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootInstancesAsync(RebootInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootInstancesAsync(RebootInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIdentityIdFormat asynchronously, invoking a callback when done
 -- @param DescribeIdentityIdFormatRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIdentityIdFormatAsync(DescribeIdentityIdFormatRequest, cb)
 	assert(DescribeIdentityIdFormatRequest, "You must provide a DescribeIdentityIdFormatRequest")
 	local headers = {
@@ -44913,19 +44959,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIdentityIdFormatRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIdentityIdFormatSync(DescribeIdentityIdFormatRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIdentityIdFormatAsync(DescribeIdentityIdFormatRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIdentityIdFormatAsync(DescribeIdentityIdFormatRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyIdentityIdFormat asynchronously, invoking a callback when done
 -- @param ModifyIdentityIdFormatRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyIdentityIdFormatAsync(ModifyIdentityIdFormatRequest, cb)
 	assert(ModifyIdentityIdFormatRequest, "You must provide a ModifyIdentityIdFormatRequest")
 	local headers = {
@@ -44948,19 +44995,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyIdentityIdFormatRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyIdentityIdFormatSync(ModifyIdentityIdFormatRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyIdentityIdFormatAsync(ModifyIdentityIdFormatRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyIdentityIdFormatAsync(ModifyIdentityIdFormatRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSpotFleetRequestHistory asynchronously, invoking a callback when done
 -- @param DescribeSpotFleetRequestHistoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSpotFleetRequestHistoryAsync(DescribeSpotFleetRequestHistoryRequest, cb)
 	assert(DescribeSpotFleetRequestHistoryRequest, "You must provide a DescribeSpotFleetRequestHistoryRequest")
 	local headers = {
@@ -44983,19 +45031,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSpotFleetRequestHistoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSpotFleetRequestHistorySync(DescribeSpotFleetRequestHistoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSpotFleetRequestHistoryAsync(DescribeSpotFleetRequestHistoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSpotFleetRequestHistoryAsync(DescribeSpotFleetRequestHistoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseScheduledInstances asynchronously, invoking a callback when done
 -- @param PurchaseScheduledInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseScheduledInstancesAsync(PurchaseScheduledInstancesRequest, cb)
 	assert(PurchaseScheduledInstancesRequest, "You must provide a PurchaseScheduledInstancesRequest")
 	local headers = {
@@ -45018,19 +45067,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseScheduledInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseScheduledInstancesSync(PurchaseScheduledInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseScheduledInstancesAsync(PurchaseScheduledInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseScheduledInstancesAsync(PurchaseScheduledInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyInstanceCreditSpecification asynchronously, invoking a callback when done
 -- @param ModifyInstanceCreditSpecificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyInstanceCreditSpecificationAsync(ModifyInstanceCreditSpecificationRequest, cb)
 	assert(ModifyInstanceCreditSpecificationRequest, "You must provide a ModifyInstanceCreditSpecificationRequest")
 	local headers = {
@@ -45053,19 +45103,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyInstanceCreditSpecificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyInstanceCreditSpecificationSync(ModifyInstanceCreditSpecificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyInstanceCreditSpecificationAsync(ModifyInstanceCreditSpecificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyInstanceCreditSpecificationAsync(ModifyInstanceCreditSpecificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachVolume asynchronously, invoking a callback when done
 -- @param DetachVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachVolumeAsync(DetachVolumeRequest, cb)
 	assert(DetachVolumeRequest, "You must provide a DetachVolumeRequest")
 	local headers = {
@@ -45088,19 +45139,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachVolumeSync(DetachVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachVolumeAsync(DetachVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachVolumeAsync(DetachVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIamInstanceProfileAssociations asynchronously, invoking a callback when done
 -- @param DescribeIamInstanceProfileAssociationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIamInstanceProfileAssociationsAsync(DescribeIamInstanceProfileAssociationsRequest, cb)
 	assert(DescribeIamInstanceProfileAssociationsRequest, "You must provide a DescribeIamInstanceProfileAssociationsRequest")
 	local headers = {
@@ -45123,19 +45175,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIamInstanceProfileAssociationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIamInstanceProfileAssociationsSync(DescribeIamInstanceProfileAssociationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIamInstanceProfileAssociationsAsync(DescribeIamInstanceProfileAssociationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIamInstanceProfileAssociationsAsync(DescribeIamInstanceProfileAssociationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssignPrivateIpAddresses asynchronously, invoking a callback when done
 -- @param AssignPrivateIpAddressesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssignPrivateIpAddressesAsync(AssignPrivateIpAddressesRequest, cb)
 	assert(AssignPrivateIpAddressesRequest, "You must provide a AssignPrivateIpAddressesRequest")
 	local headers = {
@@ -45158,19 +45211,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssignPrivateIpAddressesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssignPrivateIpAddressesSync(AssignPrivateIpAddressesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssignPrivateIpAddressesAsync(AssignPrivateIpAddressesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssignPrivateIpAddressesAsync(AssignPrivateIpAddressesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelExportTask asynchronously, invoking a callback when done
 -- @param CancelExportTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelExportTaskAsync(CancelExportTaskRequest, cb)
 	assert(CancelExportTaskRequest, "You must provide a CancelExportTaskRequest")
 	local headers = {
@@ -45193,19 +45247,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelExportTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelExportTaskSync(CancelExportTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelExportTaskAsync(CancelExportTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelExportTaskAsync(CancelExportTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptVpcEndpointConnections asynchronously, invoking a callback when done
 -- @param AcceptVpcEndpointConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptVpcEndpointConnectionsAsync(AcceptVpcEndpointConnectionsRequest, cb)
 	assert(AcceptVpcEndpointConnectionsRequest, "You must provide a AcceptVpcEndpointConnectionsRequest")
 	local headers = {
@@ -45228,19 +45283,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptVpcEndpointConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptVpcEndpointConnectionsSync(AcceptVpcEndpointConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptVpcEndpointConnectionsAsync(AcceptVpcEndpointConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptVpcEndpointConnectionsAsync(AcceptVpcEndpointConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachVpnGateway asynchronously, invoking a callback when done
 -- @param DetachVpnGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachVpnGatewayAsync(DetachVpnGatewayRequest, cb)
 	assert(DetachVpnGatewayRequest, "You must provide a DetachVpnGatewayRequest")
 	local headers = {
@@ -45263,19 +45319,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachVpnGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachVpnGatewaySync(DetachVpnGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachVpnGatewayAsync(DetachVpnGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachVpnGatewayAsync(DetachVpnGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcAttribute asynchronously, invoking a callback when done
 -- @param DescribeVpcAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcAttributeAsync(DescribeVpcAttributeRequest, cb)
 	assert(DescribeVpcAttributeRequest, "You must provide a DescribeVpcAttributeRequest")
 	local headers = {
@@ -45298,19 +45355,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcAttributeSync(DescribeVpcAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcAttributeAsync(DescribeVpcAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcAttributeAsync(DescribeVpcAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelBundleTask asynchronously, invoking a callback when done
 -- @param CancelBundleTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelBundleTaskAsync(CancelBundleTaskRequest, cb)
 	assert(CancelBundleTaskRequest, "You must provide a CancelBundleTaskRequest")
 	local headers = {
@@ -45333,19 +45391,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelBundleTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelBundleTaskSync(CancelBundleTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelBundleTaskAsync(CancelBundleTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelBundleTaskAsync(CancelBundleTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNatGateways asynchronously, invoking a callback when done
 -- @param DescribeNatGatewaysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNatGatewaysAsync(DescribeNatGatewaysRequest, cb)
 	assert(DescribeNatGatewaysRequest, "You must provide a DescribeNatGatewaysRequest")
 	local headers = {
@@ -45368,19 +45427,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNatGatewaysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNatGatewaysSync(DescribeNatGatewaysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNatGatewaysAsync(DescribeNatGatewaysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNatGatewaysAsync(DescribeNatGatewaysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateSubnetCidrBlock asynchronously, invoking a callback when done
 -- @param DisassociateSubnetCidrBlockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateSubnetCidrBlockAsync(DisassociateSubnetCidrBlockRequest, cb)
 	assert(DisassociateSubnetCidrBlockRequest, "You must provide a DisassociateSubnetCidrBlockRequest")
 	local headers = {
@@ -45403,19 +45463,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateSubnetCidrBlockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateSubnetCidrBlockSync(DisassociateSubnetCidrBlockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateSubnetCidrBlockAsync(DisassociateSubnetCidrBlockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateSubnetCidrBlockAsync(DisassociateSubnetCidrBlockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpcPeeringConnection asynchronously, invoking a callback when done
 -- @param CreateVpcPeeringConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcPeeringConnectionAsync(CreateVpcPeeringConnectionRequest, cb)
 	assert(CreateVpcPeeringConnectionRequest, "You must provide a CreateVpcPeeringConnectionRequest")
 	local headers = {
@@ -45438,19 +45499,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcPeeringConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcPeeringConnectionSync(CreateVpcPeeringConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcPeeringConnectionAsync(CreateVpcPeeringConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcPeeringConnectionAsync(CreateVpcPeeringConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyIdFormat asynchronously, invoking a callback when done
 -- @param ModifyIdFormatRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyIdFormatAsync(ModifyIdFormatRequest, cb)
 	assert(ModifyIdFormatRequest, "You must provide a ModifyIdFormatRequest")
 	local headers = {
@@ -45473,19 +45535,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyIdFormatRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyIdFormatSync(ModifyIdFormatRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyIdFormatAsync(ModifyIdFormatRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyIdFormatAsync(ModifyIdFormatRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSpotFleetRequests asynchronously, invoking a callback when done
 -- @param DescribeSpotFleetRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSpotFleetRequestsAsync(DescribeSpotFleetRequestsRequest, cb)
 	assert(DescribeSpotFleetRequestsRequest, "You must provide a DescribeSpotFleetRequestsRequest")
 	local headers = {
@@ -45508,19 +45571,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSpotFleetRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSpotFleetRequestsSync(DescribeSpotFleetRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSpotFleetRequestsAsync(DescribeSpotFleetRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSpotFleetRequestsAsync(DescribeSpotFleetRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AllocateHosts asynchronously, invoking a callback when done
 -- @param AllocateHostsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AllocateHostsAsync(AllocateHostsRequest, cb)
 	assert(AllocateHostsRequest, "You must provide a AllocateHostsRequest")
 	local headers = {
@@ -45543,19 +45607,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AllocateHostsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AllocateHostsSync(AllocateHostsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AllocateHostsAsync(AllocateHostsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AllocateHostsAsync(AllocateHostsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNetworkAcl asynchronously, invoking a callback when done
 -- @param DeleteNetworkAclRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNetworkAclAsync(DeleteNetworkAclRequest, cb)
 	assert(DeleteNetworkAclRequest, "You must provide a DeleteNetworkAclRequest")
 	local headers = {
@@ -45578,19 +45643,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNetworkAclRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNetworkAclSync(DeleteNetworkAclRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNetworkAclAsync(DeleteNetworkAclRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNetworkAclAsync(DeleteNetworkAclRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call WithdrawByoipCidr asynchronously, invoking a callback when done
 -- @param WithdrawByoipCidrRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.WithdrawByoipCidrAsync(WithdrawByoipCidrRequest, cb)
 	assert(WithdrawByoipCidrRequest, "You must provide a WithdrawByoipCidrRequest")
 	local headers = {
@@ -45613,19 +45679,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param WithdrawByoipCidrRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.WithdrawByoipCidrSync(WithdrawByoipCidrRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.WithdrawByoipCidrAsync(WithdrawByoipCidrRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.WithdrawByoipCidrAsync(WithdrawByoipCidrRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHostReservationPurchasePreview asynchronously, invoking a callback when done
 -- @param GetHostReservationPurchasePreviewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHostReservationPurchasePreviewAsync(GetHostReservationPurchasePreviewRequest, cb)
 	assert(GetHostReservationPurchasePreviewRequest, "You must provide a GetHostReservationPurchasePreviewRequest")
 	local headers = {
@@ -45648,19 +45715,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHostReservationPurchasePreviewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHostReservationPurchasePreviewSync(GetHostReservationPurchasePreviewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHostReservationPurchasePreviewAsync(GetHostReservationPurchasePreviewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHostReservationPurchasePreviewAsync(GetHostReservationPurchasePreviewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSecurityGroup asynchronously, invoking a callback when done
 -- @param DeleteSecurityGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSecurityGroupAsync(DeleteSecurityGroupRequest, cb)
 	assert(DeleteSecurityGroupRequest, "You must provide a DeleteSecurityGroupRequest")
 	local headers = {
@@ -45683,19 +45751,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSecurityGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSecurityGroupSync(DeleteSecurityGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSecurityGroupAsync(DeleteSecurityGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSecurityGroupAsync(DeleteSecurityGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSecurityGroupRuleDescriptionsEgress asynchronously, invoking a callback when done
 -- @param UpdateSecurityGroupRuleDescriptionsEgressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSecurityGroupRuleDescriptionsEgressAsync(UpdateSecurityGroupRuleDescriptionsEgressRequest, cb)
 	assert(UpdateSecurityGroupRuleDescriptionsEgressRequest, "You must provide a UpdateSecurityGroupRuleDescriptionsEgressRequest")
 	local headers = {
@@ -45718,19 +45787,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSecurityGroupRuleDescriptionsEgressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSecurityGroupRuleDescriptionsEgressSync(UpdateSecurityGroupRuleDescriptionsEgressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSecurityGroupRuleDescriptionsEgressAsync(UpdateSecurityGroupRuleDescriptionsEgressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSecurityGroupRuleDescriptionsEgressAsync(UpdateSecurityGroupRuleDescriptionsEgressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSnapshot asynchronously, invoking a callback when done
 -- @param CreateSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSnapshotAsync(CreateSnapshotRequest, cb)
 	assert(CreateSnapshotRequest, "You must provide a CreateSnapshotRequest")
 	local headers = {
@@ -45753,19 +45823,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSnapshotSync(CreateSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSnapshotAsync(CreateSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSnapshotAsync(CreateSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSubnet asynchronously, invoking a callback when done
 -- @param CreateSubnetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSubnetAsync(CreateSubnetRequest, cb)
 	assert(CreateSubnetRequest, "You must provide a CreateSubnetRequest")
 	local headers = {
@@ -45788,19 +45859,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSubnetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSubnetSync(CreateSubnetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSubnetAsync(CreateSubnetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSubnetAsync(CreateSubnetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RequestSpotFleet asynchronously, invoking a callback when done
 -- @param RequestSpotFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RequestSpotFleetAsync(RequestSpotFleetRequest, cb)
 	assert(RequestSpotFleetRequest, "You must provide a RequestSpotFleetRequest")
 	local headers = {
@@ -45823,19 +45895,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RequestSpotFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RequestSpotFleetSync(RequestSpotFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RequestSpotFleetAsync(RequestSpotFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RequestSpotFleetAsync(RequestSpotFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyImageAttribute asynchronously, invoking a callback when done
 -- @param ModifyImageAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyImageAttributeAsync(ModifyImageAttributeRequest, cb)
 	assert(ModifyImageAttributeRequest, "You must provide a ModifyImageAttributeRequest")
 	local headers = {
@@ -45858,19 +45931,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyImageAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyImageAttributeSync(ModifyImageAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyImageAttributeAsync(ModifyImageAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyImageAttributeAsync(ModifyImageAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyInstanceCapacityReservationAttributes asynchronously, invoking a callback when done
 -- @param ModifyInstanceCapacityReservationAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyInstanceCapacityReservationAttributesAsync(ModifyInstanceCapacityReservationAttributesRequest, cb)
 	assert(ModifyInstanceCapacityReservationAttributesRequest, "You must provide a ModifyInstanceCapacityReservationAttributesRequest")
 	local headers = {
@@ -45893,19 +45967,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyInstanceCapacityReservationAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyInstanceCapacityReservationAttributesSync(ModifyInstanceCapacityReservationAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyInstanceCapacityReservationAttributesAsync(ModifyInstanceCapacityReservationAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyInstanceCapacityReservationAttributesAsync(ModifyInstanceCapacityReservationAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateSubnetCidrBlock asynchronously, invoking a callback when done
 -- @param AssociateSubnetCidrBlockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateSubnetCidrBlockAsync(AssociateSubnetCidrBlockRequest, cb)
 	assert(AssociateSubnetCidrBlockRequest, "You must provide a AssociateSubnetCidrBlockRequest")
 	local headers = {
@@ -45928,19 +46003,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateSubnetCidrBlockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateSubnetCidrBlockSync(AssociateSubnetCidrBlockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateSubnetCidrBlockAsync(AssociateSubnetCidrBlockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateSubnetCidrBlockAsync(AssociateSubnetCidrBlockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyFpgaImageAttribute asynchronously, invoking a callback when done
 -- @param ModifyFpgaImageAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyFpgaImageAttributeAsync(ModifyFpgaImageAttributeRequest, cb)
 	assert(ModifyFpgaImageAttributeRequest, "You must provide a ModifyFpgaImageAttributeRequest")
 	local headers = {
@@ -45963,19 +46039,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyFpgaImageAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyFpgaImageAttributeSync(ModifyFpgaImageAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyFpgaImageAttributeAsync(ModifyFpgaImageAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyFpgaImageAttributeAsync(ModifyFpgaImageAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartInstances asynchronously, invoking a callback when done
 -- @param StartInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartInstancesAsync(StartInstancesRequest, cb)
 	assert(StartInstancesRequest, "You must provide a StartInstancesRequest")
 	local headers = {
@@ -45998,19 +46075,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartInstancesSync(StartInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartInstancesAsync(StartInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartInstancesAsync(StartInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSpotInstanceRequests asynchronously, invoking a callback when done
 -- @param DescribeSpotInstanceRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSpotInstanceRequestsAsync(DescribeSpotInstanceRequestsRequest, cb)
 	assert(DescribeSpotInstanceRequestsRequest, "You must provide a DescribeSpotInstanceRequestsRequest")
 	local headers = {
@@ -46033,19 +46111,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSpotInstanceRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSpotInstanceRequestsSync(DescribeSpotInstanceRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSpotInstanceRequestsAsync(DescribeSpotInstanceRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSpotInstanceRequestsAsync(DescribeSpotInstanceRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableVgwRoutePropagation asynchronously, invoking a callback when done
 -- @param DisableVgwRoutePropagationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableVgwRoutePropagationAsync(DisableVgwRoutePropagationRequest, cb)
 	assert(DisableVgwRoutePropagationRequest, "You must provide a DisableVgwRoutePropagationRequest")
 	local headers = {
@@ -46068,19 +46147,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableVgwRoutePropagationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableVgwRoutePropagationSync(DisableVgwRoutePropagationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableVgwRoutePropagationAsync(DisableVgwRoutePropagationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableVgwRoutePropagationAsync(DisableVgwRoutePropagationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetFpgaImageAttribute asynchronously, invoking a callback when done
 -- @param ResetFpgaImageAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetFpgaImageAttributeAsync(ResetFpgaImageAttributeRequest, cb)
 	assert(ResetFpgaImageAttributeRequest, "You must provide a ResetFpgaImageAttributeRequest")
 	local headers = {
@@ -46103,19 +46183,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetFpgaImageAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetFpgaImageAttributeSync(ResetFpgaImageAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetFpgaImageAttributeAsync(ResetFpgaImageAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetFpgaImageAttributeAsync(ResetFpgaImageAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcs asynchronously, invoking a callback when done
 -- @param DescribeVpcsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcsAsync(DescribeVpcsRequest, cb)
 	assert(DescribeVpcsRequest, "You must provide a DescribeVpcsRequest")
 	local headers = {
@@ -46138,19 +46219,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcsSync(DescribeVpcsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcsAsync(DescribeVpcsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcsAsync(DescribeVpcsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateAddress asynchronously, invoking a callback when done
 -- @param DisassociateAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateAddressAsync(DisassociateAddressRequest, cb)
 	assert(DisassociateAddressRequest, "You must provide a DisassociateAddressRequest")
 	local headers = {
@@ -46173,19 +46255,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateAddressSync(DisassociateAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateAddressAsync(DisassociateAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateAddressAsync(DisassociateAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifySnapshotAttribute asynchronously, invoking a callback when done
 -- @param ModifySnapshotAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifySnapshotAttributeAsync(ModifySnapshotAttributeRequest, cb)
 	assert(ModifySnapshotAttributeRequest, "You must provide a ModifySnapshotAttributeRequest")
 	local headers = {
@@ -46208,19 +46291,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifySnapshotAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifySnapshotAttributeSync(ModifySnapshotAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifySnapshotAttributeAsync(ModifySnapshotAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifySnapshotAttributeAsync(ModifySnapshotAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call MoveAddressToVpc asynchronously, invoking a callback when done
 -- @param MoveAddressToVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.MoveAddressToVpcAsync(MoveAddressToVpcRequest, cb)
 	assert(MoveAddressToVpcRequest, "You must provide a MoveAddressToVpcRequest")
 	local headers = {
@@ -46243,19 +46327,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param MoveAddressToVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.MoveAddressToVpcSync(MoveAddressToVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.MoveAddressToVpcAsync(MoveAddressToVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.MoveAddressToVpcAsync(MoveAddressToVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVpcEndpointConnectionNotification asynchronously, invoking a callback when done
 -- @param ModifyVpcEndpointConnectionNotificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVpcEndpointConnectionNotificationAsync(ModifyVpcEndpointConnectionNotificationRequest, cb)
 	assert(ModifyVpcEndpointConnectionNotificationRequest, "You must provide a ModifyVpcEndpointConnectionNotificationRequest")
 	local headers = {
@@ -46278,19 +46363,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVpcEndpointConnectionNotificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVpcEndpointConnectionNotificationSync(ModifyVpcEndpointConnectionNotificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVpcEndpointConnectionNotificationAsync(ModifyVpcEndpointConnectionNotificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVpcEndpointConnectionNotificationAsync(ModifyVpcEndpointConnectionNotificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyInstanceAttribute asynchronously, invoking a callback when done
 -- @param ModifyInstanceAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyInstanceAttributeAsync(ModifyInstanceAttributeRequest, cb)
 	assert(ModifyInstanceAttributeRequest, "You must provide a ModifyInstanceAttributeRequest")
 	local headers = {
@@ -46313,19 +46399,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyInstanceAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyInstanceAttributeSync(ModifyInstanceAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyInstanceAttributeAsync(ModifyInstanceAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyInstanceAttributeAsync(ModifyInstanceAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpc asynchronously, invoking a callback when done
 -- @param CreateVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcAsync(CreateVpcRequest, cb)
 	assert(CreateVpcRequest, "You must provide a CreateVpcRequest")
 	local headers = {
@@ -46348,19 +46435,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcSync(CreateVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcAsync(CreateVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcAsync(CreateVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcEndpointServices asynchronously, invoking a callback when done
 -- @param DescribeVpcEndpointServicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcEndpointServicesAsync(DescribeVpcEndpointServicesRequest, cb)
 	assert(DescribeVpcEndpointServicesRequest, "You must provide a DescribeVpcEndpointServicesRequest")
 	local headers = {
@@ -46383,19 +46471,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcEndpointServicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcEndpointServicesSync(DescribeVpcEndpointServicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcEndpointServicesAsync(DescribeVpcEndpointServicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcEndpointServicesAsync(DescribeVpcEndpointServicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelSpotFleetRequests asynchronously, invoking a callback when done
 -- @param CancelSpotFleetRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelSpotFleetRequestsAsync(CancelSpotFleetRequestsRequest, cb)
 	assert(CancelSpotFleetRequestsRequest, "You must provide a CancelSpotFleetRequestsRequest")
 	local headers = {
@@ -46418,19 +46507,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelSpotFleetRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelSpotFleetRequestsSync(CancelSpotFleetRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelSpotFleetRequestsAsync(CancelSpotFleetRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelSpotFleetRequestsAsync(CancelSpotFleetRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnmonitorInstances asynchronously, invoking a callback when done
 -- @param UnmonitorInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnmonitorInstancesAsync(UnmonitorInstancesRequest, cb)
 	assert(UnmonitorInstancesRequest, "You must provide a UnmonitorInstancesRequest")
 	local headers = {
@@ -46453,19 +46543,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnmonitorInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnmonitorInstancesSync(UnmonitorInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnmonitorInstancesAsync(UnmonitorInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnmonitorInstancesAsync(UnmonitorInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSubnet asynchronously, invoking a callback when done
 -- @param DeleteSubnetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSubnetAsync(DeleteSubnetRequest, cb)
 	assert(DeleteSubnetRequest, "You must provide a DeleteSubnetRequest")
 	local headers = {
@@ -46488,19 +46579,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSubnetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSubnetSync(DeleteSubnetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSubnetAsync(DeleteSubnetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSubnetAsync(DeleteSubnetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePlacementGroup asynchronously, invoking a callback when done
 -- @param CreatePlacementGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePlacementGroupAsync(CreatePlacementGroupRequest, cb)
 	assert(CreatePlacementGroupRequest, "You must provide a CreatePlacementGroupRequest")
 	local headers = {
@@ -46523,19 +46615,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePlacementGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePlacementGroupSync(CreatePlacementGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePlacementGroupAsync(CreatePlacementGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePlacementGroupAsync(CreatePlacementGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopySnapshot asynchronously, invoking a callback when done
 -- @param CopySnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopySnapshotAsync(CopySnapshotRequest, cb)
 	assert(CopySnapshotRequest, "You must provide a CopySnapshotRequest")
 	local headers = {
@@ -46558,19 +46651,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopySnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopySnapshotSync(CopySnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopySnapshotAsync(CopySnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopySnapshotAsync(CopySnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableVpcClassicLinkDnsSupport asynchronously, invoking a callback when done
 -- @param DisableVpcClassicLinkDnsSupportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableVpcClassicLinkDnsSupportAsync(DisableVpcClassicLinkDnsSupportRequest, cb)
 	assert(DisableVpcClassicLinkDnsSupportRequest, "You must provide a DisableVpcClassicLinkDnsSupportRequest")
 	local headers = {
@@ -46593,19 +46687,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableVpcClassicLinkDnsSupportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableVpcClassicLinkDnsSupportSync(DisableVpcClassicLinkDnsSupportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableVpcClassicLinkDnsSupportAsync(DisableVpcClassicLinkDnsSupportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableVpcClassicLinkDnsSupportAsync(DisableVpcClassicLinkDnsSupportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHostReservationOfferings asynchronously, invoking a callback when done
 -- @param DescribeHostReservationOfferingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHostReservationOfferingsAsync(DescribeHostReservationOfferingsRequest, cb)
 	assert(DescribeHostReservationOfferingsRequest, "You must provide a DescribeHostReservationOfferingsRequest")
 	local headers = {
@@ -46628,19 +46723,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHostReservationOfferingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHostReservationOfferingsSync(DescribeHostReservationOfferingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHostReservationOfferingsAsync(DescribeHostReservationOfferingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHostReservationOfferingsAsync(DescribeHostReservationOfferingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVolumesModifications asynchronously, invoking a callback when done
 -- @param DescribeVolumesModificationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVolumesModificationsAsync(DescribeVolumesModificationsRequest, cb)
 	assert(DescribeVolumesModificationsRequest, "You must provide a DescribeVolumesModificationsRequest")
 	local headers = {
@@ -46663,19 +46759,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVolumesModificationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVolumesModificationsSync(DescribeVolumesModificationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVolumesModificationsAsync(DescribeVolumesModificationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVolumesModificationsAsync(DescribeVolumesModificationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpnGateways asynchronously, invoking a callback when done
 -- @param DescribeVpnGatewaysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpnGatewaysAsync(DescribeVpnGatewaysRequest, cb)
 	assert(DescribeVpnGatewaysRequest, "You must provide a DescribeVpnGatewaysRequest")
 	local headers = {
@@ -46698,19 +46795,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpnGatewaysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpnGatewaysSync(DescribeVpnGatewaysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpnGatewaysAsync(DescribeVpnGatewaysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpnGatewaysAsync(DescribeVpnGatewaysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateVpcCidrBlock asynchronously, invoking a callback when done
 -- @param AssociateVpcCidrBlockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateVpcCidrBlockAsync(AssociateVpcCidrBlockRequest, cb)
 	assert(AssociateVpcCidrBlockRequest, "You must provide a AssociateVpcCidrBlockRequest")
 	local headers = {
@@ -46733,19 +46831,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateVpcCidrBlockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateVpcCidrBlockSync(AssociateVpcCidrBlockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateVpcCidrBlockAsync(AssociateVpcCidrBlockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateVpcCidrBlockAsync(AssociateVpcCidrBlockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateAddress asynchronously, invoking a callback when done
 -- @param AssociateAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateAddressAsync(AssociateAddressRequest, cb)
 	assert(AssociateAddressRequest, "You must provide a AssociateAddressRequest")
 	local headers = {
@@ -46768,19 +46867,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateAddressSync(AssociateAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateAddressAsync(AssociateAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateAddressAsync(AssociateAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCustomerGateway asynchronously, invoking a callback when done
 -- @param DeleteCustomerGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCustomerGatewayAsync(DeleteCustomerGatewayRequest, cb)
 	assert(DeleteCustomerGatewayRequest, "You must provide a DeleteCustomerGatewayRequest")
 	local headers = {
@@ -46803,19 +46903,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCustomerGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCustomerGatewaySync(DeleteCustomerGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCustomerGatewayAsync(DeleteCustomerGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCustomerGatewayAsync(DeleteCustomerGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyFpgaImage asynchronously, invoking a callback when done
 -- @param CopyFpgaImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyFpgaImageAsync(CopyFpgaImageRequest, cb)
 	assert(CopyFpgaImageRequest, "You must provide a CopyFpgaImageRequest")
 	local headers = {
@@ -46838,19 +46939,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyFpgaImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyFpgaImageSync(CopyFpgaImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyFpgaImageAsync(CopyFpgaImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyFpgaImageAsync(CopyFpgaImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInternetGateway asynchronously, invoking a callback when done
 -- @param CreateInternetGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInternetGatewayAsync(CreateInternetGatewayRequest, cb)
 	assert(CreateInternetGatewayRequest, "You must provide a CreateInternetGatewayRequest")
 	local headers = {
@@ -46873,19 +46975,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInternetGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInternetGatewaySync(CreateInternetGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInternetGatewayAsync(CreateInternetGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInternetGatewayAsync(CreateInternetGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLaunchTemplate asynchronously, invoking a callback when done
 -- @param CreateLaunchTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLaunchTemplateAsync(CreateLaunchTemplateRequest, cb)
 	assert(CreateLaunchTemplateRequest, "You must provide a CreateLaunchTemplateRequest")
 	local headers = {
@@ -46908,19 +47011,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLaunchTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLaunchTemplateSync(CreateLaunchTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLaunchTemplateAsync(CreateLaunchTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLaunchTemplateAsync(CreateLaunchTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachClassicLinkVpc asynchronously, invoking a callback when done
 -- @param AttachClassicLinkVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachClassicLinkVpcAsync(AttachClassicLinkVpcRequest, cb)
 	assert(AttachClassicLinkVpcRequest, "You must provide a AttachClassicLinkVpcRequest")
 	local headers = {
@@ -46943,19 +47047,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachClassicLinkVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachClassicLinkVpcSync(AttachClassicLinkVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachClassicLinkVpcAsync(AttachClassicLinkVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachClassicLinkVpcAsync(AttachClassicLinkVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSpotPriceHistory asynchronously, invoking a callback when done
 -- @param DescribeSpotPriceHistoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSpotPriceHistoryAsync(DescribeSpotPriceHistoryRequest, cb)
 	assert(DescribeSpotPriceHistoryRequest, "You must provide a DescribeSpotPriceHistoryRequest")
 	local headers = {
@@ -46978,19 +47083,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSpotPriceHistoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSpotPriceHistorySync(DescribeSpotPriceHistoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSpotPriceHistoryAsync(DescribeSpotPriceHistoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSpotPriceHistoryAsync(DescribeSpotPriceHistoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDhcpOptions asynchronously, invoking a callback when done
 -- @param DescribeDhcpOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDhcpOptionsAsync(DescribeDhcpOptionsRequest, cb)
 	assert(DescribeDhcpOptionsRequest, "You must provide a DescribeDhcpOptionsRequest")
 	local headers = {
@@ -47013,19 +47119,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDhcpOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDhcpOptionsSync(DescribeDhcpOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDhcpOptionsAsync(DescribeDhcpOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDhcpOptionsAsync(DescribeDhcpOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpcPeeringConnection asynchronously, invoking a callback when done
 -- @param DeleteVpcPeeringConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcPeeringConnectionAsync(DeleteVpcPeeringConnectionRequest, cb)
 	assert(DeleteVpcPeeringConnectionRequest, "You must provide a DeleteVpcPeeringConnectionRequest")
 	local headers = {
@@ -47048,19 +47155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcPeeringConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcPeeringConnectionSync(DeleteVpcPeeringConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcPeeringConnectionAsync(DeleteVpcPeeringConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcPeeringConnectionAsync(DeleteVpcPeeringConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFlowLogs asynchronously, invoking a callback when done
 -- @param DescribeFlowLogsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFlowLogsAsync(DescribeFlowLogsRequest, cb)
 	assert(DescribeFlowLogsRequest, "You must provide a DescribeFlowLogsRequest")
 	local headers = {
@@ -47083,19 +47191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFlowLogsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFlowLogsSync(DescribeFlowLogsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFlowLogsAsync(DescribeFlowLogsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFlowLogsAsync(DescribeFlowLogsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNetworkAclEntry asynchronously, invoking a callback when done
 -- @param CreateNetworkAclEntryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNetworkAclEntryAsync(CreateNetworkAclEntryRequest, cb)
 	assert(CreateNetworkAclEntryRequest, "You must provide a CreateNetworkAclEntryRequest")
 	local headers = {
@@ -47118,19 +47227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNetworkAclEntryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNetworkAclEntrySync(CreateNetworkAclEntryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNetworkAclEntryAsync(CreateNetworkAclEntryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNetworkAclEntryAsync(CreateNetworkAclEntryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReleaseHosts asynchronously, invoking a callback when done
 -- @param ReleaseHostsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReleaseHostsAsync(ReleaseHostsRequest, cb)
 	assert(ReleaseHostsRequest, "You must provide a ReleaseHostsRequest")
 	local headers = {
@@ -47153,19 +47263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReleaseHostsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReleaseHostsSync(ReleaseHostsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReleaseHostsAsync(ReleaseHostsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReleaseHostsAsync(ReleaseHostsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreAddressToClassic asynchronously, invoking a callback when done
 -- @param RestoreAddressToClassicRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreAddressToClassicAsync(RestoreAddressToClassicRequest, cb)
 	assert(RestoreAddressToClassicRequest, "You must provide a RestoreAddressToClassicRequest")
 	local headers = {
@@ -47188,19 +47299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreAddressToClassicRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreAddressToClassicSync(RestoreAddressToClassicRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreAddressToClassicAsync(RestoreAddressToClassicRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreAddressToClassicAsync(RestoreAddressToClassicRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNetworkInterface asynchronously, invoking a callback when done
 -- @param CreateNetworkInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNetworkInterfaceAsync(CreateNetworkInterfaceRequest, cb)
 	assert(CreateNetworkInterfaceRequest, "You must provide a CreateNetworkInterfaceRequest")
 	local headers = {
@@ -47223,19 +47335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNetworkInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNetworkInterfaceSync(CreateNetworkInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNetworkInterfaceAsync(CreateNetworkInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNetworkInterfaceAsync(CreateNetworkInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLaunchTemplateVersions asynchronously, invoking a callback when done
 -- @param DeleteLaunchTemplateVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLaunchTemplateVersionsAsync(DeleteLaunchTemplateVersionsRequest, cb)
 	assert(DeleteLaunchTemplateVersionsRequest, "You must provide a DeleteLaunchTemplateVersionsRequest")
 	local headers = {
@@ -47258,19 +47371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLaunchTemplateVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLaunchTemplateVersionsSync(DeleteLaunchTemplateVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLaunchTemplateVersionsAsync(DeleteLaunchTemplateVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLaunchTemplateVersionsAsync(DeleteLaunchTemplateVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param RevokeSecurityGroupIngressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeSecurityGroupIngressAsync(RevokeSecurityGroupIngressRequest, cb)
 	assert(RevokeSecurityGroupIngressRequest, "You must provide a RevokeSecurityGroupIngressRequest")
 	local headers = {
@@ -47293,19 +47407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeSecurityGroupIngressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeSecurityGroupIngressSync(RevokeSecurityGroupIngressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeSecurityGroupIngressAsync(RevokeSecurityGroupIngressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeSecurityGroupIngressAsync(RevokeSecurityGroupIngressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnassignPrivateIpAddresses asynchronously, invoking a callback when done
 -- @param UnassignPrivateIpAddressesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnassignPrivateIpAddressesAsync(UnassignPrivateIpAddressesRequest, cb)
 	assert(UnassignPrivateIpAddressesRequest, "You must provide a UnassignPrivateIpAddressesRequest")
 	local headers = {
@@ -47328,19 +47443,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnassignPrivateIpAddressesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnassignPrivateIpAddressesSync(UnassignPrivateIpAddressesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnassignPrivateIpAddressesAsync(UnassignPrivateIpAddressesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnassignPrivateIpAddressesAsync(UnassignPrivateIpAddressesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachInternetGateway asynchronously, invoking a callback when done
 -- @param AttachInternetGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachInternetGatewayAsync(AttachInternetGatewayRequest, cb)
 	assert(AttachInternetGatewayRequest, "You must provide a AttachInternetGatewayRequest")
 	local headers = {
@@ -47363,19 +47479,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachInternetGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachInternetGatewaySync(AttachInternetGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachInternetGatewayAsync(AttachInternetGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachInternetGatewayAsync(AttachInternetGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInstanceExportTask asynchronously, invoking a callback when done
 -- @param CreateInstanceExportTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInstanceExportTaskAsync(CreateInstanceExportTaskRequest, cb)
 	assert(CreateInstanceExportTaskRequest, "You must provide a CreateInstanceExportTaskRequest")
 	local headers = {
@@ -47398,19 +47515,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInstanceExportTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInstanceExportTaskSync(CreateInstanceExportTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInstanceExportTaskAsync(CreateInstanceExportTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInstanceExportTaskAsync(CreateInstanceExportTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDhcpOptions asynchronously, invoking a callback when done
 -- @param DeleteDhcpOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDhcpOptionsAsync(DeleteDhcpOptionsRequest, cb)
 	assert(DeleteDhcpOptionsRequest, "You must provide a DeleteDhcpOptionsRequest")
 	local headers = {
@@ -47433,19 +47551,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDhcpOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDhcpOptionsSync(DeleteDhcpOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDhcpOptionsAsync(DeleteDhcpOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDhcpOptionsAsync(DeleteDhcpOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetNetworkInterfaceAttribute asynchronously, invoking a callback when done
 -- @param ResetNetworkInterfaceAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetNetworkInterfaceAttributeAsync(ResetNetworkInterfaceAttributeRequest, cb)
 	assert(ResetNetworkInterfaceAttributeRequest, "You must provide a ResetNetworkInterfaceAttributeRequest")
 	local headers = {
@@ -47468,19 +47587,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetNetworkInterfaceAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetNetworkInterfaceAttributeSync(ResetNetworkInterfaceAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetNetworkInterfaceAttributeAsync(ResetNetworkInterfaceAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetNetworkInterfaceAttributeAsync(ResetNetworkInterfaceAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyReservedInstances asynchronously, invoking a callback when done
 -- @param ModifyReservedInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyReservedInstancesAsync(ModifyReservedInstancesRequest, cb)
 	assert(ModifyReservedInstancesRequest, "You must provide a ModifyReservedInstancesRequest")
 	local headers = {
@@ -47503,19 +47623,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyReservedInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyReservedInstancesSync(ModifyReservedInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyReservedInstancesAsync(ModifyReservedInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyReservedInstancesAsync(ModifyReservedInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachNetworkInterface asynchronously, invoking a callback when done
 -- @param DetachNetworkInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachNetworkInterfaceAsync(DetachNetworkInterfaceRequest, cb)
 	assert(DetachNetworkInterfaceRequest, "You must provide a DetachNetworkInterfaceRequest")
 	local headers = {
@@ -47538,19 +47659,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachNetworkInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachNetworkInterfaceSync(DetachNetworkInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachNetworkInterfaceAsync(DetachNetworkInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachNetworkInterfaceAsync(DetachNetworkInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImportImageTasks asynchronously, invoking a callback when done
 -- @param DescribeImportImageTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImportImageTasksAsync(DescribeImportImageTasksRequest, cb)
 	assert(DescribeImportImageTasksRequest, "You must provide a DescribeImportImageTasksRequest")
 	local headers = {
@@ -47573,19 +47695,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImportImageTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImportImageTasksSync(DescribeImportImageTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImportImageTasksAsync(DescribeImportImageTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImportImageTasksAsync(DescribeImportImageTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcEndpointServicePermissions asynchronously, invoking a callback when done
 -- @param DescribeVpcEndpointServicePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcEndpointServicePermissionsAsync(DescribeVpcEndpointServicePermissionsRequest, cb)
 	assert(DescribeVpcEndpointServicePermissionsRequest, "You must provide a DescribeVpcEndpointServicePermissionsRequest")
 	local headers = {
@@ -47608,19 +47731,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcEndpointServicePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcEndpointServicePermissionsSync(DescribeVpcEndpointServicePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcEndpointServicePermissionsAsync(DescribeVpcEndpointServicePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcEndpointServicePermissionsAsync(DescribeVpcEndpointServicePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSpotFleetInstances asynchronously, invoking a callback when done
 -- @param DescribeSpotFleetInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSpotFleetInstancesAsync(DescribeSpotFleetInstancesRequest, cb)
 	assert(DescribeSpotFleetInstancesRequest, "You must provide a DescribeSpotFleetInstancesRequest")
 	local headers = {
@@ -47643,19 +47767,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSpotFleetInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSpotFleetInstancesSync(DescribeSpotFleetInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSpotFleetInstancesAsync(DescribeSpotFleetInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSpotFleetInstancesAsync(DescribeSpotFleetInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableVpcClassicLink asynchronously, invoking a callback when done
 -- @param EnableVpcClassicLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableVpcClassicLinkAsync(EnableVpcClassicLinkRequest, cb)
 	assert(EnableVpcClassicLinkRequest, "You must provide a EnableVpcClassicLinkRequest")
 	local headers = {
@@ -47678,19 +47803,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableVpcClassicLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableVpcClassicLinkSync(EnableVpcClassicLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableVpcClassicLinkAsync(EnableVpcClassicLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableVpcClassicLinkAsync(EnableVpcClassicLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFlowLogs asynchronously, invoking a callback when done
 -- @param CreateFlowLogsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFlowLogsAsync(CreateFlowLogsRequest, cb)
 	assert(CreateFlowLogsRequest, "You must provide a CreateFlowLogsRequest")
 	local headers = {
@@ -47713,19 +47839,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFlowLogsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFlowLogsSync(CreateFlowLogsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFlowLogsAsync(CreateFlowLogsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFlowLogsAsync(CreateFlowLogsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateVpcCidrBlock asynchronously, invoking a callback when done
 -- @param DisassociateVpcCidrBlockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateVpcCidrBlockAsync(DisassociateVpcCidrBlockRequest, cb)
 	assert(DisassociateVpcCidrBlockRequest, "You must provide a DisassociateVpcCidrBlockRequest")
 	local headers = {
@@ -47748,19 +47875,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateVpcCidrBlockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateVpcCidrBlockSync(DisassociateVpcCidrBlockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateVpcCidrBlockAsync(DisassociateVpcCidrBlockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateVpcCidrBlockAsync(DisassociateVpcCidrBlockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDefaultSubnet asynchronously, invoking a callback when done
 -- @param CreateDefaultSubnetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDefaultSubnetAsync(CreateDefaultSubnetRequest, cb)
 	assert(CreateDefaultSubnetRequest, "You must provide a CreateDefaultSubnetRequest")
 	local headers = {
@@ -47783,19 +47911,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDefaultSubnetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDefaultSubnetSync(CreateDefaultSubnetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDefaultSubnetAsync(CreateDefaultSubnetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDefaultSubnetAsync(CreateDefaultSubnetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpcEndpointConnectionNotifications asynchronously, invoking a callback when done
 -- @param DeleteVpcEndpointConnectionNotificationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcEndpointConnectionNotificationsAsync(DeleteVpcEndpointConnectionNotificationsRequest, cb)
 	assert(DeleteVpcEndpointConnectionNotificationsRequest, "You must provide a DeleteVpcEndpointConnectionNotificationsRequest")
 	local headers = {
@@ -47818,19 +47947,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcEndpointConnectionNotificationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcEndpointConnectionNotificationsSync(DeleteVpcEndpointConnectionNotificationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcEndpointConnectionNotificationsAsync(DeleteVpcEndpointConnectionNotificationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcEndpointConnectionNotificationsAsync(DeleteVpcEndpointConnectionNotificationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVolumeStatus asynchronously, invoking a callback when done
 -- @param DescribeVolumeStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVolumeStatusAsync(DescribeVolumeStatusRequest, cb)
 	assert(DescribeVolumeStatusRequest, "You must provide a DescribeVolumeStatusRequest")
 	local headers = {
@@ -47853,19 +47983,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVolumeStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVolumeStatusSync(DescribeVolumeStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVolumeStatusAsync(DescribeVolumeStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVolumeStatusAsync(DescribeVolumeStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHosts asynchronously, invoking a callback when done
 -- @param DescribeHostsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHostsAsync(DescribeHostsRequest, cb)
 	assert(DescribeHostsRequest, "You must provide a DescribeHostsRequest")
 	local headers = {
@@ -47888,19 +48019,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHostsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHostsSync(DescribeHostsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHostsAsync(DescribeHostsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHostsAsync(DescribeHostsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcPeeringConnections asynchronously, invoking a callback when done
 -- @param DescribeVpcPeeringConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcPeeringConnectionsAsync(DescribeVpcPeeringConnectionsRequest, cb)
 	assert(DescribeVpcPeeringConnectionsRequest, "You must provide a DescribeVpcPeeringConnectionsRequest")
 	local headers = {
@@ -47923,19 +48055,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcPeeringConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcPeeringConnectionsSync(DescribeVpcPeeringConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcPeeringConnectionsAsync(DescribeVpcPeeringConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcPeeringConnectionsAsync(DescribeVpcPeeringConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVolumes asynchronously, invoking a callback when done
 -- @param DescribeVolumesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVolumesAsync(DescribeVolumesRequest, cb)
 	assert(DescribeVolumesRequest, "You must provide a DescribeVolumesRequest")
 	local headers = {
@@ -47958,19 +48091,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVolumesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVolumesSync(DescribeVolumesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVolumesAsync(DescribeVolumesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVolumesAsync(DescribeVolumesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNetworkInterface asynchronously, invoking a callback when done
 -- @param DeleteNetworkInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNetworkInterfaceAsync(DeleteNetworkInterfaceRequest, cb)
 	assert(DeleteNetworkInterfaceRequest, "You must provide a DeleteNetworkInterfaceRequest")
 	local headers = {
@@ -47993,19 +48127,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNetworkInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNetworkInterfaceSync(DeleteNetworkInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNetworkInterfaceAsync(DeleteNetworkInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNetworkInterfaceAsync(DeleteNetworkInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpnConnections asynchronously, invoking a callback when done
 -- @param DescribeVpnConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpnConnectionsAsync(DescribeVpnConnectionsRequest, cb)
 	assert(DescribeVpnConnectionsRequest, "You must provide a DescribeVpnConnectionsRequest")
 	local headers = {
@@ -48028,19 +48163,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpnConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpnConnectionsSync(DescribeVpnConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpnConnectionsAsync(DescribeVpnConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpnConnectionsAsync(DescribeVpnConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpcEndpoints asynchronously, invoking a callback when done
 -- @param DeleteVpcEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcEndpointsAsync(DeleteVpcEndpointsRequest, cb)
 	assert(DeleteVpcEndpointsRequest, "You must provide a DeleteVpcEndpointsRequest")
 	local headers = {
@@ -48063,19 +48199,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcEndpointsSync(DeleteVpcEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcEndpointsAsync(DeleteVpcEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcEndpointsAsync(DeleteVpcEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVolumeAttribute asynchronously, invoking a callback when done
 -- @param DescribeVolumeAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVolumeAttributeAsync(DescribeVolumeAttributeRequest, cb)
 	assert(DescribeVolumeAttributeRequest, "You must provide a DescribeVolumeAttributeRequest")
 	local headers = {
@@ -48098,19 +48235,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVolumeAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVolumeAttributeSync(DescribeVolumeAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVolumeAttributeAsync(DescribeVolumeAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVolumeAttributeAsync(DescribeVolumeAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteKeyPair asynchronously, invoking a callback when done
 -- @param DeleteKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteKeyPairAsync(DeleteKeyPairRequest, cb)
 	assert(DeleteKeyPairRequest, "You must provide a DeleteKeyPairRequest")
 	local headers = {
@@ -48133,19 +48271,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteKeyPairSync(DeleteKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteKeyPairAsync(DeleteKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteKeyPairAsync(DeleteKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNatGateway asynchronously, invoking a callback when done
 -- @param DeleteNatGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNatGatewayAsync(DeleteNatGatewayRequest, cb)
 	assert(DeleteNatGatewayRequest, "You must provide a DeleteNatGatewayRequest")
 	local headers = {
@@ -48168,19 +48307,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNatGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNatGatewaySync(DeleteNatGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNatGatewayAsync(DeleteNatGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNatGatewayAsync(DeleteNatGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnassignIpv6Addresses asynchronously, invoking a callback when done
 -- @param UnassignIpv6AddressesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnassignIpv6AddressesAsync(UnassignIpv6AddressesRequest, cb)
 	assert(UnassignIpv6AddressesRequest, "You must provide a UnassignIpv6AddressesRequest")
 	local headers = {
@@ -48203,19 +48343,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnassignIpv6AddressesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnassignIpv6AddressesSync(UnassignIpv6AddressesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnassignIpv6AddressesAsync(UnassignIpv6AddressesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnassignIpv6AddressesAsync(UnassignIpv6AddressesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyInstancePlacement asynchronously, invoking a callback when done
 -- @param ModifyInstancePlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyInstancePlacementAsync(ModifyInstancePlacementRequest, cb)
 	assert(ModifyInstancePlacementRequest, "You must provide a ModifyInstancePlacementRequest")
 	local headers = {
@@ -48238,19 +48379,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyInstancePlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyInstancePlacementSync(ModifyInstancePlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyInstancePlacementAsync(ModifyInstancePlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyInstancePlacementAsync(ModifyInstancePlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSecurityGroupRuleDescriptionsIngress asynchronously, invoking a callback when done
 -- @param UpdateSecurityGroupRuleDescriptionsIngressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSecurityGroupRuleDescriptionsIngressAsync(UpdateSecurityGroupRuleDescriptionsIngressRequest, cb)
 	assert(UpdateSecurityGroupRuleDescriptionsIngressRequest, "You must provide a UpdateSecurityGroupRuleDescriptionsIngressRequest")
 	local headers = {
@@ -48273,19 +48415,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSecurityGroupRuleDescriptionsIngressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSecurityGroupRuleDescriptionsIngressSync(UpdateSecurityGroupRuleDescriptionsIngressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSecurityGroupRuleDescriptionsIngressAsync(UpdateSecurityGroupRuleDescriptionsIngressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSecurityGroupRuleDescriptionsIngressAsync(UpdateSecurityGroupRuleDescriptionsIngressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReplaceNetworkAclEntry asynchronously, invoking a callback when done
 -- @param ReplaceNetworkAclEntryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReplaceNetworkAclEntryAsync(ReplaceNetworkAclEntryRequest, cb)
 	assert(ReplaceNetworkAclEntryRequest, "You must provide a ReplaceNetworkAclEntryRequest")
 	local headers = {
@@ -48308,19 +48451,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReplaceNetworkAclEntryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReplaceNetworkAclEntrySync(ReplaceNetworkAclEntryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReplaceNetworkAclEntryAsync(ReplaceNetworkAclEntryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReplaceNetworkAclEntryAsync(ReplaceNetworkAclEntryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEgressOnlyInternetGateway asynchronously, invoking a callback when done
 -- @param CreateEgressOnlyInternetGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEgressOnlyInternetGatewayAsync(CreateEgressOnlyInternetGatewayRequest, cb)
 	assert(CreateEgressOnlyInternetGatewayRequest, "You must provide a CreateEgressOnlyInternetGatewayRequest")
 	local headers = {
@@ -48343,19 +48487,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEgressOnlyInternetGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEgressOnlyInternetGatewaySync(CreateEgressOnlyInternetGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEgressOnlyInternetGatewayAsync(CreateEgressOnlyInternetGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEgressOnlyInternetGatewayAsync(CreateEgressOnlyInternetGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInternetGateway asynchronously, invoking a callback when done
 -- @param DeleteInternetGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInternetGatewayAsync(DeleteInternetGatewayRequest, cb)
 	assert(DeleteInternetGatewayRequest, "You must provide a DeleteInternetGatewayRequest")
 	local headers = {
@@ -48378,19 +48523,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInternetGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInternetGatewaySync(DeleteInternetGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInternetGatewayAsync(DeleteInternetGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInternetGatewayAsync(DeleteInternetGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVolume asynchronously, invoking a callback when done
 -- @param CreateVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVolumeAsync(CreateVolumeRequest, cb)
 	assert(CreateVolumeRequest, "You must provide a CreateVolumeRequest")
 	local headers = {
@@ -48413,19 +48559,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVolumeSync(CreateVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVolumeAsync(CreateVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVolumeAsync(CreateVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RunInstances asynchronously, invoking a callback when done
 -- @param RunInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RunInstancesAsync(RunInstancesRequest, cb)
 	assert(RunInstancesRequest, "You must provide a RunInstancesRequest")
 	local headers = {
@@ -48448,19 +48595,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RunInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RunInstancesSync(RunInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RunInstancesAsync(RunInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RunInstancesAsync(RunInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeScheduledInstances asynchronously, invoking a callback when done
 -- @param DescribeScheduledInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScheduledInstancesAsync(DescribeScheduledInstancesRequest, cb)
 	assert(DescribeScheduledInstancesRequest, "You must provide a DescribeScheduledInstancesRequest")
 	local headers = {
@@ -48483,19 +48631,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScheduledInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScheduledInstancesSync(DescribeScheduledInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScheduledInstancesAsync(DescribeScheduledInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScheduledInstancesAsync(DescribeScheduledInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRoute asynchronously, invoking a callback when done
 -- @param DeleteRouteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRouteAsync(DeleteRouteRequest, cb)
 	assert(DeleteRouteRequest, "You must provide a DeleteRouteRequest")
 	local headers = {
@@ -48518,19 +48667,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRouteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRouteSync(DeleteRouteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRouteAsync(DeleteRouteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRouteAsync(DeleteRouteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDefaultVpc asynchronously, invoking a callback when done
 -- @param CreateDefaultVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDefaultVpcAsync(CreateDefaultVpcRequest, cb)
 	assert(CreateDefaultVpcRequest, "You must provide a CreateDefaultVpcRequest")
 	local headers = {
@@ -48553,19 +48703,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDefaultVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDefaultVpcSync(CreateDefaultVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDefaultVpcAsync(CreateDefaultVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDefaultVpcAsync(CreateDefaultVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableVpcClassicLink asynchronously, invoking a callback when done
 -- @param DisableVpcClassicLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableVpcClassicLinkAsync(DisableVpcClassicLinkRequest, cb)
 	assert(DisableVpcClassicLinkRequest, "You must provide a DisableVpcClassicLinkRequest")
 	local headers = {
@@ -48588,19 +48739,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableVpcClassicLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableVpcClassicLinkSync(DisableVpcClassicLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableVpcClassicLinkAsync(DisableVpcClassicLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableVpcClassicLinkAsync(DisableVpcClassicLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachNetworkInterface asynchronously, invoking a callback when done
 -- @param AttachNetworkInterfaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachNetworkInterfaceAsync(AttachNetworkInterfaceRequest, cb)
 	assert(AttachNetworkInterfaceRequest, "You must provide a AttachNetworkInterfaceRequest")
 	local headers = {
@@ -48623,19 +48775,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachNetworkInterfaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachNetworkInterfaceSync(AttachNetworkInterfaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachNetworkInterfaceAsync(AttachNetworkInterfaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachNetworkInterfaceAsync(AttachNetworkInterfaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNatGateway asynchronously, invoking a callback when done
 -- @param CreateNatGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNatGatewayAsync(CreateNatGatewayRequest, cb)
 	assert(CreateNatGatewayRequest, "You must provide a CreateNatGatewayRequest")
 	local headers = {
@@ -48658,19 +48811,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNatGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNatGatewaySync(CreateNatGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNatGatewayAsync(CreateNatGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNatGatewayAsync(CreateNatGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpnConnectionRoute asynchronously, invoking a callback when done
 -- @param DeleteVpnConnectionRouteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpnConnectionRouteAsync(DeleteVpnConnectionRouteRequest, cb)
 	assert(DeleteVpnConnectionRouteRequest, "You must provide a DeleteVpnConnectionRouteRequest")
 	local headers = {
@@ -48693,19 +48847,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpnConnectionRouteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpnConnectionRouteSync(DeleteVpnConnectionRouteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpnConnectionRouteAsync(DeleteVpnConnectionRouteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpnConnectionRouteAsync(DeleteVpnConnectionRouteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelSpotInstanceRequests asynchronously, invoking a callback when done
 -- @param CancelSpotInstanceRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelSpotInstanceRequestsAsync(CancelSpotInstanceRequestsRequest, cb)
 	assert(CancelSpotInstanceRequestsRequest, "You must provide a CancelSpotInstanceRequestsRequest")
 	local headers = {
@@ -48728,19 +48883,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelSpotInstanceRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelSpotInstanceRequestsSync(CancelSpotInstanceRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelSpotInstanceRequestsAsync(CancelSpotInstanceRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelSpotInstanceRequestsAsync(CancelSpotInstanceRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateKeyPair asynchronously, invoking a callback when done
 -- @param CreateKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateKeyPairAsync(CreateKeyPairRequest, cb)
 	assert(CreateKeyPairRequest, "You must provide a CreateKeyPairRequest")
 	local headers = {
@@ -48763,19 +48919,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateKeyPairSync(CreateKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateKeyPairAsync(CreateKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateKeyPairAsync(CreateKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNetworkInterfaceAttribute asynchronously, invoking a callback when done
 -- @param DescribeNetworkInterfaceAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNetworkInterfaceAttributeAsync(DescribeNetworkInterfaceAttributeRequest, cb)
 	assert(DescribeNetworkInterfaceAttributeRequest, "You must provide a DescribeNetworkInterfaceAttributeRequest")
 	local headers = {
@@ -48798,19 +48955,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNetworkInterfaceAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNetworkInterfaceAttributeSync(DescribeNetworkInterfaceAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNetworkInterfaceAttributeAsync(DescribeNetworkInterfaceAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNetworkInterfaceAttributeAsync(DescribeNetworkInterfaceAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIdFormat asynchronously, invoking a callback when done
 -- @param DescribeIdFormatRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIdFormatAsync(DescribeIdFormatRequest, cb)
 	assert(DescribeIdFormatRequest, "You must provide a DescribeIdFormatRequest")
 	local headers = {
@@ -48833,19 +48991,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIdFormatRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIdFormatSync(DescribeIdFormatRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIdFormatAsync(DescribeIdFormatRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIdFormatAsync(DescribeIdFormatRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyLaunchTemplate asynchronously, invoking a callback when done
 -- @param ModifyLaunchTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyLaunchTemplateAsync(ModifyLaunchTemplateRequest, cb)
 	assert(ModifyLaunchTemplateRequest, "You must provide a ModifyLaunchTemplateRequest")
 	local headers = {
@@ -48868,19 +49027,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyLaunchTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyLaunchTemplateSync(ModifyLaunchTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyLaunchTemplateAsync(ModifyLaunchTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyLaunchTemplateAsync(ModifyLaunchTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSnapshot asynchronously, invoking a callback when done
 -- @param DeleteSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSnapshotAsync(DeleteSnapshotRequest, cb)
 	assert(DeleteSnapshotRequest, "You must provide a DeleteSnapshotRequest")
 	local headers = {
@@ -48903,19 +49063,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSnapshotSync(DeleteSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSnapshotAsync(DeleteSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSnapshotAsync(DeleteSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMovingAddresses asynchronously, invoking a callback when done
 -- @param DescribeMovingAddressesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMovingAddressesAsync(DescribeMovingAddressesRequest, cb)
 	assert(DescribeMovingAddressesRequest, "You must provide a DescribeMovingAddressesRequest")
 	local headers = {
@@ -48938,19 +49099,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMovingAddressesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMovingAddressesSync(DescribeMovingAddressesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMovingAddressesAsync(DescribeMovingAddressesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMovingAddressesAsync(DescribeMovingAddressesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeSecurityGroupEgress asynchronously, invoking a callback when done
 -- @param RevokeSecurityGroupEgressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeSecurityGroupEgressAsync(RevokeSecurityGroupEgressRequest, cb)
 	assert(RevokeSecurityGroupEgressRequest, "You must provide a RevokeSecurityGroupEgressRequest")
 	local headers = {
@@ -48973,19 +49135,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeSecurityGroupEgressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeSecurityGroupEgressSync(RevokeSecurityGroupEgressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeSecurityGroupEgressAsync(RevokeSecurityGroupEgressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeSecurityGroupEgressAsync(RevokeSecurityGroupEgressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstanceAttribute asynchronously, invoking a callback when done
 -- @param DescribeInstanceAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstanceAttributeAsync(DescribeInstanceAttributeRequest, cb)
 	assert(DescribeInstanceAttributeRequest, "You must provide a DescribeInstanceAttributeRequest")
 	local headers = {
@@ -49008,19 +49171,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstanceAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstanceAttributeSync(DescribeInstanceAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstanceAttributeAsync(DescribeInstanceAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstanceAttributeAsync(DescribeInstanceAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterImage asynchronously, invoking a callback when done
 -- @param DeregisterImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterImageAsync(DeregisterImageRequest, cb)
 	assert(DeregisterImageRequest, "You must provide a DeregisterImageRequest")
 	local headers = {
@@ -49043,19 +49207,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterImageSync(DeregisterImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterImageAsync(DeregisterImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterImageAsync(DeregisterImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpnGateway asynchronously, invoking a callback when done
 -- @param DeleteVpnGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpnGatewayAsync(DeleteVpnGatewayRequest, cb)
 	assert(DeleteVpnGatewayRequest, "You must provide a DeleteVpnGatewayRequest")
 	local headers = {
@@ -49078,19 +49243,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpnGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpnGatewaySync(DeleteVpnGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpnGatewayAsync(DeleteVpnGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpnGatewayAsync(DeleteVpnGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReportInstanceStatus asynchronously, invoking a callback when done
 -- @param ReportInstanceStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReportInstanceStatusAsync(ReportInstanceStatusRequest, cb)
 	assert(ReportInstanceStatusRequest, "You must provide a ReportInstanceStatusRequest")
 	local headers = {
@@ -49113,19 +49279,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReportInstanceStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReportInstanceStatusSync(ReportInstanceStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReportInstanceStatusAsync(ReportInstanceStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReportInstanceStatusAsync(ReportInstanceStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableVgwRoutePropagation asynchronously, invoking a callback when done
 -- @param EnableVgwRoutePropagationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableVgwRoutePropagationAsync(EnableVgwRoutePropagationRequest, cb)
 	assert(EnableVgwRoutePropagationRequest, "You must provide a EnableVgwRoutePropagationRequest")
 	local headers = {
@@ -49148,19 +49315,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableVgwRoutePropagationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableVgwRoutePropagationSync(EnableVgwRoutePropagationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableVgwRoutePropagationAsync(EnableVgwRoutePropagationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableVgwRoutePropagationAsync(EnableVgwRoutePropagationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelReservedInstancesListing asynchronously, invoking a callback when done
 -- @param CancelReservedInstancesListingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelReservedInstancesListingAsync(CancelReservedInstancesListingRequest, cb)
 	assert(CancelReservedInstancesListingRequest, "You must provide a CancelReservedInstancesListingRequest")
 	local headers = {
@@ -49183,19 +49351,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelReservedInstancesListingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelReservedInstancesListingSync(CancelReservedInstancesListingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelReservedInstancesListingAsync(CancelReservedInstancesListingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelReservedInstancesListingAsync(CancelReservedInstancesListingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstanceStatus asynchronously, invoking a callback when done
 -- @param DescribeInstanceStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstanceStatusAsync(DescribeInstanceStatusRequest, cb)
 	assert(DescribeInstanceStatusRequest, "You must provide a DescribeInstanceStatusRequest")
 	local headers = {
@@ -49218,19 +49387,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstanceStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstanceStatusSync(DescribeInstanceStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstanceStatusAsync(DescribeInstanceStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstanceStatusAsync(DescribeInstanceStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePrefixLists asynchronously, invoking a callback when done
 -- @param DescribePrefixListsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePrefixListsAsync(DescribePrefixListsRequest, cb)
 	assert(DescribePrefixListsRequest, "You must provide a DescribePrefixListsRequest")
 	local headers = {
@@ -49253,19 +49423,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePrefixListsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePrefixListsSync(DescribePrefixListsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePrefixListsAsync(DescribePrefixListsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePrefixListsAsync(DescribePrefixListsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSnapshotAttribute asynchronously, invoking a callback when done
 -- @param DescribeSnapshotAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSnapshotAttributeAsync(DescribeSnapshotAttributeRequest, cb)
 	assert(DescribeSnapshotAttributeRequest, "You must provide a DescribeSnapshotAttributeRequest")
 	local headers = {
@@ -49288,19 +49459,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSnapshotAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSnapshotAttributeSync(DescribeSnapshotAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSnapshotAttributeAsync(DescribeSnapshotAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSnapshotAttributeAsync(DescribeSnapshotAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseReservedInstancesOffering asynchronously, invoking a callback when done
 -- @param PurchaseReservedInstancesOfferingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseReservedInstancesOfferingAsync(PurchaseReservedInstancesOfferingRequest, cb)
 	assert(PurchaseReservedInstancesOfferingRequest, "You must provide a PurchaseReservedInstancesOfferingRequest")
 	local headers = {
@@ -49323,19 +49495,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseReservedInstancesOfferingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseReservedInstancesOfferingSync(PurchaseReservedInstancesOfferingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseReservedInstancesOfferingAsync(PurchaseReservedInstancesOfferingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseReservedInstancesOfferingAsync(PurchaseReservedInstancesOfferingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifySubnetAttribute asynchronously, invoking a callback when done
 -- @param ModifySubnetAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifySubnetAttributeAsync(ModifySubnetAttributeRequest, cb)
 	assert(ModifySubnetAttributeRequest, "You must provide a ModifySubnetAttributeRequest")
 	local headers = {
@@ -49358,19 +49531,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifySubnetAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifySubnetAttributeSync(ModifySubnetAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifySubnetAttributeAsync(ModifySubnetAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifySubnetAttributeAsync(ModifySubnetAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNetworkInterfaces asynchronously, invoking a callback when done
 -- @param DescribeNetworkInterfacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNetworkInterfacesAsync(DescribeNetworkInterfacesRequest, cb)
 	assert(DescribeNetworkInterfacesRequest, "You must provide a DescribeNetworkInterfacesRequest")
 	local headers = {
@@ -49393,19 +49567,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNetworkInterfacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNetworkInterfacesSync(DescribeNetworkInterfacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNetworkInterfacesAsync(DescribeNetworkInterfacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNetworkInterfacesAsync(DescribeNetworkInterfacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyCapacityReservation asynchronously, invoking a callback when done
 -- @param ModifyCapacityReservationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyCapacityReservationAsync(ModifyCapacityReservationRequest, cb)
 	assert(ModifyCapacityReservationRequest, "You must provide a ModifyCapacityReservationRequest")
 	local headers = {
@@ -49428,19 +49603,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyCapacityReservationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyCapacityReservationSync(ModifyCapacityReservationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyCapacityReservationAsync(ModifyCapacityReservationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyCapacityReservationAsync(ModifyCapacityReservationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLaunchTemplates asynchronously, invoking a callback when done
 -- @param DescribeLaunchTemplatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLaunchTemplatesAsync(DescribeLaunchTemplatesRequest, cb)
 	assert(DescribeLaunchTemplatesRequest, "You must provide a DescribeLaunchTemplatesRequest")
 	local headers = {
@@ -49463,19 +49639,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLaunchTemplatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLaunchTemplatesSync(DescribeLaunchTemplatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLaunchTemplatesAsync(DescribeLaunchTemplatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLaunchTemplatesAsync(DescribeLaunchTemplatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmProductInstance asynchronously, invoking a callback when done
 -- @param ConfirmProductInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmProductInstanceAsync(ConfirmProductInstanceRequest, cb)
 	assert(ConfirmProductInstanceRequest, "You must provide a ConfirmProductInstanceRequest")
 	local headers = {
@@ -49498,19 +49675,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmProductInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmProductInstanceSync(ConfirmProductInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmProductInstanceAsync(ConfirmProductInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmProductInstanceAsync(ConfirmProductInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeExportTasks asynchronously, invoking a callback when done
 -- @param DescribeExportTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeExportTasksAsync(DescribeExportTasksRequest, cb)
 	assert(DescribeExportTasksRequest, "You must provide a DescribeExportTasksRequest")
 	local headers = {
@@ -49533,19 +49711,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeExportTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeExportTasksSync(DescribeExportTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeExportTasksAsync(DescribeExportTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeExportTasksAsync(DescribeExportTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachInternetGateway asynchronously, invoking a callback when done
 -- @param DetachInternetGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachInternetGatewayAsync(DetachInternetGatewayRequest, cb)
 	assert(DetachInternetGatewayRequest, "You must provide a DetachInternetGatewayRequest")
 	local headers = {
@@ -49568,19 +49747,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachInternetGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachInternetGatewaySync(DetachInternetGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachInternetGatewayAsync(DetachInternetGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachInternetGatewayAsync(DetachInternetGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNetworkAclEntry asynchronously, invoking a callback when done
 -- @param DeleteNetworkAclEntryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNetworkAclEntryAsync(DeleteNetworkAclEntryRequest, cb)
 	assert(DeleteNetworkAclEntryRequest, "You must provide a DeleteNetworkAclEntryRequest")
 	local headers = {
@@ -49603,19 +49783,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNetworkAclEntryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNetworkAclEntrySync(DeleteNetworkAclEntryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNetworkAclEntryAsync(DeleteNetworkAclEntryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNetworkAclEntryAsync(DeleteNetworkAclEntryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelCapacityReservation asynchronously, invoking a callback when done
 -- @param CancelCapacityReservationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelCapacityReservationAsync(CancelCapacityReservationRequest, cb)
 	assert(CancelCapacityReservationRequest, "You must provide a CancelCapacityReservationRequest")
 	local headers = {
@@ -49638,19 +49819,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelCapacityReservationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelCapacityReservationSync(CancelCapacityReservationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelCapacityReservationAsync(CancelCapacityReservationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelCapacityReservationAsync(CancelCapacityReservationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFpgaImage asynchronously, invoking a callback when done
 -- @param CreateFpgaImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFpgaImageAsync(CreateFpgaImageRequest, cb)
 	assert(CreateFpgaImageRequest, "You must provide a CreateFpgaImageRequest")
 	local headers = {
@@ -49673,19 +49855,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFpgaImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFpgaImageSync(CreateFpgaImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFpgaImageAsync(CreateFpgaImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFpgaImageAsync(CreateFpgaImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCustomerGateway asynchronously, invoking a callback when done
 -- @param CreateCustomerGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCustomerGatewayAsync(CreateCustomerGatewayRequest, cb)
 	assert(CreateCustomerGatewayRequest, "You must provide a CreateCustomerGatewayRequest")
 	local headers = {
@@ -49708,19 +49891,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCustomerGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCustomerGatewaySync(CreateCustomerGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCustomerGatewayAsync(CreateCustomerGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCustomerGatewayAsync(CreateCustomerGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopInstances asynchronously, invoking a callback when done
 -- @param StopInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopInstancesAsync(StopInstancesRequest, cb)
 	assert(StopInstancesRequest, "You must provide a StopInstancesRequest")
 	local headers = {
@@ -49743,19 +49927,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopInstancesSync(StopInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopInstancesAsync(StopInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopInstancesAsync(StopInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetInstanceAttribute asynchronously, invoking a callback when done
 -- @param ResetInstanceAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetInstanceAttributeAsync(ResetInstanceAttributeRequest, cb)
 	assert(ResetInstanceAttributeRequest, "You must provide a ResetInstanceAttributeRequest")
 	local headers = {
@@ -49778,19 +49963,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetInstanceAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetInstanceAttributeSync(ResetInstanceAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetInstanceAttributeAsync(ResetInstanceAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetInstanceAttributeAsync(ResetInstanceAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSecurityGroup asynchronously, invoking a callback when done
 -- @param CreateSecurityGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSecurityGroupAsync(CreateSecurityGroupRequest, cb)
 	assert(CreateSecurityGroupRequest, "You must provide a CreateSecurityGroupRequest")
 	local headers = {
@@ -49813,19 +49999,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSecurityGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSecurityGroupSync(CreateSecurityGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSecurityGroupAsync(CreateSecurityGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSecurityGroupAsync(CreateSecurityGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInternetGateways asynchronously, invoking a callback when done
 -- @param DescribeInternetGatewaysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInternetGatewaysAsync(DescribeInternetGatewaysRequest, cb)
 	assert(DescribeInternetGatewaysRequest, "You must provide a DescribeInternetGatewaysRequest")
 	local headers = {
@@ -49848,19 +50035,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInternetGatewaysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInternetGatewaysSync(DescribeInternetGatewaysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInternetGatewaysAsync(DescribeInternetGatewaysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInternetGatewaysAsync(DescribeInternetGatewaysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyNetworkInterfaceAttribute asynchronously, invoking a callback when done
 -- @param ModifyNetworkInterfaceAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyNetworkInterfaceAttributeAsync(ModifyNetworkInterfaceAttributeRequest, cb)
 	assert(ModifyNetworkInterfaceAttributeRequest, "You must provide a ModifyNetworkInterfaceAttributeRequest")
 	local headers = {
@@ -49883,19 +50071,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyNetworkInterfaceAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyNetworkInterfaceAttributeSync(ModifyNetworkInterfaceAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyNetworkInterfaceAttributeAsync(ModifyNetworkInterfaceAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyNetworkInterfaceAttributeAsync(ModifyNetworkInterfaceAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachVolume asynchronously, invoking a callback when done
 -- @param AttachVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachVolumeAsync(AttachVolumeRequest, cb)
 	assert(AttachVolumeRequest, "You must provide a AttachVolumeRequest")
 	local headers = {
@@ -49918,19 +50107,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachVolumeSync(AttachVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachVolumeAsync(AttachVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachVolumeAsync(AttachVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleetHistory asynchronously, invoking a callback when done
 -- @param DescribeFleetHistoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetHistoryAsync(DescribeFleetHistoryRequest, cb)
 	assert(DescribeFleetHistoryRequest, "You must provide a DescribeFleetHistoryRequest")
 	local headers = {
@@ -49953,19 +50143,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetHistoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetHistorySync(DescribeFleetHistoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetHistoryAsync(DescribeFleetHistoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetHistoryAsync(DescribeFleetHistoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ProvisionByoipCidr asynchronously, invoking a callback when done
 -- @param ProvisionByoipCidrRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ProvisionByoipCidrAsync(ProvisionByoipCidrRequest, cb)
 	assert(ProvisionByoipCidrRequest, "You must provide a ProvisionByoipCidrRequest")
 	local headers = {
@@ -49988,19 +50179,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ProvisionByoipCidrRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ProvisionByoipCidrSync(ProvisionByoipCidrRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ProvisionByoipCidrAsync(ProvisionByoipCidrRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ProvisionByoipCidrAsync(ProvisionByoipCidrRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateInstances asynchronously, invoking a callback when done
 -- @param TerminateInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateInstancesAsync(TerminateInstancesRequest, cb)
 	assert(TerminateInstancesRequest, "You must provide a TerminateInstancesRequest")
 	local headers = {
@@ -50023,19 +50215,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateInstancesSync(TerminateInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateInstancesAsync(TerminateInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateInstancesAsync(TerminateInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTags asynchronously, invoking a callback when done
 -- @param CreateTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTagsAsync(CreateTagsRequest, cb)
 	assert(CreateTagsRequest, "You must provide a CreateTagsRequest")
 	local headers = {
@@ -50058,19 +50251,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTagsSync(CreateTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTagsAsync(CreateTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTagsAsync(CreateTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSpotDatafeedSubscription asynchronously, invoking a callback when done
 -- @param DeleteSpotDatafeedSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSpotDatafeedSubscriptionAsync(DeleteSpotDatafeedSubscriptionRequest, cb)
 	assert(DeleteSpotDatafeedSubscriptionRequest, "You must provide a DeleteSpotDatafeedSubscriptionRequest")
 	local headers = {
@@ -50093,19 +50287,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSpotDatafeedSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSpotDatafeedSubscriptionSync(DeleteSpotDatafeedSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSpotDatafeedSubscriptionAsync(DeleteSpotDatafeedSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSpotDatafeedSubscriptionAsync(DeleteSpotDatafeedSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePlacementGroup asynchronously, invoking a callback when done
 -- @param DeletePlacementGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePlacementGroupAsync(DeletePlacementGroupRequest, cb)
 	assert(DeletePlacementGroupRequest, "You must provide a DeletePlacementGroupRequest")
 	local headers = {
@@ -50128,19 +50323,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePlacementGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePlacementGroupSync(DeletePlacementGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePlacementGroupAsync(DeletePlacementGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePlacementGroupAsync(DeletePlacementGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRouteTable asynchronously, invoking a callback when done
 -- @param DeleteRouteTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRouteTableAsync(DeleteRouteTableRequest, cb)
 	assert(DeleteRouteTableRequest, "You must provide a DeleteRouteTableRequest")
 	local headers = {
@@ -50163,19 +50359,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRouteTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRouteTableSync(DeleteRouteTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRouteTableAsync(DeleteRouteTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRouteTableAsync(DeleteRouteTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleetInstances asynchronously, invoking a callback when done
 -- @param DescribeFleetInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetInstancesAsync(DescribeFleetInstancesRequest, cb)
 	assert(DescribeFleetInstancesRequest, "You must provide a DescribeFleetInstancesRequest")
 	local headers = {
@@ -50198,19 +50395,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetInstancesSync(DescribeFleetInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetInstancesAsync(DescribeFleetInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetInstancesAsync(DescribeFleetInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstanceCreditSpecifications asynchronously, invoking a callback when done
 -- @param DescribeInstanceCreditSpecificationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstanceCreditSpecificationsAsync(DescribeInstanceCreditSpecificationsRequest, cb)
 	assert(DescribeInstanceCreditSpecificationsRequest, "You must provide a DescribeInstanceCreditSpecificationsRequest")
 	local headers = {
@@ -50233,19 +50431,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstanceCreditSpecificationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstanceCreditSpecificationsSync(DescribeInstanceCreditSpecificationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstanceCreditSpecificationsAsync(DescribeInstanceCreditSpecificationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstanceCreditSpecificationsAsync(DescribeInstanceCreditSpecificationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeKeyPairs asynchronously, invoking a callback when done
 -- @param DescribeKeyPairsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeKeyPairsAsync(DescribeKeyPairsRequest, cb)
 	assert(DescribeKeyPairsRequest, "You must provide a DescribeKeyPairsRequest")
 	local headers = {
@@ -50268,19 +50467,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeKeyPairsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeKeyPairsSync(DescribeKeyPairsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeKeyPairsAsync(DescribeKeyPairsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeKeyPairsAsync(DescribeKeyPairsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLaunchTemplateData asynchronously, invoking a callback when done
 -- @param GetLaunchTemplateDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLaunchTemplateDataAsync(GetLaunchTemplateDataRequest, cb)
 	assert(GetLaunchTemplateDataRequest, "You must provide a GetLaunchTemplateDataRequest")
 	local headers = {
@@ -50303,19 +50503,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLaunchTemplateDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLaunchTemplateDataSync(GetLaunchTemplateDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLaunchTemplateDataAsync(GetLaunchTemplateDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLaunchTemplateDataAsync(GetLaunchTemplateDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStaleSecurityGroups asynchronously, invoking a callback when done
 -- @param DescribeStaleSecurityGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStaleSecurityGroupsAsync(DescribeStaleSecurityGroupsRequest, cb)
 	assert(DescribeStaleSecurityGroupsRequest, "You must provide a DescribeStaleSecurityGroupsRequest")
 	local headers = {
@@ -50338,19 +50539,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStaleSecurityGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStaleSecurityGroupsSync(DescribeStaleSecurityGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStaleSecurityGroupsAsync(DescribeStaleSecurityGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStaleSecurityGroupsAsync(DescribeStaleSecurityGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedInstancesOfferings asynchronously, invoking a callback when done
 -- @param DescribeReservedInstancesOfferingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedInstancesOfferingsAsync(DescribeReservedInstancesOfferingsRequest, cb)
 	assert(DescribeReservedInstancesOfferingsRequest, "You must provide a DescribeReservedInstancesOfferingsRequest")
 	local headers = {
@@ -50373,19 +50575,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedInstancesOfferingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedInstancesOfferingsSync(DescribeReservedInstancesOfferingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedInstancesOfferingsAsync(DescribeReservedInstancesOfferingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedInstancesOfferingsAsync(DescribeReservedInstancesOfferingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call MonitorInstances asynchronously, invoking a callback when done
 -- @param MonitorInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.MonitorInstancesAsync(MonitorInstancesRequest, cb)
 	assert(MonitorInstancesRequest, "You must provide a MonitorInstancesRequest")
 	local headers = {
@@ -50408,19 +50611,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param MonitorInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.MonitorInstancesSync(MonitorInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.MonitorInstancesAsync(MonitorInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.MonitorInstancesAsync(MonitorInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConsoleScreenshot asynchronously, invoking a callback when done
 -- @param GetConsoleScreenshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConsoleScreenshotAsync(GetConsoleScreenshotRequest, cb)
 	assert(GetConsoleScreenshotRequest, "You must provide a GetConsoleScreenshotRequest")
 	local headers = {
@@ -50443,19 +50647,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConsoleScreenshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConsoleScreenshotSync(GetConsoleScreenshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConsoleScreenshotAsync(GetConsoleScreenshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConsoleScreenshotAsync(GetConsoleScreenshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountAttributes asynchronously, invoking a callback when done
 -- @param DescribeAccountAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountAttributesAsync(DescribeAccountAttributesRequest, cb)
 	assert(DescribeAccountAttributesRequest, "You must provide a DescribeAccountAttributesRequest")
 	local headers = {
@@ -50478,19 +50683,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountAttributesSync(DescribeAccountAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountAttributesAsync(DescribeAccountAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountAttributesAsync(DescribeAccountAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssignIpv6Addresses asynchronously, invoking a callback when done
 -- @param AssignIpv6AddressesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssignIpv6AddressesAsync(AssignIpv6AddressesRequest, cb)
 	assert(AssignIpv6AddressesRequest, "You must provide a AssignIpv6AddressesRequest")
 	local headers = {
@@ -50513,19 +50719,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssignIpv6AddressesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssignIpv6AddressesSync(AssignIpv6AddressesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssignIpv6AddressesAsync(AssignIpv6AddressesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssignIpv6AddressesAsync(AssignIpv6AddressesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AuthorizeSecurityGroupEgress asynchronously, invoking a callback when done
 -- @param AuthorizeSecurityGroupEgressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AuthorizeSecurityGroupEgressAsync(AuthorizeSecurityGroupEgressRequest, cb)
 	assert(AuthorizeSecurityGroupEgressRequest, "You must provide a AuthorizeSecurityGroupEgressRequest")
 	local headers = {
@@ -50548,19 +50755,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AuthorizeSecurityGroupEgressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AuthorizeSecurityGroupEgressSync(AuthorizeSecurityGroupEgressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AuthorizeSecurityGroupEgressAsync(AuthorizeSecurityGroupEgressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AuthorizeSecurityGroupEgressAsync(AuthorizeSecurityGroupEgressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AllocateAddress asynchronously, invoking a callback when done
 -- @param AllocateAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AllocateAddressAsync(AllocateAddressRequest, cb)
 	assert(AllocateAddressRequest, "You must provide a AllocateAddressRequest")
 	local headers = {
@@ -50583,19 +50791,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AllocateAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AllocateAddressSync(AllocateAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AllocateAddressAsync(AllocateAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AllocateAddressAsync(AllocateAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNetworkInterfacePermissions asynchronously, invoking a callback when done
 -- @param DescribeNetworkInterfacePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNetworkInterfacePermissionsAsync(DescribeNetworkInterfacePermissionsRequest, cb)
 	assert(DescribeNetworkInterfacePermissionsRequest, "You must provide a DescribeNetworkInterfacePermissionsRequest")
 	local headers = {
@@ -50618,19 +50827,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNetworkInterfacePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNetworkInterfacePermissionsSync(DescribeNetworkInterfacePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNetworkInterfacePermissionsAsync(DescribeNetworkInterfacePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNetworkInterfacePermissionsAsync(DescribeNetworkInterfacePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AuthorizeSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param AuthorizeSecurityGroupIngressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AuthorizeSecurityGroupIngressAsync(AuthorizeSecurityGroupIngressRequest, cb)
 	assert(AuthorizeSecurityGroupIngressRequest, "You must provide a AuthorizeSecurityGroupIngressRequest")
 	local headers = {
@@ -50653,19 +50863,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AuthorizeSecurityGroupIngressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AuthorizeSecurityGroupIngressSync(AuthorizeSecurityGroupIngressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AuthorizeSecurityGroupIngressAsync(AuthorizeSecurityGroupIngressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AuthorizeSecurityGroupIngressAsync(AuthorizeSecurityGroupIngressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSpotDatafeedSubscription asynchronously, invoking a callback when done
 -- @param CreateSpotDatafeedSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSpotDatafeedSubscriptionAsync(CreateSpotDatafeedSubscriptionRequest, cb)
 	assert(CreateSpotDatafeedSubscriptionRequest, "You must provide a CreateSpotDatafeedSubscriptionRequest")
 	local headers = {
@@ -50688,19 +50899,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSpotDatafeedSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSpotDatafeedSubscriptionSync(CreateSpotDatafeedSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSpotDatafeedSubscriptionAsync(CreateSpotDatafeedSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSpotDatafeedSubscriptionAsync(CreateSpotDatafeedSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportInstance asynchronously, invoking a callback when done
 -- @param ImportInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportInstanceAsync(ImportInstanceRequest, cb)
 	assert(ImportInstanceRequest, "You must provide a ImportInstanceRequest")
 	local headers = {
@@ -50723,19 +50935,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportInstanceSync(ImportInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportInstanceAsync(ImportInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportInstanceAsync(ImportInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFpgaImage asynchronously, invoking a callback when done
 -- @param DeleteFpgaImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFpgaImageAsync(DeleteFpgaImageRequest, cb)
 	assert(DeleteFpgaImageRequest, "You must provide a DeleteFpgaImageRequest")
 	local headers = {
@@ -50758,19 +50971,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFpgaImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFpgaImageSync(DeleteFpgaImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFpgaImageAsync(DeleteFpgaImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFpgaImageAsync(DeleteFpgaImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFpgaImageAttribute asynchronously, invoking a callback when done
 -- @param DescribeFpgaImageAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFpgaImageAttributeAsync(DescribeFpgaImageAttributeRequest, cb)
 	assert(DescribeFpgaImageAttributeRequest, "You must provide a DescribeFpgaImageAttributeRequest")
 	local headers = {
@@ -50793,19 +51007,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFpgaImageAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFpgaImageAttributeSync(DescribeFpgaImageAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFpgaImageAttributeAsync(DescribeFpgaImageAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFpgaImageAttributeAsync(DescribeFpgaImageAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReplaceNetworkAclAssociation asynchronously, invoking a callback when done
 -- @param ReplaceNetworkAclAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReplaceNetworkAclAssociationAsync(ReplaceNetworkAclAssociationRequest, cb)
 	assert(ReplaceNetworkAclAssociationRequest, "You must provide a ReplaceNetworkAclAssociationRequest")
 	local headers = {
@@ -50828,19 +51043,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReplaceNetworkAclAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReplaceNetworkAclAssociationSync(ReplaceNetworkAclAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReplaceNetworkAclAssociationAsync(ReplaceNetworkAclAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReplaceNetworkAclAssociationAsync(ReplaceNetworkAclAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVpcEndpointServiceConfiguration asynchronously, invoking a callback when done
 -- @param ModifyVpcEndpointServiceConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVpcEndpointServiceConfigurationAsync(ModifyVpcEndpointServiceConfigurationRequest, cb)
 	assert(ModifyVpcEndpointServiceConfigurationRequest, "You must provide a ModifyVpcEndpointServiceConfigurationRequest")
 	local headers = {
@@ -50863,19 +51079,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVpcEndpointServiceConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVpcEndpointServiceConfigurationSync(ModifyVpcEndpointServiceConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVpcEndpointServiceConfigurationAsync(ModifyVpcEndpointServiceConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVpcEndpointServiceConfigurationAsync(ModifyVpcEndpointServiceConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReleaseAddress asynchronously, invoking a callback when done
 -- @param ReleaseAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReleaseAddressAsync(ReleaseAddressRequest, cb)
 	assert(ReleaseAddressRequest, "You must provide a ReleaseAddressRequest")
 	local headers = {
@@ -50898,19 +51115,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReleaseAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReleaseAddressSync(ReleaseAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReleaseAddressAsync(ReleaseAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReleaseAddressAsync(ReleaseAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFpgaImages asynchronously, invoking a callback when done
 -- @param DescribeFpgaImagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFpgaImagesAsync(DescribeFpgaImagesRequest, cb)
 	assert(DescribeFpgaImagesRequest, "You must provide a DescribeFpgaImagesRequest")
 	local headers = {
@@ -50933,19 +51151,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFpgaImagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFpgaImagesSync(DescribeFpgaImagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFpgaImagesAsync(DescribeFpgaImagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFpgaImagesAsync(DescribeFpgaImagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectVpcPeeringConnection asynchronously, invoking a callback when done
 -- @param RejectVpcPeeringConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectVpcPeeringConnectionAsync(RejectVpcPeeringConnectionRequest, cb)
 	assert(RejectVpcPeeringConnectionRequest, "You must provide a RejectVpcPeeringConnectionRequest")
 	local headers = {
@@ -50968,19 +51187,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectVpcPeeringConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectVpcPeeringConnectionSync(RejectVpcPeeringConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectVpcPeeringConnectionAsync(RejectVpcPeeringConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectVpcPeeringConnectionAsync(RejectVpcPeeringConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeElasticGpus asynchronously, invoking a callback when done
 -- @param DescribeElasticGpusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeElasticGpusAsync(DescribeElasticGpusRequest, cb)
 	assert(DescribeElasticGpusRequest, "You must provide a DescribeElasticGpusRequest")
 	local headers = {
@@ -51003,19 +51223,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeElasticGpusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeElasticGpusSync(DescribeElasticGpusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeElasticGpusAsync(DescribeElasticGpusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeElasticGpusAsync(DescribeElasticGpusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleets asynchronously, invoking a callback when done
 -- @param DescribeFleetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetsAsync(DescribeFleetsRequest, cb)
 	assert(DescribeFleetsRequest, "You must provide a DescribeFleetsRequest")
 	local headers = {
@@ -51038,19 +51259,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetsSync(DescribeFleetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetsAsync(DescribeFleetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetsAsync(DescribeFleetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFleets asynchronously, invoking a callback when done
 -- @param DeleteFleetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFleetsAsync(DeleteFleetsRequest, cb)
 	assert(DeleteFleetsRequest, "You must provide a DeleteFleetsRequest")
 	local headers = {
@@ -51073,19 +51295,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFleetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFleetsSync(DeleteFleetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFleetsAsync(DeleteFleetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFleetsAsync(DeleteFleetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImages asynchronously, invoking a callback when done
 -- @param DescribeImagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImagesAsync(DescribeImagesRequest, cb)
 	assert(DescribeImagesRequest, "You must provide a DescribeImagesRequest")
 	local headers = {
@@ -51108,19 +51331,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImagesSync(DescribeImagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImagesAsync(DescribeImagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImagesAsync(DescribeImagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateRouteTable asynchronously, invoking a callback when done
 -- @param DisassociateRouteTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateRouteTableAsync(DisassociateRouteTableRequest, cb)
 	assert(DisassociateRouteTableRequest, "You must provide a DisassociateRouteTableRequest")
 	local headers = {
@@ -51143,19 +51367,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateRouteTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateRouteTableSync(DisassociateRouteTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateRouteTableAsync(DisassociateRouteTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateRouteTableAsync(DisassociateRouteTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVpcTenancy asynchronously, invoking a callback when done
 -- @param ModifyVpcTenancyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVpcTenancyAsync(ModifyVpcTenancyRequest, cb)
 	assert(ModifyVpcTenancyRequest, "You must provide a ModifyVpcTenancyRequest")
 	local headers = {
@@ -51178,19 +51403,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVpcTenancyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVpcTenancySync(ModifyVpcTenancyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVpcTenancyAsync(ModifyVpcTenancyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVpcTenancyAsync(ModifyVpcTenancyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePrincipalIdFormat asynchronously, invoking a callback when done
 -- @param DescribePrincipalIdFormatRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePrincipalIdFormatAsync(DescribePrincipalIdFormatRequest, cb)
 	assert(DescribePrincipalIdFormatRequest, "You must provide a DescribePrincipalIdFormatRequest")
 	local headers = {
@@ -51213,19 +51439,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePrincipalIdFormatRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePrincipalIdFormatSync(DescribePrincipalIdFormatRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePrincipalIdFormatAsync(DescribePrincipalIdFormatRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePrincipalIdFormatAsync(DescribePrincipalIdFormatRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePublicIpv4Pools asynchronously, invoking a callback when done
 -- @param DescribePublicIpv4PoolsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePublicIpv4PoolsAsync(DescribePublicIpv4PoolsRequest, cb)
 	assert(DescribePublicIpv4PoolsRequest, "You must provide a DescribePublicIpv4PoolsRequest")
 	local headers = {
@@ -51248,19 +51475,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePublicIpv4PoolsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePublicIpv4PoolsSync(DescribePublicIpv4PoolsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePublicIpv4PoolsAsync(DescribePublicIpv4PoolsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePublicIpv4PoolsAsync(DescribePublicIpv4PoolsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReplaceRoute asynchronously, invoking a callback when done
 -- @param ReplaceRouteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReplaceRouteAsync(ReplaceRouteRequest, cb)
 	assert(ReplaceRouteRequest, "You must provide a ReplaceRouteRequest")
 	local headers = {
@@ -51283,19 +51511,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReplaceRouteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReplaceRouteSync(ReplaceRouteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReplaceRouteAsync(ReplaceRouteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReplaceRouteAsync(ReplaceRouteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateRouteTable asynchronously, invoking a callback when done
 -- @param AssociateRouteTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateRouteTableAsync(AssociateRouteTableRequest, cb)
 	assert(AssociateRouteTableRequest, "You must provide a AssociateRouteTableRequest")
 	local headers = {
@@ -51318,19 +51547,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateRouteTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateRouteTableSync(AssociateRouteTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateRouteTableAsync(AssociateRouteTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateRouteTableAsync(AssociateRouteTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpc asynchronously, invoking a callback when done
 -- @param DeleteVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcAsync(DeleteVpcRequest, cb)
 	assert(DeleteVpcRequest, "You must provide a DeleteVpcRequest")
 	local headers = {
@@ -51353,19 +51583,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcSync(DeleteVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcAsync(DeleteVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcAsync(DeleteVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSpotDatafeedSubscription asynchronously, invoking a callback when done
 -- @param DescribeSpotDatafeedSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSpotDatafeedSubscriptionAsync(DescribeSpotDatafeedSubscriptionRequest, cb)
 	assert(DescribeSpotDatafeedSubscriptionRequest, "You must provide a DescribeSpotDatafeedSubscriptionRequest")
 	local headers = {
@@ -51388,19 +51619,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSpotDatafeedSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSpotDatafeedSubscriptionSync(DescribeSpotDatafeedSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSpotDatafeedSubscriptionAsync(DescribeSpotDatafeedSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSpotDatafeedSubscriptionAsync(DescribeSpotDatafeedSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePlacementGroups asynchronously, invoking a callback when done
 -- @param DescribePlacementGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePlacementGroupsAsync(DescribePlacementGroupsRequest, cb)
 	assert(DescribePlacementGroupsRequest, "You must provide a DescribePlacementGroupsRequest")
 	local headers = {
@@ -51423,19 +51655,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePlacementGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePlacementGroupsSync(DescribePlacementGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePlacementGroupsAsync(DescribePlacementGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePlacementGroupsAsync(DescribePlacementGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRegions asynchronously, invoking a callback when done
 -- @param DescribeRegionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRegionsAsync(DescribeRegionsRequest, cb)
 	assert(DescribeRegionsRequest, "You must provide a DescribeRegionsRequest")
 	local headers = {
@@ -51458,19 +51691,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRegionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRegionsSync(DescribeRegionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRegionsAsync(DescribeRegionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRegionsAsync(DescribeRegionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstances asynchronously, invoking a callback when done
 -- @param DescribeInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstancesAsync(DescribeInstancesRequest, cb)
 	assert(DescribeInstancesRequest, "You must provide a DescribeInstancesRequest")
 	local headers = {
@@ -51493,19 +51727,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstancesSync(DescribeInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstancesAsync(DescribeInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstancesAsync(DescribeInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLaunchTemplateVersions asynchronously, invoking a callback when done
 -- @param DescribeLaunchTemplateVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLaunchTemplateVersionsAsync(DescribeLaunchTemplateVersionsRequest, cb)
 	assert(DescribeLaunchTemplateVersionsRequest, "You must provide a DescribeLaunchTemplateVersionsRequest")
 	local headers = {
@@ -51528,19 +51763,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLaunchTemplateVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLaunchTemplateVersionsSync(DescribeLaunchTemplateVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLaunchTemplateVersionsAsync(DescribeLaunchTemplateVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLaunchTemplateVersionsAsync(DescribeLaunchTemplateVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRoute asynchronously, invoking a callback when done
 -- @param CreateRouteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRouteAsync(CreateRouteRequest, cb)
 	assert(CreateRouteRequest, "You must provide a CreateRouteRequest")
 	local headers = {
@@ -51563,19 +51799,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRouteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRouteSync(CreateRouteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRouteAsync(CreateRouteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRouteAsync(CreateRouteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEgressOnlyInternetGateway asynchronously, invoking a callback when done
 -- @param DeleteEgressOnlyInternetGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEgressOnlyInternetGatewayAsync(DeleteEgressOnlyInternetGatewayRequest, cb)
 	assert(DeleteEgressOnlyInternetGatewayRequest, "You must provide a DeleteEgressOnlyInternetGatewayRequest")
 	local headers = {
@@ -51598,19 +51835,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEgressOnlyInternetGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEgressOnlyInternetGatewaySync(DeleteEgressOnlyInternetGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEgressOnlyInternetGatewayAsync(DeleteEgressOnlyInternetGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEgressOnlyInternetGatewayAsync(DeleteEgressOnlyInternetGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSecurityGroups asynchronously, invoking a callback when done
 -- @param DescribeSecurityGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSecurityGroupsAsync(DescribeSecurityGroupsRequest, cb)
 	assert(DescribeSecurityGroupsRequest, "You must provide a DescribeSecurityGroupsRequest")
 	local headers = {
@@ -51633,19 +51871,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSecurityGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSecurityGroupsSync(DescribeSecurityGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSecurityGroupsAsync(DescribeSecurityGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSecurityGroupsAsync(DescribeSecurityGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDhcpOptions asynchronously, invoking a callback when done
 -- @param CreateDhcpOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDhcpOptionsAsync(CreateDhcpOptionsRequest, cb)
 	assert(CreateDhcpOptionsRequest, "You must provide a CreateDhcpOptionsRequest")
 	local headers = {
@@ -51668,19 +51907,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDhcpOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDhcpOptionsSync(CreateDhcpOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDhcpOptionsAsync(CreateDhcpOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDhcpOptionsAsync(CreateDhcpOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpcEndpointServiceConfigurations asynchronously, invoking a callback when done
 -- @param DeleteVpcEndpointServiceConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcEndpointServiceConfigurationsAsync(DeleteVpcEndpointServiceConfigurationsRequest, cb)
 	assert(DeleteVpcEndpointServiceConfigurationsRequest, "You must provide a DeleteVpcEndpointServiceConfigurationsRequest")
 	local headers = {
@@ -51703,19 +51943,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcEndpointServiceConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcEndpointServiceConfigurationsSync(DeleteVpcEndpointServiceConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcEndpointServiceConfigurationsAsync(DeleteVpcEndpointServiceConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcEndpointServiceConfigurationsAsync(DeleteVpcEndpointServiceConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpnGateway asynchronously, invoking a callback when done
 -- @param CreateVpnGatewayRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpnGatewayAsync(CreateVpnGatewayRequest, cb)
 	assert(CreateVpnGatewayRequest, "You must provide a CreateVpnGatewayRequest")
 	local headers = {
@@ -51738,19 +51979,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpnGatewayRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpnGatewaySync(CreateVpnGatewayRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpnGatewayAsync(CreateVpnGatewayRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpnGatewayAsync(CreateVpnGatewayRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBundleTasks asynchronously, invoking a callback when done
 -- @param DescribeBundleTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBundleTasksAsync(DescribeBundleTasksRequest, cb)
 	assert(DescribeBundleTasksRequest, "You must provide a DescribeBundleTasksRequest")
 	local headers = {
@@ -51773,19 +52015,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBundleTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBundleTasksSync(DescribeBundleTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBundleTasksAsync(DescribeBundleTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBundleTasksAsync(DescribeBundleTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedInstancesListings asynchronously, invoking a callback when done
 -- @param DescribeReservedInstancesListingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedInstancesListingsAsync(DescribeReservedInstancesListingsRequest, cb)
 	assert(DescribeReservedInstancesListingsRequest, "You must provide a DescribeReservedInstancesListingsRequest")
 	local headers = {
@@ -51808,19 +52051,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedInstancesListingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedInstancesListingsSync(DescribeReservedInstancesListingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedInstancesListingsAsync(DescribeReservedInstancesListingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedInstancesListingsAsync(DescribeReservedInstancesListingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReservedInstancesExchangeQuote asynchronously, invoking a callback when done
 -- @param GetReservedInstancesExchangeQuoteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReservedInstancesExchangeQuoteAsync(GetReservedInstancesExchangeQuoteRequest, cb)
 	assert(GetReservedInstancesExchangeQuoteRequest, "You must provide a GetReservedInstancesExchangeQuoteRequest")
 	local headers = {
@@ -51843,19 +52087,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReservedInstancesExchangeQuoteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReservedInstancesExchangeQuoteSync(GetReservedInstancesExchangeQuoteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReservedInstancesExchangeQuoteAsync(GetReservedInstancesExchangeQuoteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReservedInstancesExchangeQuoteAsync(GetReservedInstancesExchangeQuoteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClassicLinkInstances asynchronously, invoking a callback when done
 -- @param DescribeClassicLinkInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClassicLinkInstancesAsync(DescribeClassicLinkInstancesRequest, cb)
 	assert(DescribeClassicLinkInstancesRequest, "You must provide a DescribeClassicLinkInstancesRequest")
 	local headers = {
@@ -51878,19 +52123,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClassicLinkInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClassicLinkInstancesSync(DescribeClassicLinkInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClassicLinkInstancesAsync(DescribeClassicLinkInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClassicLinkInstancesAsync(DescribeClassicLinkInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifySpotFleetRequest asynchronously, invoking a callback when done
 -- @param ModifySpotFleetRequestRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifySpotFleetRequestAsync(ModifySpotFleetRequestRequest, cb)
 	assert(ModifySpotFleetRequestRequest, "You must provide a ModifySpotFleetRequestRequest")
 	local headers = {
@@ -51913,19 +52159,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifySpotFleetRequestRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifySpotFleetRequestSync(ModifySpotFleetRequestRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifySpotFleetRequestAsync(ModifySpotFleetRequestRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifySpotFleetRequestAsync(ModifySpotFleetRequestRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVolume asynchronously, invoking a callback when done
 -- @param DeleteVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVolumeAsync(DeleteVolumeRequest, cb)
 	assert(DeleteVolumeRequest, "You must provide a DeleteVolumeRequest")
 	local headers = {
@@ -51948,19 +52195,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVolumeSync(DeleteVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVolumeAsync(DeleteVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVolumeAsync(DeleteVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConversionTasks asynchronously, invoking a callback when done
 -- @param DescribeConversionTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConversionTasksAsync(DescribeConversionTasksRequest, cb)
 	assert(DescribeConversionTasksRequest, "You must provide a DescribeConversionTasksRequest")
 	local headers = {
@@ -51983,19 +52231,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConversionTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConversionTasksSync(DescribeConversionTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConversionTasksAsync(DescribeConversionTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConversionTasksAsync(DescribeConversionTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcClassicLinkDnsSupport asynchronously, invoking a callback when done
 -- @param DescribeVpcClassicLinkDnsSupportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcClassicLinkDnsSupportAsync(DescribeVpcClassicLinkDnsSupportRequest, cb)
 	assert(DescribeVpcClassicLinkDnsSupportRequest, "You must provide a DescribeVpcClassicLinkDnsSupportRequest")
 	local headers = {
@@ -52018,19 +52267,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcClassicLinkDnsSupportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcClassicLinkDnsSupportSync(DescribeVpcClassicLinkDnsSupportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcClassicLinkDnsSupportAsync(DescribeVpcClassicLinkDnsSupportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcClassicLinkDnsSupportAsync(DescribeVpcClassicLinkDnsSupportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyImage asynchronously, invoking a callback when done
 -- @param CopyImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyImageAsync(CopyImageRequest, cb)
 	assert(CopyImageRequest, "You must provide a CopyImageRequest")
 	local headers = {
@@ -52053,19 +52303,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyImageSync(CopyImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyImageAsync(CopyImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyImageAsync(CopyImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSubnets asynchronously, invoking a callback when done
 -- @param DescribeSubnetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSubnetsAsync(DescribeSubnetsRequest, cb)
 	assert(DescribeSubnetsRequest, "You must provide a DescribeSubnetsRequest")
 	local headers = {
@@ -52088,19 +52339,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSubnetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSubnetsSync(DescribeSubnetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSubnetsAsync(DescribeSubnetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSubnetsAsync(DescribeSubnetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcClassicLink asynchronously, invoking a callback when done
 -- @param DescribeVpcClassicLinkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcClassicLinkAsync(DescribeVpcClassicLinkRequest, cb)
 	assert(DescribeVpcClassicLinkRequest, "You must provide a DescribeVpcClassicLinkRequest")
 	local headers = {
@@ -52123,19 +52375,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcClassicLinkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcClassicLinkSync(DescribeVpcClassicLinkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcClassicLinkAsync(DescribeVpcClassicLinkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcClassicLinkAsync(DescribeVpcClassicLinkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCapacityReservation asynchronously, invoking a callback when done
 -- @param CreateCapacityReservationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCapacityReservationAsync(CreateCapacityReservationRequest, cb)
 	assert(CreateCapacityReservationRequest, "You must provide a CreateCapacityReservationRequest")
 	local headers = {
@@ -52158,19 +52411,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCapacityReservationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCapacityReservationSync(CreateCapacityReservationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCapacityReservationAsync(CreateCapacityReservationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCapacityReservationAsync(CreateCapacityReservationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVpcPeeringConnectionOptions asynchronously, invoking a callback when done
 -- @param ModifyVpcPeeringConnectionOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVpcPeeringConnectionOptionsAsync(ModifyVpcPeeringConnectionOptionsRequest, cb)
 	assert(ModifyVpcPeeringConnectionOptionsRequest, "You must provide a ModifyVpcPeeringConnectionOptionsRequest")
 	local headers = {
@@ -52193,19 +52447,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVpcPeeringConnectionOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVpcPeeringConnectionOptionsSync(ModifyVpcPeeringConnectionOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVpcPeeringConnectionOptionsAsync(ModifyVpcPeeringConnectionOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVpcPeeringConnectionOptionsAsync(ModifyVpcPeeringConnectionOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVolumeAttribute asynchronously, invoking a callback when done
 -- @param ModifyVolumeAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVolumeAttributeAsync(ModifyVolumeAttributeRequest, cb)
 	assert(ModifyVolumeAttributeRequest, "You must provide a ModifyVolumeAttributeRequest")
 	local headers = {
@@ -52228,19 +52483,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVolumeAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVolumeAttributeSync(ModifyVolumeAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVolumeAttributeAsync(ModifyVolumeAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVolumeAttributeAsync(ModifyVolumeAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportVolume asynchronously, invoking a callback when done
 -- @param ImportVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportVolumeAsync(ImportVolumeRequest, cb)
 	assert(ImportVolumeRequest, "You must provide a ImportVolumeRequest")
 	local headers = {
@@ -52263,19 +52519,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportVolumeSync(ImportVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportVolumeAsync(ImportVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportVolumeAsync(ImportVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportSnapshot asynchronously, invoking a callback when done
 -- @param ImportSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportSnapshotAsync(ImportSnapshotRequest, cb)
 	assert(ImportSnapshotRequest, "You must provide a ImportSnapshotRequest")
 	local headers = {
@@ -52298,19 +52555,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportSnapshotSync(ImportSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportSnapshotAsync(ImportSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportSnapshotAsync(ImportSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConsoleOutput asynchronously, invoking a callback when done
 -- @param GetConsoleOutputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConsoleOutputAsync(GetConsoleOutputRequest, cb)
 	assert(GetConsoleOutputRequest, "You must provide a GetConsoleOutputRequest")
 	local headers = {
@@ -52333,19 +52591,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConsoleOutputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConsoleOutputSync(GetConsoleOutputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConsoleOutputAsync(GetConsoleOutputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConsoleOutputAsync(GetConsoleOutputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcEndpointServiceConfigurations asynchronously, invoking a callback when done
 -- @param DescribeVpcEndpointServiceConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcEndpointServiceConfigurationsAsync(DescribeVpcEndpointServiceConfigurationsRequest, cb)
 	assert(DescribeVpcEndpointServiceConfigurationsRequest, "You must provide a DescribeVpcEndpointServiceConfigurationsRequest")
 	local headers = {
@@ -52368,19 +52627,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcEndpointServiceConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcEndpointServiceConfigurationsSync(DescribeVpcEndpointServiceConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcEndpointServiceConfigurationsAsync(DescribeVpcEndpointServiceConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcEndpointServiceConfigurationsAsync(DescribeVpcEndpointServiceConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLaunchTemplateVersion asynchronously, invoking a callback when done
 -- @param CreateLaunchTemplateVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLaunchTemplateVersionAsync(CreateLaunchTemplateVersionRequest, cb)
 	assert(CreateLaunchTemplateVersionRequest, "You must provide a CreateLaunchTemplateVersionRequest")
 	local headers = {
@@ -52403,19 +52663,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLaunchTemplateVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLaunchTemplateVersionSync(CreateLaunchTemplateVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLaunchTemplateVersionAsync(CreateLaunchTemplateVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLaunchTemplateVersionAsync(CreateLaunchTemplateVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsRequest, cb)
 	assert(DescribeTagsRequest, "You must provide a DescribeTagsRequest")
 	local headers = {
@@ -52438,19 +52699,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeprovisionByoipCidr asynchronously, invoking a callback when done
 -- @param DeprovisionByoipCidrRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeprovisionByoipCidrAsync(DeprovisionByoipCidrRequest, cb)
 	assert(DeprovisionByoipCidrRequest, "You must provide a DeprovisionByoipCidrRequest")
 	local headers = {
@@ -52473,19 +52735,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeprovisionByoipCidrRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeprovisionByoipCidrSync(DeprovisionByoipCidrRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeprovisionByoipCidrAsync(DeprovisionByoipCidrRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeprovisionByoipCidrAsync(DeprovisionByoipCidrRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcEndpointConnectionNotifications asynchronously, invoking a callback when done
 -- @param DescribeVpcEndpointConnectionNotificationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcEndpointConnectionNotificationsAsync(DescribeVpcEndpointConnectionNotificationsRequest, cb)
 	assert(DescribeVpcEndpointConnectionNotificationsRequest, "You must provide a DescribeVpcEndpointConnectionNotificationsRequest")
 	local headers = {
@@ -52508,19 +52771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcEndpointConnectionNotificationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcEndpointConnectionNotificationsSync(DescribeVpcEndpointConnectionNotificationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcEndpointConnectionNotificationsAsync(DescribeVpcEndpointConnectionNotificationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcEndpointConnectionNotificationsAsync(DescribeVpcEndpointConnectionNotificationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcEndpoints asynchronously, invoking a callback when done
 -- @param DescribeVpcEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcEndpointsAsync(DescribeVpcEndpointsRequest, cb)
 	assert(DescribeVpcEndpointsRequest, "You must provide a DescribeVpcEndpointsRequest")
 	local headers = {
@@ -52543,19 +52807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcEndpointsSync(DescribeVpcEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcEndpointsAsync(DescribeVpcEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcEndpointsAsync(DescribeVpcEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectVpcEndpointConnections asynchronously, invoking a callback when done
 -- @param RejectVpcEndpointConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectVpcEndpointConnectionsAsync(RejectVpcEndpointConnectionsRequest, cb)
 	assert(RejectVpcEndpointConnectionsRequest, "You must provide a RejectVpcEndpointConnectionsRequest")
 	local headers = {
@@ -52578,19 +52843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectVpcEndpointConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectVpcEndpointConnectionsSync(RejectVpcEndpointConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectVpcEndpointConnectionsAsync(RejectVpcEndpointConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectVpcEndpointConnectionsAsync(RejectVpcEndpointConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVpcEndpoint asynchronously, invoking a callback when done
 -- @param ModifyVpcEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVpcEndpointAsync(ModifyVpcEndpointRequest, cb)
 	assert(ModifyVpcEndpointRequest, "You must provide a ModifyVpcEndpointRequest")
 	local headers = {
@@ -52613,19 +52879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVpcEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVpcEndpointSync(ModifyVpcEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVpcEndpointAsync(ModifyVpcEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVpcEndpointAsync(ModifyVpcEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpcEndpointServiceConfiguration asynchronously, invoking a callback when done
 -- @param CreateVpcEndpointServiceConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcEndpointServiceConfigurationAsync(CreateVpcEndpointServiceConfigurationRequest, cb)
 	assert(CreateVpcEndpointServiceConfigurationRequest, "You must provide a CreateVpcEndpointServiceConfigurationRequest")
 	local headers = {
@@ -52648,19 +52915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcEndpointServiceConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcEndpointServiceConfigurationSync(CreateVpcEndpointServiceConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcEndpointServiceConfigurationAsync(CreateVpcEndpointServiceConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcEndpointServiceConfigurationAsync(CreateVpcEndpointServiceConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVpcAttribute asynchronously, invoking a callback when done
 -- @param ModifyVpcAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVpcAttributeAsync(ModifyVpcAttributeRequest, cb)
 	assert(ModifyVpcAttributeRequest, "You must provide a ModifyVpcAttributeRequest")
 	local headers = {
@@ -52683,19 +52951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVpcAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVpcAttributeSync(ModifyVpcAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVpcAttributeAsync(ModifyVpcAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVpcAttributeAsync(ModifyVpcAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableVolumeIO asynchronously, invoking a callback when done
 -- @param EnableVolumeIORequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableVolumeIOAsync(EnableVolumeIORequest, cb)
 	assert(EnableVolumeIORequest, "You must provide a EnableVolumeIORequest")
 	local headers = {
@@ -52718,19 +52987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableVolumeIORequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableVolumeIOSync(EnableVolumeIORequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableVolumeIOAsync(EnableVolumeIORequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableVolumeIOAsync(EnableVolumeIORequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptReservedInstancesExchangeQuote asynchronously, invoking a callback when done
 -- @param AcceptReservedInstancesExchangeQuoteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptReservedInstancesExchangeQuoteAsync(AcceptReservedInstancesExchangeQuoteRequest, cb)
 	assert(AcceptReservedInstancesExchangeQuoteRequest, "You must provide a AcceptReservedInstancesExchangeQuoteRequest")
 	local headers = {
@@ -52753,19 +53023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptReservedInstancesExchangeQuoteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptReservedInstancesExchangeQuoteSync(AcceptReservedInstancesExchangeQuoteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptReservedInstancesExchangeQuoteAsync(AcceptReservedInstancesExchangeQuoteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptReservedInstancesExchangeQuoteAsync(AcceptReservedInstancesExchangeQuoteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSecurityGroupReferences asynchronously, invoking a callback when done
 -- @param DescribeSecurityGroupReferencesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSecurityGroupReferencesAsync(DescribeSecurityGroupReferencesRequest, cb)
 	assert(DescribeSecurityGroupReferencesRequest, "You must provide a DescribeSecurityGroupReferencesRequest")
 	local headers = {
@@ -52788,19 +53059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSecurityGroupReferencesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSecurityGroupReferencesSync(DescribeSecurityGroupReferencesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSecurityGroupReferencesAsync(DescribeSecurityGroupReferencesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSecurityGroupReferencesAsync(DescribeSecurityGroupReferencesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcEndpointConnections asynchronously, invoking a callback when done
 -- @param DescribeVpcEndpointConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcEndpointConnectionsAsync(DescribeVpcEndpointConnectionsRequest, cb)
 	assert(DescribeVpcEndpointConnectionsRequest, "You must provide a DescribeVpcEndpointConnectionsRequest")
 	local headers = {
@@ -52823,19 +53095,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcEndpointConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcEndpointConnectionsSync(DescribeVpcEndpointConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcEndpointConnectionsAsync(DescribeVpcEndpointConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcEndpointConnectionsAsync(DescribeVpcEndpointConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFlowLogs asynchronously, invoking a callback when done
 -- @param DeleteFlowLogsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFlowLogsAsync(DeleteFlowLogsRequest, cb)
 	assert(DeleteFlowLogsRequest, "You must provide a DeleteFlowLogsRequest")
 	local headers = {
@@ -52858,19 +53131,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFlowLogsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFlowLogsSync(DeleteFlowLogsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFlowLogsAsync(DeleteFlowLogsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFlowLogsAsync(DeleteFlowLogsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyFleet asynchronously, invoking a callback when done
 -- @param ModifyFleetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyFleetAsync(ModifyFleetRequest, cb)
 	assert(ModifyFleetRequest, "You must provide a ModifyFleetRequest")
 	local headers = {
@@ -52893,19 +53167,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyFleetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyFleetSync(ModifyFleetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyFleetAsync(ModifyFleetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyFleetAsync(ModifyFleetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpnConnection asynchronously, invoking a callback when done
 -- @param CreateVpnConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpnConnectionAsync(CreateVpnConnectionRequest, cb)
 	assert(CreateVpnConnectionRequest, "You must provide a CreateVpnConnectionRequest")
 	local headers = {
@@ -52928,19 +53203,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpnConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpnConnectionSync(CreateVpnConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpnConnectionAsync(CreateVpnConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpnConnectionAsync(CreateVpnConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachClassicLinkVpc asynchronously, invoking a callback when done
 -- @param DetachClassicLinkVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachClassicLinkVpcAsync(DetachClassicLinkVpcRequest, cb)
 	assert(DetachClassicLinkVpcRequest, "You must provide a DetachClassicLinkVpcRequest")
 	local headers = {
@@ -52963,19 +53239,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachClassicLinkVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachClassicLinkVpcSync(DetachClassicLinkVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachClassicLinkVpcAsync(DetachClassicLinkVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachClassicLinkVpcAsync(DetachClassicLinkVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReservedInstancesListing asynchronously, invoking a callback when done
 -- @param CreateReservedInstancesListingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReservedInstancesListingAsync(CreateReservedInstancesListingRequest, cb)
 	assert(CreateReservedInstancesListingRequest, "You must provide a CreateReservedInstancesListingRequest")
 	local headers = {
@@ -52998,19 +53275,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReservedInstancesListingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReservedInstancesListingSync(CreateReservedInstancesListingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReservedInstancesListingAsync(CreateReservedInstancesListingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReservedInstancesListingAsync(CreateReservedInstancesListingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNetworkInterfacePermission asynchronously, invoking a callback when done
 -- @param DeleteNetworkInterfacePermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNetworkInterfacePermissionAsync(DeleteNetworkInterfacePermissionRequest, cb)
 	assert(DeleteNetworkInterfacePermissionRequest, "You must provide a DeleteNetworkInterfacePermissionRequest")
 	local headers = {
@@ -53033,19 +53311,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNetworkInterfacePermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNetworkInterfacePermissionSync(DeleteNetworkInterfacePermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNetworkInterfacePermissionAsync(DeleteNetworkInterfacePermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNetworkInterfacePermissionAsync(DeleteNetworkInterfacePermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHostReservations asynchronously, invoking a callback when done
 -- @param DescribeHostReservationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHostReservationsAsync(DescribeHostReservationsRequest, cb)
 	assert(DescribeHostReservationsRequest, "You must provide a DescribeHostReservationsRequest")
 	local headers = {
@@ -53068,19 +53347,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHostReservationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHostReservationsSync(DescribeHostReservationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHostReservationsAsync(DescribeHostReservationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHostReservationsAsync(DescribeHostReservationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEgressOnlyInternetGateways asynchronously, invoking a callback when done
 -- @param DescribeEgressOnlyInternetGatewaysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEgressOnlyInternetGatewaysAsync(DescribeEgressOnlyInternetGatewaysRequest, cb)
 	assert(DescribeEgressOnlyInternetGatewaysRequest, "You must provide a DescribeEgressOnlyInternetGatewaysRequest")
 	local headers = {
@@ -53103,19 +53383,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEgressOnlyInternetGatewaysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEgressOnlyInternetGatewaysSync(DescribeEgressOnlyInternetGatewaysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEgressOnlyInternetGatewaysAsync(DescribeEgressOnlyInternetGatewaysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEgressOnlyInternetGatewaysAsync(DescribeEgressOnlyInternetGatewaysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAggregateIdFormat asynchronously, invoking a callback when done
 -- @param DescribeAggregateIdFormatRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAggregateIdFormatAsync(DescribeAggregateIdFormatRequest, cb)
 	assert(DescribeAggregateIdFormatRequest, "You must provide a DescribeAggregateIdFormatRequest")
 	local headers = {
@@ -53138,19 +53419,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAggregateIdFormatRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAggregateIdFormatSync(DescribeAggregateIdFormatRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAggregateIdFormatAsync(DescribeAggregateIdFormatRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAggregateIdFormatAsync(DescribeAggregateIdFormatRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyVolume asynchronously, invoking a callback when done
 -- @param ModifyVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyVolumeAsync(ModifyVolumeRequest, cb)
 	assert(ModifyVolumeRequest, "You must provide a ModifyVolumeRequest")
 	local headers = {
@@ -53173,19 +53455,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyVolumeSync(ModifyVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyVolumeAsync(ModifyVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyVolumeAsync(ModifyVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RunScheduledInstances asynchronously, invoking a callback when done
 -- @param RunScheduledInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RunScheduledInstancesAsync(RunScheduledInstancesRequest, cb)
 	assert(RunScheduledInstancesRequest, "You must provide a RunScheduledInstancesRequest")
 	local headers = {
@@ -53208,19 +53491,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RunScheduledInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RunScheduledInstancesSync(RunScheduledInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RunScheduledInstancesAsync(RunScheduledInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RunScheduledInstancesAsync(RunScheduledInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeByoipCidrs asynchronously, invoking a callback when done
 -- @param DescribeByoipCidrsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeByoipCidrsAsync(DescribeByoipCidrsRequest, cb)
 	assert(DescribeByoipCidrsRequest, "You must provide a DescribeByoipCidrsRequest")
 	local headers = {
@@ -53243,12 +53527,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeByoipCidrsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeByoipCidrsSync(DescribeByoipCidrsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeByoipCidrsAsync(DescribeByoipCidrsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeByoipCidrsAsync(DescribeByoipCidrsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/ecr.lua
+++ b/aws-sdk/ecr.lua
@@ -4019,7 +4019,7 @@ end
 --
 --- Call DeleteRepository asynchronously, invoking a callback when done
 -- @param DeleteRepositoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRepositoryAsync(DeleteRepositoryRequest, cb)
 	assert(DeleteRepositoryRequest, "You must provide a DeleteRepositoryRequest")
 	local headers = {
@@ -4042,19 +4042,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRepositoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRepositorySync(DeleteRepositoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRepositoryAsync(DeleteRepositoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRepositoryAsync(DeleteRepositoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAuthorizationToken asynchronously, invoking a callback when done
 -- @param GetAuthorizationTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAuthorizationTokenAsync(GetAuthorizationTokenRequest, cb)
 	assert(GetAuthorizationTokenRequest, "You must provide a GetAuthorizationTokenRequest")
 	local headers = {
@@ -4077,19 +4078,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAuthorizationTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAuthorizationTokenSync(GetAuthorizationTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAuthorizationTokenAsync(GetAuthorizationTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAuthorizationTokenAsync(GetAuthorizationTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartLifecyclePolicyPreview asynchronously, invoking a callback when done
 -- @param StartLifecyclePolicyPreviewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartLifecyclePolicyPreviewAsync(StartLifecyclePolicyPreviewRequest, cb)
 	assert(StartLifecyclePolicyPreviewRequest, "You must provide a StartLifecyclePolicyPreviewRequest")
 	local headers = {
@@ -4112,19 +4114,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartLifecyclePolicyPreviewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartLifecyclePolicyPreviewSync(StartLifecyclePolicyPreviewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartLifecyclePolicyPreviewAsync(StartLifecyclePolicyPreviewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartLifecyclePolicyPreviewAsync(StartLifecyclePolicyPreviewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeImages asynchronously, invoking a callback when done
 -- @param DescribeImagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeImagesAsync(DescribeImagesRequest, cb)
 	assert(DescribeImagesRequest, "You must provide a DescribeImagesRequest")
 	local headers = {
@@ -4147,19 +4150,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeImagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeImagesSync(DescribeImagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeImagesAsync(DescribeImagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeImagesAsync(DescribeImagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLifecyclePolicy asynchronously, invoking a callback when done
 -- @param DeleteLifecyclePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLifecyclePolicyAsync(DeleteLifecyclePolicyRequest, cb)
 	assert(DeleteLifecyclePolicyRequest, "You must provide a DeleteLifecyclePolicyRequest")
 	local headers = {
@@ -4182,19 +4186,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLifecyclePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLifecyclePolicySync(DeleteLifecyclePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLifecyclePolicyAsync(DeleteLifecyclePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLifecyclePolicyAsync(DeleteLifecyclePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRepositories asynchronously, invoking a callback when done
 -- @param DescribeRepositoriesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRepositoriesAsync(DescribeRepositoriesRequest, cb)
 	assert(DescribeRepositoriesRequest, "You must provide a DescribeRepositoriesRequest")
 	local headers = {
@@ -4217,19 +4222,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRepositoriesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRepositoriesSync(DescribeRepositoriesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRepositoriesAsync(DescribeRepositoriesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRepositoriesAsync(DescribeRepositoriesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLifecyclePolicy asynchronously, invoking a callback when done
 -- @param GetLifecyclePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLifecyclePolicyAsync(GetLifecyclePolicyRequest, cb)
 	assert(GetLifecyclePolicyRequest, "You must provide a GetLifecyclePolicyRequest")
 	local headers = {
@@ -4252,19 +4258,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLifecyclePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLifecyclePolicySync(GetLifecyclePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLifecyclePolicyAsync(GetLifecyclePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLifecyclePolicyAsync(GetLifecyclePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetRepositoryPolicy asynchronously, invoking a callback when done
 -- @param SetRepositoryPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetRepositoryPolicyAsync(SetRepositoryPolicyRequest, cb)
 	assert(SetRepositoryPolicyRequest, "You must provide a SetRepositoryPolicyRequest")
 	local headers = {
@@ -4287,19 +4294,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetRepositoryPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetRepositoryPolicySync(SetRepositoryPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetRepositoryPolicyAsync(SetRepositoryPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetRepositoryPolicyAsync(SetRepositoryPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutImage asynchronously, invoking a callback when done
 -- @param PutImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutImageAsync(PutImageRequest, cb)
 	assert(PutImageRequest, "You must provide a PutImageRequest")
 	local headers = {
@@ -4322,19 +4330,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutImageSync(PutImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutImageAsync(PutImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutImageAsync(PutImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadLayerPart asynchronously, invoking a callback when done
 -- @param UploadLayerPartRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadLayerPartAsync(UploadLayerPartRequest, cb)
 	assert(UploadLayerPartRequest, "You must provide a UploadLayerPartRequest")
 	local headers = {
@@ -4357,19 +4366,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadLayerPartRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadLayerPartSync(UploadLayerPartRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadLayerPartAsync(UploadLayerPartRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadLayerPartAsync(UploadLayerPartRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutLifecyclePolicy asynchronously, invoking a callback when done
 -- @param PutLifecyclePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutLifecyclePolicyAsync(PutLifecyclePolicyRequest, cb)
 	assert(PutLifecyclePolicyRequest, "You must provide a PutLifecyclePolicyRequest")
 	local headers = {
@@ -4392,19 +4402,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutLifecyclePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutLifecyclePolicySync(PutLifecyclePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutLifecyclePolicyAsync(PutLifecyclePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutLifecyclePolicyAsync(PutLifecyclePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListImages asynchronously, invoking a callback when done
 -- @param ListImagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListImagesAsync(ListImagesRequest, cb)
 	assert(ListImagesRequest, "You must provide a ListImagesRequest")
 	local headers = {
@@ -4427,19 +4438,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListImagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListImagesSync(ListImagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListImagesAsync(ListImagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListImagesAsync(ListImagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CompleteLayerUpload asynchronously, invoking a callback when done
 -- @param CompleteLayerUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CompleteLayerUploadAsync(CompleteLayerUploadRequest, cb)
 	assert(CompleteLayerUploadRequest, "You must provide a CompleteLayerUploadRequest")
 	local headers = {
@@ -4462,19 +4474,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CompleteLayerUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CompleteLayerUploadSync(CompleteLayerUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CompleteLayerUploadAsync(CompleteLayerUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CompleteLayerUploadAsync(CompleteLayerUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitiateLayerUpload asynchronously, invoking a callback when done
 -- @param InitiateLayerUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitiateLayerUploadAsync(InitiateLayerUploadRequest, cb)
 	assert(InitiateLayerUploadRequest, "You must provide a InitiateLayerUploadRequest")
 	local headers = {
@@ -4497,19 +4510,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitiateLayerUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitiateLayerUploadSync(InitiateLayerUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitiateLayerUploadAsync(InitiateLayerUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitiateLayerUploadAsync(InitiateLayerUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRepository asynchronously, invoking a callback when done
 -- @param CreateRepositoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRepositoryAsync(CreateRepositoryRequest, cb)
 	assert(CreateRepositoryRequest, "You must provide a CreateRepositoryRequest")
 	local headers = {
@@ -4532,19 +4546,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRepositoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRepositorySync(CreateRepositoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRepositoryAsync(CreateRepositoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRepositoryAsync(CreateRepositoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchCheckLayerAvailability asynchronously, invoking a callback when done
 -- @param BatchCheckLayerAvailabilityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchCheckLayerAvailabilityAsync(BatchCheckLayerAvailabilityRequest, cb)
 	assert(BatchCheckLayerAvailabilityRequest, "You must provide a BatchCheckLayerAvailabilityRequest")
 	local headers = {
@@ -4567,19 +4582,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchCheckLayerAvailabilityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchCheckLayerAvailabilitySync(BatchCheckLayerAvailabilityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchCheckLayerAvailabilityAsync(BatchCheckLayerAvailabilityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchCheckLayerAvailabilityAsync(BatchCheckLayerAvailabilityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLifecyclePolicyPreview asynchronously, invoking a callback when done
 -- @param GetLifecyclePolicyPreviewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLifecyclePolicyPreviewAsync(GetLifecyclePolicyPreviewRequest, cb)
 	assert(GetLifecyclePolicyPreviewRequest, "You must provide a GetLifecyclePolicyPreviewRequest")
 	local headers = {
@@ -4602,19 +4618,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLifecyclePolicyPreviewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLifecyclePolicyPreviewSync(GetLifecyclePolicyPreviewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLifecyclePolicyPreviewAsync(GetLifecyclePolicyPreviewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLifecyclePolicyPreviewAsync(GetLifecyclePolicyPreviewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDeleteImage asynchronously, invoking a callback when done
 -- @param BatchDeleteImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDeleteImageAsync(BatchDeleteImageRequest, cb)
 	assert(BatchDeleteImageRequest, "You must provide a BatchDeleteImageRequest")
 	local headers = {
@@ -4637,19 +4654,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDeleteImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDeleteImageSync(BatchDeleteImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDeleteImageAsync(BatchDeleteImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDeleteImageAsync(BatchDeleteImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDownloadUrlForLayer asynchronously, invoking a callback when done
 -- @param GetDownloadUrlForLayerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDownloadUrlForLayerAsync(GetDownloadUrlForLayerRequest, cb)
 	assert(GetDownloadUrlForLayerRequest, "You must provide a GetDownloadUrlForLayerRequest")
 	local headers = {
@@ -4672,19 +4690,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDownloadUrlForLayerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDownloadUrlForLayerSync(GetDownloadUrlForLayerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDownloadUrlForLayerAsync(GetDownloadUrlForLayerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDownloadUrlForLayerAsync(GetDownloadUrlForLayerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRepositoryPolicy asynchronously, invoking a callback when done
 -- @param GetRepositoryPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRepositoryPolicyAsync(GetRepositoryPolicyRequest, cb)
 	assert(GetRepositoryPolicyRequest, "You must provide a GetRepositoryPolicyRequest")
 	local headers = {
@@ -4707,19 +4726,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRepositoryPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRepositoryPolicySync(GetRepositoryPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRepositoryPolicyAsync(GetRepositoryPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRepositoryPolicyAsync(GetRepositoryPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRepositoryPolicy asynchronously, invoking a callback when done
 -- @param DeleteRepositoryPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRepositoryPolicyAsync(DeleteRepositoryPolicyRequest, cb)
 	assert(DeleteRepositoryPolicyRequest, "You must provide a DeleteRepositoryPolicyRequest")
 	local headers = {
@@ -4742,19 +4762,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRepositoryPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRepositoryPolicySync(DeleteRepositoryPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRepositoryPolicyAsync(DeleteRepositoryPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRepositoryPolicyAsync(DeleteRepositoryPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetImage asynchronously, invoking a callback when done
 -- @param BatchGetImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetImageAsync(BatchGetImageRequest, cb)
 	assert(BatchGetImageRequest, "You must provide a BatchGetImageRequest")
 	local headers = {
@@ -4777,12 +4798,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetImageSync(BatchGetImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetImageAsync(BatchGetImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetImageAsync(BatchGetImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/ecs.lua
+++ b/aws-sdk/ecs.lua
@@ -6064,7 +6064,7 @@ end
 --
 --- Call CreateService asynchronously, invoking a callback when done
 -- @param CreateServiceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateServiceAsync(CreateServiceRequest, cb)
 	assert(CreateServiceRequest, "You must provide a CreateServiceRequest")
 	local headers = {
@@ -6087,19 +6087,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateServiceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateServiceSync(CreateServiceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateServiceAsync(CreateServiceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateServiceAsync(CreateServiceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SubmitContainerStateChange asynchronously, invoking a callback when done
 -- @param SubmitContainerStateChangeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SubmitContainerStateChangeAsync(SubmitContainerStateChangeRequest, cb)
 	assert(SubmitContainerStateChangeRequest, "You must provide a SubmitContainerStateChangeRequest")
 	local headers = {
@@ -6122,19 +6123,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SubmitContainerStateChangeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SubmitContainerStateChangeSync(SubmitContainerStateChangeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SubmitContainerStateChangeAsync(SubmitContainerStateChangeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SubmitContainerStateChangeAsync(SubmitContainerStateChangeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAttributes asynchronously, invoking a callback when done
 -- @param ListAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAttributesAsync(ListAttributesRequest, cb)
 	assert(ListAttributesRequest, "You must provide a ListAttributesRequest")
 	local headers = {
@@ -6157,19 +6159,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAttributesSync(ListAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAttributesAsync(ListAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAttributesAsync(ListAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCluster asynchronously, invoking a callback when done
 -- @param CreateClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterAsync(CreateClusterRequest, cb)
 	assert(CreateClusterRequest, "You must provide a CreateClusterRequest")
 	local headers = {
@@ -6192,19 +6195,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSync(CreateClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterAsync(CreateClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterAsync(CreateClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SubmitTaskStateChange asynchronously, invoking a callback when done
 -- @param SubmitTaskStateChangeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SubmitTaskStateChangeAsync(SubmitTaskStateChangeRequest, cb)
 	assert(SubmitTaskStateChangeRequest, "You must provide a SubmitTaskStateChangeRequest")
 	local headers = {
@@ -6227,19 +6231,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SubmitTaskStateChangeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SubmitTaskStateChangeSync(SubmitTaskStateChangeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SubmitTaskStateChangeAsync(SubmitTaskStateChangeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SubmitTaskStateChangeAsync(SubmitTaskStateChangeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTaskDefinitionFamilies asynchronously, invoking a callback when done
 -- @param ListTaskDefinitionFamiliesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTaskDefinitionFamiliesAsync(ListTaskDefinitionFamiliesRequest, cb)
 	assert(ListTaskDefinitionFamiliesRequest, "You must provide a ListTaskDefinitionFamiliesRequest")
 	local headers = {
@@ -6262,19 +6267,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTaskDefinitionFamiliesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTaskDefinitionFamiliesSync(ListTaskDefinitionFamiliesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTaskDefinitionFamiliesAsync(ListTaskDefinitionFamiliesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTaskDefinitionFamiliesAsync(ListTaskDefinitionFamiliesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteService asynchronously, invoking a callback when done
 -- @param DeleteServiceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServiceAsync(DeleteServiceRequest, cb)
 	assert(DeleteServiceRequest, "You must provide a DeleteServiceRequest")
 	local headers = {
@@ -6297,19 +6303,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServiceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServiceSync(DeleteServiceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServiceAsync(DeleteServiceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServiceAsync(DeleteServiceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListContainerInstances asynchronously, invoking a callback when done
 -- @param ListContainerInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListContainerInstancesAsync(ListContainerInstancesRequest, cb)
 	assert(ListContainerInstancesRequest, "You must provide a ListContainerInstancesRequest")
 	local headers = {
@@ -6332,19 +6339,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListContainerInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListContainerInstancesSync(ListContainerInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListContainerInstancesAsync(ListContainerInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListContainerInstancesAsync(ListContainerInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeServices asynchronously, invoking a callback when done
 -- @param DescribeServicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeServicesAsync(DescribeServicesRequest, cb)
 	assert(DescribeServicesRequest, "You must provide a DescribeServicesRequest")
 	local headers = {
@@ -6367,19 +6375,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeServicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeServicesSync(DescribeServicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeServicesAsync(DescribeServicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeServicesAsync(DescribeServicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCluster asynchronously, invoking a callback when done
 -- @param DeleteClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterAsync(DeleteClusterRequest, cb)
 	assert(DeleteClusterRequest, "You must provide a DeleteClusterRequest")
 	local headers = {
@@ -6402,19 +6411,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSync(DeleteClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateService asynchronously, invoking a callback when done
 -- @param UpdateServiceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServiceAsync(UpdateServiceRequest, cb)
 	assert(UpdateServiceRequest, "You must provide a UpdateServiceRequest")
 	local headers = {
@@ -6437,19 +6447,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServiceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServiceSync(UpdateServiceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServiceAsync(UpdateServiceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServiceAsync(UpdateServiceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListClusters asynchronously, invoking a callback when done
 -- @param ListClustersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListClustersAsync(ListClustersRequest, cb)
 	assert(ListClustersRequest, "You must provide a ListClustersRequest")
 	local headers = {
@@ -6472,19 +6483,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListClustersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListClustersSync(ListClustersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListClustersAsync(ListClustersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListClustersAsync(ListClustersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterTaskDefinition asynchronously, invoking a callback when done
 -- @param DeregisterTaskDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterTaskDefinitionAsync(DeregisterTaskDefinitionRequest, cb)
 	assert(DeregisterTaskDefinitionRequest, "You must provide a DeregisterTaskDefinitionRequest")
 	local headers = {
@@ -6507,19 +6519,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterTaskDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterTaskDefinitionSync(DeregisterTaskDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterTaskDefinitionAsync(DeregisterTaskDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterTaskDefinitionAsync(DeregisterTaskDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterTaskDefinition asynchronously, invoking a callback when done
 -- @param RegisterTaskDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterTaskDefinitionAsync(RegisterTaskDefinitionRequest, cb)
 	assert(RegisterTaskDefinitionRequest, "You must provide a RegisterTaskDefinitionRequest")
 	local headers = {
@@ -6542,19 +6555,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterTaskDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterTaskDefinitionSync(RegisterTaskDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterTaskDefinitionAsync(RegisterTaskDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterTaskDefinitionAsync(RegisterTaskDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopTask asynchronously, invoking a callback when done
 -- @param StopTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopTaskAsync(StopTaskRequest, cb)
 	assert(StopTaskRequest, "You must provide a StopTaskRequest")
 	local headers = {
@@ -6577,19 +6591,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopTaskSync(StopTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopTaskAsync(StopTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopTaskAsync(StopTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTaskDefinitions asynchronously, invoking a callback when done
 -- @param ListTaskDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTaskDefinitionsAsync(ListTaskDefinitionsRequest, cb)
 	assert(ListTaskDefinitionsRequest, "You must provide a ListTaskDefinitionsRequest")
 	local headers = {
@@ -6612,19 +6627,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTaskDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTaskDefinitionsSync(ListTaskDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTaskDefinitionsAsync(ListTaskDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTaskDefinitionsAsync(ListTaskDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusters asynchronously, invoking a callback when done
 -- @param DescribeClustersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClustersAsync(DescribeClustersRequest, cb)
 	assert(DescribeClustersRequest, "You must provide a DescribeClustersRequest")
 	local headers = {
@@ -6647,19 +6663,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClustersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClustersSync(DescribeClustersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClustersAsync(DescribeClustersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClustersAsync(DescribeClustersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateContainerAgent asynchronously, invoking a callback when done
 -- @param UpdateContainerAgentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateContainerAgentAsync(UpdateContainerAgentRequest, cb)
 	assert(UpdateContainerAgentRequest, "You must provide a UpdateContainerAgentRequest")
 	local headers = {
@@ -6682,19 +6699,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateContainerAgentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateContainerAgentSync(UpdateContainerAgentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateContainerAgentAsync(UpdateContainerAgentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateContainerAgentAsync(UpdateContainerAgentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAttributes asynchronously, invoking a callback when done
 -- @param DeleteAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAttributesAsync(DeleteAttributesRequest, cb)
 	assert(DeleteAttributesRequest, "You must provide a DeleteAttributesRequest")
 	local headers = {
@@ -6717,19 +6735,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAttributesSync(DeleteAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAttributesAsync(DeleteAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAttributesAsync(DeleteAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListServices asynchronously, invoking a callback when done
 -- @param ListServicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListServicesAsync(ListServicesRequest, cb)
 	assert(ListServicesRequest, "You must provide a ListServicesRequest")
 	local headers = {
@@ -6752,19 +6771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListServicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListServicesSync(ListServicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListServicesAsync(ListServicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListServicesAsync(ListServicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutAttributes asynchronously, invoking a callback when done
 -- @param PutAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutAttributesAsync(PutAttributesRequest, cb)
 	assert(PutAttributesRequest, "You must provide a PutAttributesRequest")
 	local headers = {
@@ -6787,19 +6807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutAttributesSync(PutAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutAttributesAsync(PutAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutAttributesAsync(PutAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartTask asynchronously, invoking a callback when done
 -- @param StartTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartTaskAsync(StartTaskRequest, cb)
 	assert(StartTaskRequest, "You must provide a StartTaskRequest")
 	local headers = {
@@ -6822,19 +6843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartTaskSync(StartTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartTaskAsync(StartTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartTaskAsync(StartTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterContainerInstance asynchronously, invoking a callback when done
 -- @param RegisterContainerInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterContainerInstanceAsync(RegisterContainerInstanceRequest, cb)
 	assert(RegisterContainerInstanceRequest, "You must provide a RegisterContainerInstanceRequest")
 	local headers = {
@@ -6857,19 +6879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterContainerInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterContainerInstanceSync(RegisterContainerInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterContainerInstanceAsync(RegisterContainerInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterContainerInstanceAsync(RegisterContainerInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTaskDefinition asynchronously, invoking a callback when done
 -- @param DescribeTaskDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTaskDefinitionAsync(DescribeTaskDefinitionRequest, cb)
 	assert(DescribeTaskDefinitionRequest, "You must provide a DescribeTaskDefinitionRequest")
 	local headers = {
@@ -6892,19 +6915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTaskDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTaskDefinitionSync(DescribeTaskDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTaskDefinitionAsync(DescribeTaskDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTaskDefinitionAsync(DescribeTaskDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTasks asynchronously, invoking a callback when done
 -- @param DescribeTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTasksAsync(DescribeTasksRequest, cb)
 	assert(DescribeTasksRequest, "You must provide a DescribeTasksRequest")
 	local headers = {
@@ -6927,19 +6951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTasksSync(DescribeTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTasksAsync(DescribeTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTasksAsync(DescribeTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateContainerInstancesState asynchronously, invoking a callback when done
 -- @param UpdateContainerInstancesStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateContainerInstancesStateAsync(UpdateContainerInstancesStateRequest, cb)
 	assert(UpdateContainerInstancesStateRequest, "You must provide a UpdateContainerInstancesStateRequest")
 	local headers = {
@@ -6962,19 +6987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateContainerInstancesStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateContainerInstancesStateSync(UpdateContainerInstancesStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateContainerInstancesStateAsync(UpdateContainerInstancesStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateContainerInstancesStateAsync(UpdateContainerInstancesStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterContainerInstance asynchronously, invoking a callback when done
 -- @param DeregisterContainerInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterContainerInstanceAsync(DeregisterContainerInstanceRequest, cb)
 	assert(DeregisterContainerInstanceRequest, "You must provide a DeregisterContainerInstanceRequest")
 	local headers = {
@@ -6997,19 +7023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterContainerInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterContainerInstanceSync(DeregisterContainerInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterContainerInstanceAsync(DeregisterContainerInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterContainerInstanceAsync(DeregisterContainerInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTasks asynchronously, invoking a callback when done
 -- @param ListTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTasksAsync(ListTasksRequest, cb)
 	assert(ListTasksRequest, "You must provide a ListTasksRequest")
 	local headers = {
@@ -7032,19 +7059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTasksSync(ListTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTasksAsync(ListTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTasksAsync(ListTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeContainerInstances asynchronously, invoking a callback when done
 -- @param DescribeContainerInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeContainerInstancesAsync(DescribeContainerInstancesRequest, cb)
 	assert(DescribeContainerInstancesRequest, "You must provide a DescribeContainerInstancesRequest")
 	local headers = {
@@ -7067,19 +7095,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeContainerInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeContainerInstancesSync(DescribeContainerInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeContainerInstancesAsync(DescribeContainerInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeContainerInstancesAsync(DescribeContainerInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RunTask asynchronously, invoking a callback when done
 -- @param RunTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RunTaskAsync(RunTaskRequest, cb)
 	assert(RunTaskRequest, "You must provide a RunTaskRequest")
 	local headers = {
@@ -7102,19 +7131,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RunTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RunTaskSync(RunTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RunTaskAsync(RunTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RunTaskAsync(RunTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DiscoverPollEndpoint asynchronously, invoking a callback when done
 -- @param DiscoverPollEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DiscoverPollEndpointAsync(DiscoverPollEndpointRequest, cb)
 	assert(DiscoverPollEndpointRequest, "You must provide a DiscoverPollEndpointRequest")
 	local headers = {
@@ -7137,12 +7167,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DiscoverPollEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DiscoverPollEndpointSync(DiscoverPollEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DiscoverPollEndpointAsync(DiscoverPollEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DiscoverPollEndpointAsync(DiscoverPollEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/eks.lua
+++ b/aws-sdk/eks.lua
@@ -656,7 +656,7 @@ end
 --
 --- Call DescribeCluster asynchronously, invoking a callback when done
 -- @param DescribeClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterAsync(DescribeClusterRequest, cb)
 	assert(DescribeClusterRequest, "You must provide a DescribeClusterRequest")
 	local headers = {
@@ -679,19 +679,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterSync(DescribeClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterAsync(DescribeClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterAsync(DescribeClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCluster asynchronously, invoking a callback when done
 -- @param DeleteClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterAsync(DeleteClusterRequest, cb)
 	assert(DeleteClusterRequest, "You must provide a DeleteClusterRequest")
 	local headers = {
@@ -714,19 +715,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSync(DeleteClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterAsync(DeleteClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListClusters asynchronously, invoking a callback when done
 -- @param ListClustersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListClustersAsync(ListClustersRequest, cb)
 	assert(ListClustersRequest, "You must provide a ListClustersRequest")
 	local headers = {
@@ -749,19 +751,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListClustersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListClustersSync(ListClustersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListClustersAsync(ListClustersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListClustersAsync(ListClustersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCluster asynchronously, invoking a callback when done
 -- @param CreateClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterAsync(CreateClusterRequest, cb)
 	assert(CreateClusterRequest, "You must provide a CreateClusterRequest")
 	local headers = {
@@ -784,12 +787,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSync(CreateClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterAsync(CreateClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterAsync(CreateClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/elasticache.lua
+++ b/aws-sdk/elasticache.lua
@@ -6154,7 +6154,7 @@ end
 --
 --- Call DescribeCacheEngineVersions asynchronously, invoking a callback when done
 -- @param DescribeCacheEngineVersionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCacheEngineVersionsAsync(DescribeCacheEngineVersionsMessage, cb)
 	assert(DescribeCacheEngineVersionsMessage, "You must provide a DescribeCacheEngineVersionsMessage")
 	local headers = {
@@ -6177,19 +6177,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCacheEngineVersionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCacheEngineVersionsSync(DescribeCacheEngineVersionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCacheEngineVersionsAsync(DescribeCacheEngineVersionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCacheEngineVersionsAsync(DescribeCacheEngineVersionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCacheSubnetGroup asynchronously, invoking a callback when done
 -- @param DeleteCacheSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCacheSubnetGroupAsync(DeleteCacheSubnetGroupMessage, cb)
 	assert(DeleteCacheSubnetGroupMessage, "You must provide a DeleteCacheSubnetGroupMessage")
 	local headers = {
@@ -6212,19 +6213,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCacheSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCacheSubnetGroupSync(DeleteCacheSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCacheSubnetGroupAsync(DeleteCacheSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCacheSubnetGroupAsync(DeleteCacheSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetCacheParameterGroup asynchronously, invoking a callback when done
 -- @param ResetCacheParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetCacheParameterGroupAsync(ResetCacheParameterGroupMessage, cb)
 	assert(ResetCacheParameterGroupMessage, "You must provide a ResetCacheParameterGroupMessage")
 	local headers = {
@@ -6247,19 +6249,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetCacheParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetCacheParameterGroupSync(ResetCacheParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetCacheParameterGroupAsync(ResetCacheParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetCacheParameterGroupAsync(ResetCacheParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCacheSecurityGroup asynchronously, invoking a callback when done
 -- @param DeleteCacheSecurityGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCacheSecurityGroupAsync(DeleteCacheSecurityGroupMessage, cb)
 	assert(DeleteCacheSecurityGroupMessage, "You must provide a DeleteCacheSecurityGroupMessage")
 	local headers = {
@@ -6282,19 +6285,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCacheSecurityGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCacheSecurityGroupSync(DeleteCacheSecurityGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCacheSecurityGroupAsync(DeleteCacheSecurityGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCacheSecurityGroupAsync(DeleteCacheSecurityGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsMessage, cb)
 	assert(DescribeEventsMessage, "You must provide a DescribeEventsMessage")
 	local headers = {
@@ -6317,19 +6321,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEngineDefaultParameters asynchronously, invoking a callback when done
 -- @param DescribeEngineDefaultParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEngineDefaultParametersAsync(DescribeEngineDefaultParametersMessage, cb)
 	assert(DescribeEngineDefaultParametersMessage, "You must provide a DescribeEngineDefaultParametersMessage")
 	local headers = {
@@ -6352,19 +6357,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEngineDefaultParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEngineDefaultParametersSync(DescribeEngineDefaultParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEngineDefaultParametersAsync(DescribeEngineDefaultParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEngineDefaultParametersAsync(DescribeEngineDefaultParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCacheSubnetGroups asynchronously, invoking a callback when done
 -- @param DescribeCacheSubnetGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCacheSubnetGroupsAsync(DescribeCacheSubnetGroupsMessage, cb)
 	assert(DescribeCacheSubnetGroupsMessage, "You must provide a DescribeCacheSubnetGroupsMessage")
 	local headers = {
@@ -6387,19 +6393,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCacheSubnetGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCacheSubnetGroupsSync(DescribeCacheSubnetGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCacheSubnetGroupsAsync(DescribeCacheSubnetGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCacheSubnetGroupsAsync(DescribeCacheSubnetGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCacheSecurityGroups asynchronously, invoking a callback when done
 -- @param DescribeCacheSecurityGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCacheSecurityGroupsAsync(DescribeCacheSecurityGroupsMessage, cb)
 	assert(DescribeCacheSecurityGroupsMessage, "You must provide a DescribeCacheSecurityGroupsMessage")
 	local headers = {
@@ -6422,19 +6429,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCacheSecurityGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCacheSecurityGroupsSync(DescribeCacheSecurityGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCacheSecurityGroupsAsync(DescribeCacheSecurityGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCacheSecurityGroupsAsync(DescribeCacheSecurityGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootCacheCluster asynchronously, invoking a callback when done
 -- @param RebootCacheClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootCacheClusterAsync(RebootCacheClusterMessage, cb)
 	assert(RebootCacheClusterMessage, "You must provide a RebootCacheClusterMessage")
 	local headers = {
@@ -6457,19 +6465,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootCacheClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootCacheClusterSync(RebootCacheClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootCacheClusterAsync(RebootCacheClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootCacheClusterAsync(RebootCacheClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DecreaseReplicaCount asynchronously, invoking a callback when done
 -- @param DecreaseReplicaCountMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DecreaseReplicaCountAsync(DecreaseReplicaCountMessage, cb)
 	assert(DecreaseReplicaCountMessage, "You must provide a DecreaseReplicaCountMessage")
 	local headers = {
@@ -6492,19 +6501,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DecreaseReplicaCountMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DecreaseReplicaCountSync(DecreaseReplicaCountMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DecreaseReplicaCountAsync(DecreaseReplicaCountMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DecreaseReplicaCountAsync(DecreaseReplicaCountMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyCacheSubnetGroup asynchronously, invoking a callback when done
 -- @param ModifyCacheSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyCacheSubnetGroupAsync(ModifyCacheSubnetGroupMessage, cb)
 	assert(ModifyCacheSubnetGroupMessage, "You must provide a ModifyCacheSubnetGroupMessage")
 	local headers = {
@@ -6527,19 +6537,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyCacheSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyCacheSubnetGroupSync(ModifyCacheSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyCacheSubnetGroupAsync(ModifyCacheSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyCacheSubnetGroupAsync(ModifyCacheSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCacheParameterGroups asynchronously, invoking a callback when done
 -- @param DescribeCacheParameterGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCacheParameterGroupsAsync(DescribeCacheParameterGroupsMessage, cb)
 	assert(DescribeCacheParameterGroupsMessage, "You must provide a DescribeCacheParameterGroupsMessage")
 	local headers = {
@@ -6562,19 +6573,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCacheParameterGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCacheParameterGroupsSync(DescribeCacheParameterGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCacheParameterGroupsAsync(DescribeCacheParameterGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCacheParameterGroupsAsync(DescribeCacheParameterGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCacheParameterGroup asynchronously, invoking a callback when done
 -- @param DeleteCacheParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCacheParameterGroupAsync(DeleteCacheParameterGroupMessage, cb)
 	assert(DeleteCacheParameterGroupMessage, "You must provide a DeleteCacheParameterGroupMessage")
 	local headers = {
@@ -6597,19 +6609,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCacheParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCacheParameterGroupSync(DeleteCacheParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCacheParameterGroupAsync(DeleteCacheParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCacheParameterGroupAsync(DeleteCacheParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AuthorizeCacheSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param AuthorizeCacheSecurityGroupIngressMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AuthorizeCacheSecurityGroupIngressAsync(AuthorizeCacheSecurityGroupIngressMessage, cb)
 	assert(AuthorizeCacheSecurityGroupIngressMessage, "You must provide a AuthorizeCacheSecurityGroupIngressMessage")
 	local headers = {
@@ -6632,19 +6645,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AuthorizeCacheSecurityGroupIngressMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AuthorizeCacheSecurityGroupIngressSync(AuthorizeCacheSecurityGroupIngressMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AuthorizeCacheSecurityGroupIngressAsync(AuthorizeCacheSecurityGroupIngressMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AuthorizeCacheSecurityGroupIngressAsync(AuthorizeCacheSecurityGroupIngressMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopySnapshot asynchronously, invoking a callback when done
 -- @param CopySnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopySnapshotAsync(CopySnapshotMessage, cb)
 	assert(CopySnapshotMessage, "You must provide a CopySnapshotMessage")
 	local headers = {
@@ -6667,19 +6681,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopySnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopySnapshotSync(CopySnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopySnapshotAsync(CopySnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopySnapshotAsync(CopySnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToResource asynchronously, invoking a callback when done
 -- @param AddTagsToResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToResourceAsync(AddTagsToResourceMessage, cb)
 	assert(AddTagsToResourceMessage, "You must provide a AddTagsToResourceMessage")
 	local headers = {
@@ -6702,19 +6717,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToResourceSync(AddTagsToResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToResourceAsync(AddTagsToResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToResourceAsync(AddTagsToResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call IncreaseReplicaCount asynchronously, invoking a callback when done
 -- @param IncreaseReplicaCountMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.IncreaseReplicaCountAsync(IncreaseReplicaCountMessage, cb)
 	assert(IncreaseReplicaCountMessage, "You must provide a IncreaseReplicaCountMessage")
 	local headers = {
@@ -6737,19 +6753,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IncreaseReplicaCountMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.IncreaseReplicaCountSync(IncreaseReplicaCountMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.IncreaseReplicaCountAsync(IncreaseReplicaCountMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.IncreaseReplicaCountAsync(IncreaseReplicaCountMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCacheClusters asynchronously, invoking a callback when done
 -- @param DescribeCacheClustersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCacheClustersAsync(DescribeCacheClustersMessage, cb)
 	assert(DescribeCacheClustersMessage, "You must provide a DescribeCacheClustersMessage")
 	local headers = {
@@ -6772,19 +6789,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCacheClustersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCacheClustersSync(DescribeCacheClustersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCacheClustersAsync(DescribeCacheClustersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCacheClustersAsync(DescribeCacheClustersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyCacheCluster asynchronously, invoking a callback when done
 -- @param ModifyCacheClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyCacheClusterAsync(ModifyCacheClusterMessage, cb)
 	assert(ModifyCacheClusterMessage, "You must provide a ModifyCacheClusterMessage")
 	local headers = {
@@ -6807,19 +6825,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyCacheClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyCacheClusterSync(ModifyCacheClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyCacheClusterAsync(ModifyCacheClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyCacheClusterAsync(ModifyCacheClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReplicationGroup asynchronously, invoking a callback when done
 -- @param CreateReplicationGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReplicationGroupAsync(CreateReplicationGroupMessage, cb)
 	assert(CreateReplicationGroupMessage, "You must provide a CreateReplicationGroupMessage")
 	local headers = {
@@ -6842,19 +6861,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReplicationGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReplicationGroupSync(CreateReplicationGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReplicationGroupAsync(CreateReplicationGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReplicationGroupAsync(CreateReplicationGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromResource asynchronously, invoking a callback when done
 -- @param RemoveTagsFromResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, cb)
 	assert(RemoveTagsFromResourceMessage, "You must provide a RemoveTagsFromResourceMessage")
 	local headers = {
@@ -6877,19 +6897,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromResourceSync(RemoveTagsFromResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCacheParameters asynchronously, invoking a callback when done
 -- @param DescribeCacheParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCacheParametersAsync(DescribeCacheParametersMessage, cb)
 	assert(DescribeCacheParametersMessage, "You must provide a DescribeCacheParametersMessage")
 	local headers = {
@@ -6912,19 +6933,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCacheParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCacheParametersSync(DescribeCacheParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCacheParametersAsync(DescribeCacheParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCacheParametersAsync(DescribeCacheParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCacheParameterGroup asynchronously, invoking a callback when done
 -- @param CreateCacheParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCacheParameterGroupAsync(CreateCacheParameterGroupMessage, cb)
 	assert(CreateCacheParameterGroupMessage, "You must provide a CreateCacheParameterGroupMessage")
 	local headers = {
@@ -6947,19 +6969,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCacheParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCacheParameterGroupSync(CreateCacheParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCacheParameterGroupAsync(CreateCacheParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCacheParameterGroupAsync(CreateCacheParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestFailover asynchronously, invoking a callback when done
 -- @param TestFailoverMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestFailoverAsync(TestFailoverMessage, cb)
 	assert(TestFailoverMessage, "You must provide a TestFailoverMessage")
 	local headers = {
@@ -6982,19 +7005,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestFailoverMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestFailoverSync(TestFailoverMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestFailoverAsync(TestFailoverMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestFailoverAsync(TestFailoverMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReplicationGroups asynchronously, invoking a callback when done
 -- @param DescribeReplicationGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReplicationGroupsAsync(DescribeReplicationGroupsMessage, cb)
 	assert(DescribeReplicationGroupsMessage, "You must provide a DescribeReplicationGroupsMessage")
 	local headers = {
@@ -7017,19 +7041,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReplicationGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReplicationGroupsSync(DescribeReplicationGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReplicationGroupsAsync(DescribeReplicationGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReplicationGroupsAsync(DescribeReplicationGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReplicationGroup asynchronously, invoking a callback when done
 -- @param DeleteReplicationGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReplicationGroupAsync(DeleteReplicationGroupMessage, cb)
 	assert(DeleteReplicationGroupMessage, "You must provide a DeleteReplicationGroupMessage")
 	local headers = {
@@ -7052,19 +7077,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReplicationGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReplicationGroupSync(DeleteReplicationGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReplicationGroupAsync(DeleteReplicationGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReplicationGroupAsync(DeleteReplicationGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedCacheNodesOfferings asynchronously, invoking a callback when done
 -- @param DescribeReservedCacheNodesOfferingsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedCacheNodesOfferingsAsync(DescribeReservedCacheNodesOfferingsMessage, cb)
 	assert(DescribeReservedCacheNodesOfferingsMessage, "You must provide a DescribeReservedCacheNodesOfferingsMessage")
 	local headers = {
@@ -7087,19 +7113,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedCacheNodesOfferingsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedCacheNodesOfferingsSync(DescribeReservedCacheNodesOfferingsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedCacheNodesOfferingsAsync(DescribeReservedCacheNodesOfferingsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedCacheNodesOfferingsAsync(DescribeReservedCacheNodesOfferingsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCacheCluster asynchronously, invoking a callback when done
 -- @param CreateCacheClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCacheClusterAsync(CreateCacheClusterMessage, cb)
 	assert(CreateCacheClusterMessage, "You must provide a CreateCacheClusterMessage")
 	local headers = {
@@ -7122,19 +7149,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCacheClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCacheClusterSync(CreateCacheClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCacheClusterAsync(CreateCacheClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCacheClusterAsync(CreateCacheClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCacheSubnetGroup asynchronously, invoking a callback when done
 -- @param CreateCacheSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCacheSubnetGroupAsync(CreateCacheSubnetGroupMessage, cb)
 	assert(CreateCacheSubnetGroupMessage, "You must provide a CreateCacheSubnetGroupMessage")
 	local headers = {
@@ -7157,19 +7185,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCacheSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCacheSubnetGroupSync(CreateCacheSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCacheSubnetGroupAsync(CreateCacheSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCacheSubnetGroupAsync(CreateCacheSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyReplicationGroup asynchronously, invoking a callback when done
 -- @param ModifyReplicationGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyReplicationGroupAsync(ModifyReplicationGroupMessage, cb)
 	assert(ModifyReplicationGroupMessage, "You must provide a ModifyReplicationGroupMessage")
 	local headers = {
@@ -7192,19 +7221,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyReplicationGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyReplicationGroupSync(ModifyReplicationGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyReplicationGroupAsync(ModifyReplicationGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyReplicationGroupAsync(ModifyReplicationGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyCacheParameterGroup asynchronously, invoking a callback when done
 -- @param ModifyCacheParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyCacheParameterGroupAsync(ModifyCacheParameterGroupMessage, cb)
 	assert(ModifyCacheParameterGroupMessage, "You must provide a ModifyCacheParameterGroupMessage")
 	local headers = {
@@ -7227,19 +7257,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyCacheParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyCacheParameterGroupSync(ModifyCacheParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyCacheParameterGroupAsync(ModifyCacheParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyCacheParameterGroupAsync(ModifyCacheParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSnapshots asynchronously, invoking a callback when done
 -- @param DescribeSnapshotsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSnapshotsAsync(DescribeSnapshotsMessage, cb)
 	assert(DescribeSnapshotsMessage, "You must provide a DescribeSnapshotsMessage")
 	local headers = {
@@ -7262,19 +7293,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSnapshotsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSnapshotsSync(DescribeSnapshotsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSnapshotsAsync(DescribeSnapshotsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSnapshotsAsync(DescribeSnapshotsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyReplicationGroupShardConfiguration asynchronously, invoking a callback when done
 -- @param ModifyReplicationGroupShardConfigurationMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyReplicationGroupShardConfigurationAsync(ModifyReplicationGroupShardConfigurationMessage, cb)
 	assert(ModifyReplicationGroupShardConfigurationMessage, "You must provide a ModifyReplicationGroupShardConfigurationMessage")
 	local headers = {
@@ -7297,19 +7329,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyReplicationGroupShardConfigurationMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyReplicationGroupShardConfigurationSync(ModifyReplicationGroupShardConfigurationMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyReplicationGroupShardConfigurationAsync(ModifyReplicationGroupShardConfigurationMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyReplicationGroupShardConfigurationAsync(ModifyReplicationGroupShardConfigurationMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCacheCluster asynchronously, invoking a callback when done
 -- @param DeleteCacheClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCacheClusterAsync(DeleteCacheClusterMessage, cb)
 	assert(DeleteCacheClusterMessage, "You must provide a DeleteCacheClusterMessage")
 	local headers = {
@@ -7332,19 +7365,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCacheClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCacheClusterSync(DeleteCacheClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCacheClusterAsync(DeleteCacheClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCacheClusterAsync(DeleteCacheClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseReservedCacheNodesOffering asynchronously, invoking a callback when done
 -- @param PurchaseReservedCacheNodesOfferingMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseReservedCacheNodesOfferingAsync(PurchaseReservedCacheNodesOfferingMessage, cb)
 	assert(PurchaseReservedCacheNodesOfferingMessage, "You must provide a PurchaseReservedCacheNodesOfferingMessage")
 	local headers = {
@@ -7367,19 +7401,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseReservedCacheNodesOfferingMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseReservedCacheNodesOfferingSync(PurchaseReservedCacheNodesOfferingMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseReservedCacheNodesOfferingAsync(PurchaseReservedCacheNodesOfferingMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseReservedCacheNodesOfferingAsync(PurchaseReservedCacheNodesOfferingMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSnapshot asynchronously, invoking a callback when done
 -- @param DeleteSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSnapshotAsync(DeleteSnapshotMessage, cb)
 	assert(DeleteSnapshotMessage, "You must provide a DeleteSnapshotMessage")
 	local headers = {
@@ -7402,19 +7437,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSnapshotSync(DeleteSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSnapshotAsync(DeleteSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSnapshotAsync(DeleteSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeCacheSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param RevokeCacheSecurityGroupIngressMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeCacheSecurityGroupIngressAsync(RevokeCacheSecurityGroupIngressMessage, cb)
 	assert(RevokeCacheSecurityGroupIngressMessage, "You must provide a RevokeCacheSecurityGroupIngressMessage")
 	local headers = {
@@ -7437,19 +7473,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeCacheSecurityGroupIngressMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeCacheSecurityGroupIngressSync(RevokeCacheSecurityGroupIngressMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeCacheSecurityGroupIngressAsync(RevokeCacheSecurityGroupIngressMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeCacheSecurityGroupIngressAsync(RevokeCacheSecurityGroupIngressMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAllowedNodeTypeModifications asynchronously, invoking a callback when done
 -- @param ListAllowedNodeTypeModificationsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAllowedNodeTypeModificationsAsync(ListAllowedNodeTypeModificationsMessage, cb)
 	assert(ListAllowedNodeTypeModificationsMessage, "You must provide a ListAllowedNodeTypeModificationsMessage")
 	local headers = {
@@ -7472,19 +7509,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAllowedNodeTypeModificationsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAllowedNodeTypeModificationsSync(ListAllowedNodeTypeModificationsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAllowedNodeTypeModificationsAsync(ListAllowedNodeTypeModificationsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAllowedNodeTypeModificationsAsync(ListAllowedNodeTypeModificationsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedCacheNodes asynchronously, invoking a callback when done
 -- @param DescribeReservedCacheNodesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedCacheNodesAsync(DescribeReservedCacheNodesMessage, cb)
 	assert(DescribeReservedCacheNodesMessage, "You must provide a DescribeReservedCacheNodesMessage")
 	local headers = {
@@ -7507,19 +7545,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedCacheNodesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedCacheNodesSync(DescribeReservedCacheNodesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedCacheNodesAsync(DescribeReservedCacheNodesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedCacheNodesAsync(DescribeReservedCacheNodesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCacheSecurityGroup asynchronously, invoking a callback when done
 -- @param CreateCacheSecurityGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCacheSecurityGroupAsync(CreateCacheSecurityGroupMessage, cb)
 	assert(CreateCacheSecurityGroupMessage, "You must provide a CreateCacheSecurityGroupMessage")
 	local headers = {
@@ -7542,19 +7581,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCacheSecurityGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCacheSecurityGroupSync(CreateCacheSecurityGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCacheSecurityGroupAsync(CreateCacheSecurityGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCacheSecurityGroupAsync(CreateCacheSecurityGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceMessage, cb)
 	assert(ListTagsForResourceMessage, "You must provide a ListTagsForResourceMessage")
 	local headers = {
@@ -7577,19 +7617,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSnapshot asynchronously, invoking a callback when done
 -- @param CreateSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSnapshotAsync(CreateSnapshotMessage, cb)
 	assert(CreateSnapshotMessage, "You must provide a CreateSnapshotMessage")
 	local headers = {
@@ -7612,12 +7653,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSnapshotSync(CreateSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSnapshotAsync(CreateSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSnapshotAsync(CreateSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/elasticbeanstalk.lua
+++ b/aws-sdk/elasticbeanstalk.lua
@@ -7464,7 +7464,7 @@ end
 --
 --- Call UpdateTagsForResource asynchronously, invoking a callback when done
 -- @param UpdateTagsForResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTagsForResourceAsync(UpdateTagsForResourceMessage, cb)
 	assert(UpdateTagsForResourceMessage, "You must provide a UpdateTagsForResourceMessage")
 	local headers = {
@@ -7487,19 +7487,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTagsForResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTagsForResourceSync(UpdateTagsForResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTagsForResourceAsync(UpdateTagsForResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTagsForResourceAsync(UpdateTagsForResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeApplicationVersions asynchronously, invoking a callback when done
 -- @param DescribeApplicationVersionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeApplicationVersionsAsync(DescribeApplicationVersionsMessage, cb)
 	assert(DescribeApplicationVersionsMessage, "You must provide a DescribeApplicationVersionsMessage")
 	local headers = {
@@ -7522,19 +7523,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeApplicationVersionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeApplicationVersionsSync(DescribeApplicationVersionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeApplicationVersionsAsync(DescribeApplicationVersionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeApplicationVersionsAsync(DescribeApplicationVersionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RequestEnvironmentInfo asynchronously, invoking a callback when done
 -- @param RequestEnvironmentInfoMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RequestEnvironmentInfoAsync(RequestEnvironmentInfoMessage, cb)
 	assert(RequestEnvironmentInfoMessage, "You must provide a RequestEnvironmentInfoMessage")
 	local headers = {
@@ -7557,19 +7559,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RequestEnvironmentInfoMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RequestEnvironmentInfoSync(RequestEnvironmentInfoMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RequestEnvironmentInfoAsync(RequestEnvironmentInfoMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RequestEnvironmentInfoAsync(RequestEnvironmentInfoMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironmentResources asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentResourcesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentResourcesAsync(DescribeEnvironmentResourcesMessage, cb)
 	assert(DescribeEnvironmentResourcesMessage, "You must provide a DescribeEnvironmentResourcesMessage")
 	local headers = {
@@ -7592,19 +7595,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentResourcesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentResourcesSync(DescribeEnvironmentResourcesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentResourcesAsync(DescribeEnvironmentResourcesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentResourcesAsync(DescribeEnvironmentResourcesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsMessage, cb)
 	assert(DescribeEventsMessage, "You must provide a DescribeEventsMessage")
 	local headers = {
@@ -7627,19 +7631,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironmentHealth asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentHealthRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentHealthAsync(DescribeEnvironmentHealthRequest, cb)
 	assert(DescribeEnvironmentHealthRequest, "You must provide a DescribeEnvironmentHealthRequest")
 	local headers = {
@@ -7662,19 +7667,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentHealthRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentHealthSync(DescribeEnvironmentHealthRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentHealthAsync(DescribeEnvironmentHealthRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentHealthAsync(DescribeEnvironmentHealthRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApplicationResourceLifecycle asynchronously, invoking a callback when done
 -- @param UpdateApplicationResourceLifecycleMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationResourceLifecycleAsync(UpdateApplicationResourceLifecycleMessage, cb)
 	assert(UpdateApplicationResourceLifecycleMessage, "You must provide a UpdateApplicationResourceLifecycleMessage")
 	local headers = {
@@ -7697,19 +7703,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationResourceLifecycleMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationResourceLifecycleSync(UpdateApplicationResourceLifecycleMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationResourceLifecycleAsync(UpdateApplicationResourceLifecycleMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationResourceLifecycleAsync(UpdateApplicationResourceLifecycleMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateEnvironment asynchronously, invoking a callback when done
 -- @param TerminateEnvironmentMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateEnvironmentAsync(TerminateEnvironmentMessage, cb)
 	assert(TerminateEnvironmentMessage, "You must provide a TerminateEnvironmentMessage")
 	local headers = {
@@ -7732,19 +7739,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateEnvironmentMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateEnvironmentSync(TerminateEnvironmentMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateEnvironmentAsync(TerminateEnvironmentMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateEnvironmentAsync(TerminateEnvironmentMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApplicationVersion asynchronously, invoking a callback when done
 -- @param UpdateApplicationVersionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationVersionAsync(UpdateApplicationVersionMessage, cb)
 	assert(UpdateApplicationVersionMessage, "You must provide a UpdateApplicationVersionMessage")
 	local headers = {
@@ -7767,19 +7775,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationVersionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationVersionSync(UpdateApplicationVersionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationVersionAsync(UpdateApplicationVersionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationVersionAsync(UpdateApplicationVersionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplication asynchronously, invoking a callback when done
 -- @param DeleteApplicationMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationAsync(DeleteApplicationMessage, cb)
 	assert(DeleteApplicationMessage, "You must provide a DeleteApplicationMessage")
 	local headers = {
@@ -7802,19 +7811,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationSync(DeleteApplicationMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationAsync(DeleteApplicationMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationAsync(DeleteApplicationMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ApplyEnvironmentManagedAction asynchronously, invoking a callback when done
 -- @param ApplyEnvironmentManagedActionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ApplyEnvironmentManagedActionAsync(ApplyEnvironmentManagedActionRequest, cb)
 	assert(ApplyEnvironmentManagedActionRequest, "You must provide a ApplyEnvironmentManagedActionRequest")
 	local headers = {
@@ -7837,19 +7847,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ApplyEnvironmentManagedActionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ApplyEnvironmentManagedActionSync(ApplyEnvironmentManagedActionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ApplyEnvironmentManagedActionAsync(ApplyEnvironmentManagedActionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ApplyEnvironmentManagedActionAsync(ApplyEnvironmentManagedActionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationOptions asynchronously, invoking a callback when done
 -- @param DescribeConfigurationOptionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationOptionsAsync(DescribeConfigurationOptionsMessage, cb)
 	assert(DescribeConfigurationOptionsMessage, "You must provide a DescribeConfigurationOptionsMessage")
 	local headers = {
@@ -7872,19 +7883,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationOptionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationOptionsSync(DescribeConfigurationOptionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationOptionsAsync(DescribeConfigurationOptionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationOptionsAsync(DescribeConfigurationOptionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironmentManagedActionHistory asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentManagedActionHistoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentManagedActionHistoryAsync(DescribeEnvironmentManagedActionHistoryRequest, cb)
 	assert(DescribeEnvironmentManagedActionHistoryRequest, "You must provide a DescribeEnvironmentManagedActionHistoryRequest")
 	local headers = {
@@ -7907,19 +7919,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentManagedActionHistoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentManagedActionHistorySync(DescribeEnvironmentManagedActionHistoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentManagedActionHistoryAsync(DescribeEnvironmentManagedActionHistoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentManagedActionHistoryAsync(DescribeEnvironmentManagedActionHistoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConfigurationTemplate asynchronously, invoking a callback when done
 -- @param DeleteConfigurationTemplateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConfigurationTemplateAsync(DeleteConfigurationTemplateMessage, cb)
 	assert(DeleteConfigurationTemplateMessage, "You must provide a DeleteConfigurationTemplateMessage")
 	local headers = {
@@ -7942,19 +7955,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConfigurationTemplateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConfigurationTemplateSync(DeleteConfigurationTemplateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConfigurationTemplateAsync(DeleteConfigurationTemplateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConfigurationTemplateAsync(DeleteConfigurationTemplateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ValidateConfigurationSettings asynchronously, invoking a callback when done
 -- @param ValidateConfigurationSettingsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ValidateConfigurationSettingsAsync(ValidateConfigurationSettingsMessage, cb)
 	assert(ValidateConfigurationSettingsMessage, "You must provide a ValidateConfigurationSettingsMessage")
 	local headers = {
@@ -7977,18 +7991,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ValidateConfigurationSettingsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ValidateConfigurationSettingsSync(ValidateConfigurationSettingsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ValidateConfigurationSettingsAsync(ValidateConfigurationSettingsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ValidateConfigurationSettingsAsync(ValidateConfigurationSettingsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAvailableSolutionStacks asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAvailableSolutionStacksAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -8007,19 +8022,20 @@ end
 --- Call ListAvailableSolutionStacks synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAvailableSolutionStacksSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAvailableSolutionStacksAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAvailableSolutionStacksAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ComposeEnvironments asynchronously, invoking a callback when done
 -- @param ComposeEnvironmentsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ComposeEnvironmentsAsync(ComposeEnvironmentsMessage, cb)
 	assert(ComposeEnvironmentsMessage, "You must provide a ComposeEnvironmentsMessage")
 	local headers = {
@@ -8042,19 +8058,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ComposeEnvironmentsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ComposeEnvironmentsSync(ComposeEnvironmentsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ComposeEnvironmentsAsync(ComposeEnvironmentsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ComposeEnvironmentsAsync(ComposeEnvironmentsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationSettings asynchronously, invoking a callback when done
 -- @param DescribeConfigurationSettingsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationSettingsAsync(DescribeConfigurationSettingsMessage, cb)
 	assert(DescribeConfigurationSettingsMessage, "You must provide a DescribeConfigurationSettingsMessage")
 	local headers = {
@@ -8077,19 +8094,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationSettingsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationSettingsSync(DescribeConfigurationSettingsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationSettingsAsync(DescribeConfigurationSettingsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationSettingsAsync(DescribeConfigurationSettingsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApplication asynchronously, invoking a callback when done
 -- @param CreateApplicationMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApplicationAsync(CreateApplicationMessage, cb)
 	assert(CreateApplicationMessage, "You must provide a CreateApplicationMessage")
 	local headers = {
@@ -8112,19 +8130,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApplicationMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApplicationSync(CreateApplicationMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApplicationAsync(CreateApplicationMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApplicationAsync(CreateApplicationMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConfigurationTemplate asynchronously, invoking a callback when done
 -- @param UpdateConfigurationTemplateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConfigurationTemplateAsync(UpdateConfigurationTemplateMessage, cb)
 	assert(UpdateConfigurationTemplateMessage, "You must provide a UpdateConfigurationTemplateMessage")
 	local headers = {
@@ -8147,19 +8166,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConfigurationTemplateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConfigurationTemplateSync(UpdateConfigurationTemplateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConfigurationTemplateAsync(UpdateConfigurationTemplateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConfigurationTemplateAsync(UpdateConfigurationTemplateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplicationVersion asynchronously, invoking a callback when done
 -- @param DeleteApplicationVersionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationVersionAsync(DeleteApplicationVersionMessage, cb)
 	assert(DeleteApplicationVersionMessage, "You must provide a DeleteApplicationVersionMessage")
 	local headers = {
@@ -8182,19 +8202,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationVersionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationVersionSync(DeleteApplicationVersionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationVersionAsync(DeleteApplicationVersionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationVersionAsync(DeleteApplicationVersionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RetrieveEnvironmentInfo asynchronously, invoking a callback when done
 -- @param RetrieveEnvironmentInfoMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RetrieveEnvironmentInfoAsync(RetrieveEnvironmentInfoMessage, cb)
 	assert(RetrieveEnvironmentInfoMessage, "You must provide a RetrieveEnvironmentInfoMessage")
 	local headers = {
@@ -8217,19 +8238,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RetrieveEnvironmentInfoMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RetrieveEnvironmentInfoSync(RetrieveEnvironmentInfoMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RetrieveEnvironmentInfoAsync(RetrieveEnvironmentInfoMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RetrieveEnvironmentInfoAsync(RetrieveEnvironmentInfoMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApplication asynchronously, invoking a callback when done
 -- @param UpdateApplicationMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationAsync(UpdateApplicationMessage, cb)
 	assert(UpdateApplicationMessage, "You must provide a UpdateApplicationMessage")
 	local headers = {
@@ -8252,19 +8274,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationSync(UpdateApplicationMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationAsync(UpdateApplicationMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationAsync(UpdateApplicationMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEnvironment asynchronously, invoking a callback when done
 -- @param UpdateEnvironmentMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEnvironmentAsync(UpdateEnvironmentMessage, cb)
 	assert(UpdateEnvironmentMessage, "You must provide a UpdateEnvironmentMessage")
 	local headers = {
@@ -8287,19 +8310,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEnvironmentMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEnvironmentSync(UpdateEnvironmentMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEnvironmentAsync(UpdateEnvironmentMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEnvironmentAsync(UpdateEnvironmentMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironments asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentsAsync(DescribeEnvironmentsMessage, cb)
 	assert(DescribeEnvironmentsMessage, "You must provide a DescribeEnvironmentsMessage")
 	local headers = {
@@ -8322,19 +8346,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentsSync(DescribeEnvironmentsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentsAsync(DescribeEnvironmentsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentsAsync(DescribeEnvironmentsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPlatformVersions asynchronously, invoking a callback when done
 -- @param ListPlatformVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPlatformVersionsAsync(ListPlatformVersionsRequest, cb)
 	assert(ListPlatformVersionsRequest, "You must provide a ListPlatformVersionsRequest")
 	local headers = {
@@ -8357,19 +8382,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPlatformVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPlatformVersionsSync(ListPlatformVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPlatformVersionsAsync(ListPlatformVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPlatformVersionsAsync(ListPlatformVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEnvironmentManagedActions asynchronously, invoking a callback when done
 -- @param DescribeEnvironmentManagedActionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEnvironmentManagedActionsAsync(DescribeEnvironmentManagedActionsRequest, cb)
 	assert(DescribeEnvironmentManagedActionsRequest, "You must provide a DescribeEnvironmentManagedActionsRequest")
 	local headers = {
@@ -8392,19 +8418,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEnvironmentManagedActionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEnvironmentManagedActionsSync(DescribeEnvironmentManagedActionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEnvironmentManagedActionsAsync(DescribeEnvironmentManagedActionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEnvironmentManagedActionsAsync(DescribeEnvironmentManagedActionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AbortEnvironmentUpdate asynchronously, invoking a callback when done
 -- @param AbortEnvironmentUpdateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AbortEnvironmentUpdateAsync(AbortEnvironmentUpdateMessage, cb)
 	assert(AbortEnvironmentUpdateMessage, "You must provide a AbortEnvironmentUpdateMessage")
 	local headers = {
@@ -8427,19 +8454,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AbortEnvironmentUpdateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AbortEnvironmentUpdateSync(AbortEnvironmentUpdateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AbortEnvironmentUpdateAsync(AbortEnvironmentUpdateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AbortEnvironmentUpdateAsync(AbortEnvironmentUpdateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestartAppServer asynchronously, invoking a callback when done
 -- @param RestartAppServerMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestartAppServerAsync(RestartAppServerMessage, cb)
 	assert(RestartAppServerMessage, "You must provide a RestartAppServerMessage")
 	local headers = {
@@ -8462,19 +8490,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestartAppServerMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestartAppServerSync(RestartAppServerMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestartAppServerAsync(RestartAppServerMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestartAppServerAsync(RestartAppServerMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEnvironmentConfiguration asynchronously, invoking a callback when done
 -- @param DeleteEnvironmentConfigurationMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEnvironmentConfigurationAsync(DeleteEnvironmentConfigurationMessage, cb)
 	assert(DeleteEnvironmentConfigurationMessage, "You must provide a DeleteEnvironmentConfigurationMessage")
 	local headers = {
@@ -8497,19 +8526,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEnvironmentConfigurationMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEnvironmentConfigurationSync(DeleteEnvironmentConfigurationMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEnvironmentConfigurationAsync(DeleteEnvironmentConfigurationMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEnvironmentConfigurationAsync(DeleteEnvironmentConfigurationMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEnvironment asynchronously, invoking a callback when done
 -- @param CreateEnvironmentMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEnvironmentAsync(CreateEnvironmentMessage, cb)
 	assert(CreateEnvironmentMessage, "You must provide a CreateEnvironmentMessage")
 	local headers = {
@@ -8532,19 +8562,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEnvironmentMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEnvironmentSync(CreateEnvironmentMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEnvironmentAsync(CreateEnvironmentMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEnvironmentAsync(CreateEnvironmentMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SwapEnvironmentCNAMEs asynchronously, invoking a callback when done
 -- @param SwapEnvironmentCNAMEsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SwapEnvironmentCNAMEsAsync(SwapEnvironmentCNAMEsMessage, cb)
 	assert(SwapEnvironmentCNAMEsMessage, "You must provide a SwapEnvironmentCNAMEsMessage")
 	local headers = {
@@ -8567,19 +8598,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SwapEnvironmentCNAMEsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SwapEnvironmentCNAMEsSync(SwapEnvironmentCNAMEsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SwapEnvironmentCNAMEsAsync(SwapEnvironmentCNAMEsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SwapEnvironmentCNAMEsAsync(SwapEnvironmentCNAMEsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePlatformVersion asynchronously, invoking a callback when done
 -- @param DeletePlatformVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePlatformVersionAsync(DeletePlatformVersionRequest, cb)
 	assert(DeletePlatformVersionRequest, "You must provide a DeletePlatformVersionRequest")
 	local headers = {
@@ -8602,18 +8634,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePlatformVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePlatformVersionSync(DeletePlatformVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePlatformVersionAsync(DeletePlatformVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePlatformVersionAsync(DeletePlatformVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStorageLocation asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStorageLocationAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -8632,19 +8665,20 @@ end
 --- Call CreateStorageLocation synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStorageLocationSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStorageLocationAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStorageLocationAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebuildEnvironment asynchronously, invoking a callback when done
 -- @param RebuildEnvironmentMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebuildEnvironmentAsync(RebuildEnvironmentMessage, cb)
 	assert(RebuildEnvironmentMessage, "You must provide a RebuildEnvironmentMessage")
 	local headers = {
@@ -8667,19 +8701,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebuildEnvironmentMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebuildEnvironmentSync(RebuildEnvironmentMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebuildEnvironmentAsync(RebuildEnvironmentMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebuildEnvironmentAsync(RebuildEnvironmentMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceMessage, cb)
 	assert(ListTagsForResourceMessage, "You must provide a ListTagsForResourceMessage")
 	local headers = {
@@ -8702,19 +8737,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeApplications asynchronously, invoking a callback when done
 -- @param DescribeApplicationsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeApplicationsAsync(DescribeApplicationsMessage, cb)
 	assert(DescribeApplicationsMessage, "You must provide a DescribeApplicationsMessage")
 	local headers = {
@@ -8737,19 +8773,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeApplicationsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeApplicationsSync(DescribeApplicationsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeApplicationsAsync(DescribeApplicationsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeApplicationsAsync(DescribeApplicationsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePlatformVersion asynchronously, invoking a callback when done
 -- @param CreatePlatformVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePlatformVersionAsync(CreatePlatformVersionRequest, cb)
 	assert(CreatePlatformVersionRequest, "You must provide a CreatePlatformVersionRequest")
 	local headers = {
@@ -8772,19 +8809,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePlatformVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePlatformVersionSync(CreatePlatformVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePlatformVersionAsync(CreatePlatformVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePlatformVersionAsync(CreatePlatformVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePlatformVersion asynchronously, invoking a callback when done
 -- @param DescribePlatformVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePlatformVersionAsync(DescribePlatformVersionRequest, cb)
 	assert(DescribePlatformVersionRequest, "You must provide a DescribePlatformVersionRequest")
 	local headers = {
@@ -8807,18 +8845,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePlatformVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePlatformVersionSync(DescribePlatformVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePlatformVersionAsync(DescribePlatformVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePlatformVersionAsync(DescribePlatformVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountAttributes asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountAttributesAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -8837,19 +8876,20 @@ end
 --- Call DescribeAccountAttributes synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountAttributesSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountAttributesAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountAttributesAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstancesHealth asynchronously, invoking a callback when done
 -- @param DescribeInstancesHealthRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstancesHealthAsync(DescribeInstancesHealthRequest, cb)
 	assert(DescribeInstancesHealthRequest, "You must provide a DescribeInstancesHealthRequest")
 	local headers = {
@@ -8872,19 +8912,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstancesHealthRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstancesHealthSync(DescribeInstancesHealthRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstancesHealthAsync(DescribeInstancesHealthRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstancesHealthAsync(DescribeInstancesHealthRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApplicationVersion asynchronously, invoking a callback when done
 -- @param CreateApplicationVersionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApplicationVersionAsync(CreateApplicationVersionMessage, cb)
 	assert(CreateApplicationVersionMessage, "You must provide a CreateApplicationVersionMessage")
 	local headers = {
@@ -8907,19 +8948,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApplicationVersionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApplicationVersionSync(CreateApplicationVersionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApplicationVersionAsync(CreateApplicationVersionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApplicationVersionAsync(CreateApplicationVersionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConfigurationTemplate asynchronously, invoking a callback when done
 -- @param CreateConfigurationTemplateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConfigurationTemplateAsync(CreateConfigurationTemplateMessage, cb)
 	assert(CreateConfigurationTemplateMessage, "You must provide a CreateConfigurationTemplateMessage")
 	local headers = {
@@ -8942,19 +8984,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConfigurationTemplateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConfigurationTemplateSync(CreateConfigurationTemplateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConfigurationTemplateAsync(CreateConfigurationTemplateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConfigurationTemplateAsync(CreateConfigurationTemplateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CheckDNSAvailability asynchronously, invoking a callback when done
 -- @param CheckDNSAvailabilityMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CheckDNSAvailabilityAsync(CheckDNSAvailabilityMessage, cb)
 	assert(CheckDNSAvailabilityMessage, "You must provide a CheckDNSAvailabilityMessage")
 	local headers = {
@@ -8977,12 +9020,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CheckDNSAvailabilityMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CheckDNSAvailabilitySync(CheckDNSAvailabilityMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CheckDNSAvailabilityAsync(CheckDNSAvailabilityMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CheckDNSAvailabilityAsync(CheckDNSAvailabilityMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/elasticfilesystem.lua
+++ b/aws-sdk/elasticfilesystem.lua
@@ -2247,7 +2247,7 @@ end
 --
 --- Call DeleteTags asynchronously, invoking a callback when done
 -- @param DeleteTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsAsync(DeleteTagsRequest, cb)
 	assert(DeleteTagsRequest, "You must provide a DeleteTagsRequest")
 	local headers = {
@@ -2270,19 +2270,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsSync(DeleteTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMountTargetSecurityGroups asynchronously, invoking a callback when done
 -- @param DescribeMountTargetSecurityGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMountTargetSecurityGroupsAsync(DescribeMountTargetSecurityGroupsRequest, cb)
 	assert(DescribeMountTargetSecurityGroupsRequest, "You must provide a DescribeMountTargetSecurityGroupsRequest")
 	local headers = {
@@ -2305,19 +2306,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMountTargetSecurityGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMountTargetSecurityGroupsSync(DescribeMountTargetSecurityGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMountTargetSecurityGroupsAsync(DescribeMountTargetSecurityGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMountTargetSecurityGroupsAsync(DescribeMountTargetSecurityGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFileSystem asynchronously, invoking a callback when done
 -- @param DeleteFileSystemRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFileSystemAsync(DeleteFileSystemRequest, cb)
 	assert(DeleteFileSystemRequest, "You must provide a DeleteFileSystemRequest")
 	local headers = {
@@ -2340,19 +2342,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFileSystemRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFileSystemSync(DeleteFileSystemRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFileSystemAsync(DeleteFileSystemRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFileSystemAsync(DeleteFileSystemRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTags asynchronously, invoking a callback when done
 -- @param CreateTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTagsAsync(CreateTagsRequest, cb)
 	assert(CreateTagsRequest, "You must provide a CreateTagsRequest")
 	local headers = {
@@ -2375,19 +2378,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTagsSync(CreateTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTagsAsync(CreateTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTagsAsync(CreateTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMountTarget asynchronously, invoking a callback when done
 -- @param CreateMountTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMountTargetAsync(CreateMountTargetRequest, cb)
 	assert(CreateMountTargetRequest, "You must provide a CreateMountTargetRequest")
 	local headers = {
@@ -2410,19 +2414,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMountTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMountTargetSync(CreateMountTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMountTargetAsync(CreateMountTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMountTargetAsync(CreateMountTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFileSystems asynchronously, invoking a callback when done
 -- @param DescribeFileSystemsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFileSystemsAsync(DescribeFileSystemsRequest, cb)
 	assert(DescribeFileSystemsRequest, "You must provide a DescribeFileSystemsRequest")
 	local headers = {
@@ -2445,19 +2450,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFileSystemsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFileSystemsSync(DescribeFileSystemsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFileSystemsAsync(DescribeFileSystemsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFileSystemsAsync(DescribeFileSystemsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsRequest, cb)
 	assert(DescribeTagsRequest, "You must provide a DescribeTagsRequest")
 	local headers = {
@@ -2480,19 +2486,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFileSystem asynchronously, invoking a callback when done
 -- @param UpdateFileSystemRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFileSystemAsync(UpdateFileSystemRequest, cb)
 	assert(UpdateFileSystemRequest, "You must provide a UpdateFileSystemRequest")
 	local headers = {
@@ -2515,19 +2522,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFileSystemRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFileSystemSync(UpdateFileSystemRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFileSystemAsync(UpdateFileSystemRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFileSystemAsync(UpdateFileSystemRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyMountTargetSecurityGroups asynchronously, invoking a callback when done
 -- @param ModifyMountTargetSecurityGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyMountTargetSecurityGroupsAsync(ModifyMountTargetSecurityGroupsRequest, cb)
 	assert(ModifyMountTargetSecurityGroupsRequest, "You must provide a ModifyMountTargetSecurityGroupsRequest")
 	local headers = {
@@ -2550,19 +2558,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyMountTargetSecurityGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyMountTargetSecurityGroupsSync(ModifyMountTargetSecurityGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyMountTargetSecurityGroupsAsync(ModifyMountTargetSecurityGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyMountTargetSecurityGroupsAsync(ModifyMountTargetSecurityGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMountTargets asynchronously, invoking a callback when done
 -- @param DescribeMountTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMountTargetsAsync(DescribeMountTargetsRequest, cb)
 	assert(DescribeMountTargetsRequest, "You must provide a DescribeMountTargetsRequest")
 	local headers = {
@@ -2585,19 +2594,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMountTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMountTargetsSync(DescribeMountTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMountTargetsAsync(DescribeMountTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMountTargetsAsync(DescribeMountTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFileSystem asynchronously, invoking a callback when done
 -- @param CreateFileSystemRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFileSystemAsync(CreateFileSystemRequest, cb)
 	assert(CreateFileSystemRequest, "You must provide a CreateFileSystemRequest")
 	local headers = {
@@ -2620,19 +2630,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFileSystemRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFileSystemSync(CreateFileSystemRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFileSystemAsync(CreateFileSystemRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFileSystemAsync(CreateFileSystemRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMountTarget asynchronously, invoking a callback when done
 -- @param DeleteMountTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMountTargetAsync(DeleteMountTargetRequest, cb)
 	assert(DeleteMountTargetRequest, "You must provide a DeleteMountTargetRequest")
 	local headers = {
@@ -2655,12 +2666,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMountTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMountTargetSync(DeleteMountTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMountTargetAsync(DeleteMountTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMountTargetAsync(DeleteMountTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/elasticloadbalancing.lua
+++ b/aws-sdk/elasticloadbalancing.lua
@@ -6878,7 +6878,7 @@ end
 --
 --- Call RegisterTargets asynchronously, invoking a callback when done
 -- @param RegisterTargetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterTargetsAsync(RegisterTargetsInput, cb)
 	assert(RegisterTargetsInput, "You must provide a RegisterTargetsInput")
 	local headers = {
@@ -6901,19 +6901,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterTargetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterTargetsSync(RegisterTargetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterTargetsAsync(RegisterTargetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterTargetsAsync(RegisterTargetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSSLPolicies asynchronously, invoking a callback when done
 -- @param DescribeSSLPoliciesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSSLPoliciesAsync(DescribeSSLPoliciesInput, cb)
 	assert(DescribeSSLPoliciesInput, "You must provide a DescribeSSLPoliciesInput")
 	local headers = {
@@ -6936,19 +6937,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSSLPoliciesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSSLPoliciesSync(DescribeSSLPoliciesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSSLPoliciesAsync(DescribeSSLPoliciesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSSLPoliciesAsync(DescribeSSLPoliciesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetSecurityGroups asynchronously, invoking a callback when done
 -- @param SetSecurityGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetSecurityGroupsAsync(SetSecurityGroupsInput, cb)
 	assert(SetSecurityGroupsInput, "You must provide a SetSecurityGroupsInput")
 	local headers = {
@@ -6971,19 +6973,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetSecurityGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetSecurityGroupsSync(SetSecurityGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetSecurityGroupsAsync(SetSecurityGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetSecurityGroupsAsync(SetSecurityGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddListenerCertificates asynchronously, invoking a callback when done
 -- @param AddListenerCertificatesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddListenerCertificatesAsync(AddListenerCertificatesInput, cb)
 	assert(AddListenerCertificatesInput, "You must provide a AddListenerCertificatesInput")
 	local headers = {
@@ -7006,19 +7009,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddListenerCertificatesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddListenerCertificatesSync(AddListenerCertificatesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddListenerCertificatesAsync(AddListenerCertificatesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddListenerCertificatesAsync(AddListenerCertificatesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteListener asynchronously, invoking a callback when done
 -- @param DeleteListenerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteListenerAsync(DeleteListenerInput, cb)
 	assert(DeleteListenerInput, "You must provide a DeleteListenerInput")
 	local headers = {
@@ -7041,19 +7045,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteListenerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteListenerSync(DeleteListenerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteListenerAsync(DeleteListenerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteListenerAsync(DeleteListenerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyTargetGroup asynchronously, invoking a callback when done
 -- @param ModifyTargetGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyTargetGroupAsync(ModifyTargetGroupInput, cb)
 	assert(ModifyTargetGroupInput, "You must provide a ModifyTargetGroupInput")
 	local headers = {
@@ -7076,19 +7081,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyTargetGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyTargetGroupSync(ModifyTargetGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyTargetGroupAsync(ModifyTargetGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyTargetGroupAsync(ModifyTargetGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRule asynchronously, invoking a callback when done
 -- @param CreateRuleInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRuleAsync(CreateRuleInput, cb)
 	assert(CreateRuleInput, "You must provide a CreateRuleInput")
 	local headers = {
@@ -7111,19 +7117,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRuleInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRuleSync(CreateRuleInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRuleAsync(CreateRuleInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRuleAsync(CreateRuleInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetRulePriorities asynchronously, invoking a callback when done
 -- @param SetRulePrioritiesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetRulePrioritiesAsync(SetRulePrioritiesInput, cb)
 	assert(SetRulePrioritiesInput, "You must provide a SetRulePrioritiesInput")
 	local headers = {
@@ -7146,19 +7153,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetRulePrioritiesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetRulePrioritiesSync(SetRulePrioritiesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetRulePrioritiesAsync(SetRulePrioritiesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetRulePrioritiesAsync(SetRulePrioritiesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyTargetGroupAttributes asynchronously, invoking a callback when done
 -- @param ModifyTargetGroupAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyTargetGroupAttributesAsync(ModifyTargetGroupAttributesInput, cb)
 	assert(ModifyTargetGroupAttributesInput, "You must provide a ModifyTargetGroupAttributesInput")
 	local headers = {
@@ -7181,19 +7189,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyTargetGroupAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyTargetGroupAttributesSync(ModifyTargetGroupAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyTargetGroupAttributesAsync(ModifyTargetGroupAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyTargetGroupAttributesAsync(ModifyTargetGroupAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLoadBalancerAttributes asynchronously, invoking a callback when done
 -- @param DescribeLoadBalancerAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLoadBalancerAttributesAsync(DescribeLoadBalancerAttributesInput, cb)
 	assert(DescribeLoadBalancerAttributesInput, "You must provide a DescribeLoadBalancerAttributesInput")
 	local headers = {
@@ -7216,19 +7225,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLoadBalancerAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLoadBalancerAttributesSync(DescribeLoadBalancerAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLoadBalancerAttributesAsync(DescribeLoadBalancerAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLoadBalancerAttributesAsync(DescribeLoadBalancerAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIpAddressType asynchronously, invoking a callback when done
 -- @param SetIpAddressTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIpAddressTypeAsync(SetIpAddressTypeInput, cb)
 	assert(SetIpAddressTypeInput, "You must provide a SetIpAddressTypeInput")
 	local headers = {
@@ -7251,19 +7261,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIpAddressTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIpAddressTypeSync(SetIpAddressTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIpAddressTypeAsync(SetIpAddressTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIpAddressTypeAsync(SetIpAddressTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveListenerCertificates asynchronously, invoking a callback when done
 -- @param RemoveListenerCertificatesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveListenerCertificatesAsync(RemoveListenerCertificatesInput, cb)
 	assert(RemoveListenerCertificatesInput, "You must provide a RemoveListenerCertificatesInput")
 	local headers = {
@@ -7286,19 +7297,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveListenerCertificatesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveListenerCertificatesSync(RemoveListenerCertificatesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveListenerCertificatesAsync(RemoveListenerCertificatesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveListenerCertificatesAsync(RemoveListenerCertificatesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyListener asynchronously, invoking a callback when done
 -- @param ModifyListenerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyListenerAsync(ModifyListenerInput, cb)
 	assert(ModifyListenerInput, "You must provide a ModifyListenerInput")
 	local headers = {
@@ -7321,19 +7333,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyListenerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyListenerSync(ModifyListenerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyListenerAsync(ModifyListenerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyListenerAsync(ModifyListenerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLoadBalancer asynchronously, invoking a callback when done
 -- @param DeleteLoadBalancerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLoadBalancerAsync(DeleteLoadBalancerInput, cb)
 	assert(DeleteLoadBalancerInput, "You must provide a DeleteLoadBalancerInput")
 	local headers = {
@@ -7356,19 +7369,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLoadBalancerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLoadBalancerSync(DeleteLoadBalancerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLoadBalancerAsync(DeleteLoadBalancerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLoadBalancerAsync(DeleteLoadBalancerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRule asynchronously, invoking a callback when done
 -- @param DeleteRuleInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRuleAsync(DeleteRuleInput, cb)
 	assert(DeleteRuleInput, "You must provide a DeleteRuleInput")
 	local headers = {
@@ -7391,19 +7405,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRuleInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRuleSync(DeleteRuleInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRuleAsync(DeleteRuleInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRuleAsync(DeleteRuleInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTargetGroup asynchronously, invoking a callback when done
 -- @param DeleteTargetGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTargetGroupAsync(DeleteTargetGroupInput, cb)
 	assert(DeleteTargetGroupInput, "You must provide a DeleteTargetGroupInput")
 	local headers = {
@@ -7426,19 +7441,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTargetGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTargetGroupSync(DeleteTargetGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTargetGroupAsync(DeleteTargetGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTargetGroupAsync(DeleteTargetGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTargetGroupAttributes asynchronously, invoking a callback when done
 -- @param DescribeTargetGroupAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTargetGroupAttributesAsync(DescribeTargetGroupAttributesInput, cb)
 	assert(DescribeTargetGroupAttributesInput, "You must provide a DescribeTargetGroupAttributesInput")
 	local headers = {
@@ -7461,19 +7477,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTargetGroupAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTargetGroupAttributesSync(DescribeTargetGroupAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTargetGroupAttributesAsync(DescribeTargetGroupAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTargetGroupAttributesAsync(DescribeTargetGroupAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLoadBalancers asynchronously, invoking a callback when done
 -- @param DescribeLoadBalancersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLoadBalancersAsync(DescribeLoadBalancersInput, cb)
 	assert(DescribeLoadBalancersInput, "You must provide a DescribeLoadBalancersInput")
 	local headers = {
@@ -7496,19 +7513,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLoadBalancersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLoadBalancersSync(DescribeLoadBalancersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLoadBalancersAsync(DescribeLoadBalancersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLoadBalancersAsync(DescribeLoadBalancersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeListeners asynchronously, invoking a callback when done
 -- @param DescribeListenersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeListenersAsync(DescribeListenersInput, cb)
 	assert(DescribeListenersInput, "You must provide a DescribeListenersInput")
 	local headers = {
@@ -7531,19 +7549,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeListenersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeListenersSync(DescribeListenersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeListenersAsync(DescribeListenersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeListenersAsync(DescribeListenersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTags asynchronously, invoking a callback when done
 -- @param RemoveTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsAsync(RemoveTagsInput, cb)
 	assert(RemoveTagsInput, "You must provide a RemoveTagsInput")
 	local headers = {
@@ -7566,19 +7585,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsSync(RemoveTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsAsync(RemoveTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsAsync(RemoveTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateListener asynchronously, invoking a callback when done
 -- @param CreateListenerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateListenerAsync(CreateListenerInput, cb)
 	assert(CreateListenerInput, "You must provide a CreateListenerInput")
 	local headers = {
@@ -7601,19 +7621,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateListenerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateListenerSync(CreateListenerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateListenerAsync(CreateListenerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateListenerAsync(CreateListenerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetSubnets asynchronously, invoking a callback when done
 -- @param SetSubnetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetSubnetsAsync(SetSubnetsInput, cb)
 	assert(SetSubnetsInput, "You must provide a SetSubnetsInput")
 	local headers = {
@@ -7636,19 +7657,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetSubnetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetSubnetsSync(SetSubnetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetSubnetsAsync(SetSubnetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetSubnetsAsync(SetSubnetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsInput, cb)
 	assert(DescribeTagsInput, "You must provide a DescribeTagsInput")
 	local headers = {
@@ -7671,19 +7693,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyRule asynchronously, invoking a callback when done
 -- @param ModifyRuleInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyRuleAsync(ModifyRuleInput, cb)
 	assert(ModifyRuleInput, "You must provide a ModifyRuleInput")
 	local headers = {
@@ -7706,19 +7729,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyRuleInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyRuleSync(ModifyRuleInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyRuleAsync(ModifyRuleInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyRuleAsync(ModifyRuleInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTargetGroup asynchronously, invoking a callback when done
 -- @param CreateTargetGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTargetGroupAsync(CreateTargetGroupInput, cb)
 	assert(CreateTargetGroupInput, "You must provide a CreateTargetGroupInput")
 	local headers = {
@@ -7741,19 +7765,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTargetGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTargetGroupSync(CreateTargetGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTargetGroupAsync(CreateTargetGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTargetGroupAsync(CreateTargetGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTags asynchronously, invoking a callback when done
 -- @param AddTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsAsync(AddTagsInput, cb)
 	assert(AddTagsInput, "You must provide a AddTagsInput")
 	local headers = {
@@ -7776,19 +7801,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsSync(AddTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsAsync(AddTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsAsync(AddTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTargetGroups asynchronously, invoking a callback when done
 -- @param DescribeTargetGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTargetGroupsAsync(DescribeTargetGroupsInput, cb)
 	assert(DescribeTargetGroupsInput, "You must provide a DescribeTargetGroupsInput")
 	local headers = {
@@ -7811,19 +7837,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTargetGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTargetGroupsSync(DescribeTargetGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTargetGroupsAsync(DescribeTargetGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTargetGroupsAsync(DescribeTargetGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterTargets asynchronously, invoking a callback when done
 -- @param DeregisterTargetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterTargetsAsync(DeregisterTargetsInput, cb)
 	assert(DeregisterTargetsInput, "You must provide a DeregisterTargetsInput")
 	local headers = {
@@ -7846,19 +7873,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterTargetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterTargetsSync(DeregisterTargetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterTargetsAsync(DeregisterTargetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterTargetsAsync(DeregisterTargetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyLoadBalancerAttributes asynchronously, invoking a callback when done
 -- @param ModifyLoadBalancerAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyLoadBalancerAttributesAsync(ModifyLoadBalancerAttributesInput, cb)
 	assert(ModifyLoadBalancerAttributesInput, "You must provide a ModifyLoadBalancerAttributesInput")
 	local headers = {
@@ -7881,19 +7909,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyLoadBalancerAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyLoadBalancerAttributesSync(ModifyLoadBalancerAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyLoadBalancerAttributesAsync(ModifyLoadBalancerAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyLoadBalancerAttributesAsync(ModifyLoadBalancerAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRules asynchronously, invoking a callback when done
 -- @param DescribeRulesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRulesAsync(DescribeRulesInput, cb)
 	assert(DescribeRulesInput, "You must provide a DescribeRulesInput")
 	local headers = {
@@ -7916,19 +7945,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRulesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRulesSync(DescribeRulesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRulesAsync(DescribeRulesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRulesAsync(DescribeRulesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeListenerCertificates asynchronously, invoking a callback when done
 -- @param DescribeListenerCertificatesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeListenerCertificatesAsync(DescribeListenerCertificatesInput, cb)
 	assert(DescribeListenerCertificatesInput, "You must provide a DescribeListenerCertificatesInput")
 	local headers = {
@@ -7951,19 +7981,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeListenerCertificatesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeListenerCertificatesSync(DescribeListenerCertificatesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeListenerCertificatesAsync(DescribeListenerCertificatesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeListenerCertificatesAsync(DescribeListenerCertificatesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTargetHealth asynchronously, invoking a callback when done
 -- @param DescribeTargetHealthInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTargetHealthAsync(DescribeTargetHealthInput, cb)
 	assert(DescribeTargetHealthInput, "You must provide a DescribeTargetHealthInput")
 	local headers = {
@@ -7986,19 +8017,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTargetHealthInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTargetHealthSync(DescribeTargetHealthInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTargetHealthAsync(DescribeTargetHealthInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTargetHealthAsync(DescribeTargetHealthInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLoadBalancer asynchronously, invoking a callback when done
 -- @param CreateLoadBalancerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLoadBalancerAsync(CreateLoadBalancerInput, cb)
 	assert(CreateLoadBalancerInput, "You must provide a CreateLoadBalancerInput")
 	local headers = {
@@ -8021,19 +8053,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLoadBalancerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLoadBalancerSync(CreateLoadBalancerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLoadBalancerAsync(CreateLoadBalancerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLoadBalancerAsync(CreateLoadBalancerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountLimits asynchronously, invoking a callback when done
 -- @param DescribeAccountLimitsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountLimitsAsync(DescribeAccountLimitsInput, cb)
 	assert(DescribeAccountLimitsInput, "You must provide a DescribeAccountLimitsInput")
 	local headers = {
@@ -8056,12 +8089,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountLimitsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountLimitsSync(DescribeAccountLimitsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountLimitsAsync(DescribeAccountLimitsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountLimitsAsync(DescribeAccountLimitsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/elasticmapreduce.lua
+++ b/aws-sdk/elasticmapreduce.lua
@@ -7027,7 +7027,7 @@ end
 --
 --- Call CancelSteps asynchronously, invoking a callback when done
 -- @param CancelStepsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelStepsAsync(CancelStepsInput, cb)
 	assert(CancelStepsInput, "You must provide a CancelStepsInput")
 	local headers = {
@@ -7050,19 +7050,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelStepsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelStepsSync(CancelStepsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelStepsAsync(CancelStepsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelStepsAsync(CancelStepsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveAutoScalingPolicy asynchronously, invoking a callback when done
 -- @param RemoveAutoScalingPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveAutoScalingPolicyAsync(RemoveAutoScalingPolicyInput, cb)
 	assert(RemoveAutoScalingPolicyInput, "You must provide a RemoveAutoScalingPolicyInput")
 	local headers = {
@@ -7085,19 +7086,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveAutoScalingPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveAutoScalingPolicySync(RemoveAutoScalingPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveAutoScalingPolicyAsync(RemoveAutoScalingPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveAutoScalingPolicyAsync(RemoveAutoScalingPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSecurityConfiguration asynchronously, invoking a callback when done
 -- @param CreateSecurityConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSecurityConfigurationAsync(CreateSecurityConfigurationInput, cb)
 	assert(CreateSecurityConfigurationInput, "You must provide a CreateSecurityConfigurationInput")
 	local headers = {
@@ -7120,19 +7122,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSecurityConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSecurityConfigurationSync(CreateSecurityConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSecurityConfigurationAsync(CreateSecurityConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSecurityConfigurationAsync(CreateSecurityConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RunJobFlow asynchronously, invoking a callback when done
 -- @param RunJobFlowInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RunJobFlowAsync(RunJobFlowInput, cb)
 	assert(RunJobFlowInput, "You must provide a RunJobFlowInput")
 	local headers = {
@@ -7155,19 +7158,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RunJobFlowInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RunJobFlowSync(RunJobFlowInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RunJobFlowAsync(RunJobFlowInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RunJobFlowAsync(RunJobFlowInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSecurityConfiguration asynchronously, invoking a callback when done
 -- @param DescribeSecurityConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSecurityConfigurationAsync(DescribeSecurityConfigurationInput, cb)
 	assert(DescribeSecurityConfigurationInput, "You must provide a DescribeSecurityConfigurationInput")
 	local headers = {
@@ -7190,19 +7194,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSecurityConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSecurityConfigurationSync(DescribeSecurityConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSecurityConfigurationAsync(DescribeSecurityConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSecurityConfigurationAsync(DescribeSecurityConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSecurityConfigurations asynchronously, invoking a callback when done
 -- @param ListSecurityConfigurationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSecurityConfigurationsAsync(ListSecurityConfigurationsInput, cb)
 	assert(ListSecurityConfigurationsInput, "You must provide a ListSecurityConfigurationsInput")
 	local headers = {
@@ -7225,19 +7230,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSecurityConfigurationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSecurityConfigurationsSync(ListSecurityConfigurationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSecurityConfigurationsAsync(ListSecurityConfigurationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSecurityConfigurationsAsync(ListSecurityConfigurationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetTerminationProtection asynchronously, invoking a callback when done
 -- @param SetTerminationProtectionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetTerminationProtectionAsync(SetTerminationProtectionInput, cb)
 	assert(SetTerminationProtectionInput, "You must provide a SetTerminationProtectionInput")
 	local headers = {
@@ -7260,19 +7266,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetTerminationProtectionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetTerminationProtectionSync(SetTerminationProtectionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetTerminationProtectionAsync(SetTerminationProtectionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetTerminationProtectionAsync(SetTerminationProtectionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSecurityConfiguration asynchronously, invoking a callback when done
 -- @param DeleteSecurityConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSecurityConfigurationAsync(DeleteSecurityConfigurationInput, cb)
 	assert(DeleteSecurityConfigurationInput, "You must provide a DeleteSecurityConfigurationInput")
 	local headers = {
@@ -7295,19 +7302,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSecurityConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSecurityConfigurationSync(DeleteSecurityConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSecurityConfigurationAsync(DeleteSecurityConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSecurityConfigurationAsync(DeleteSecurityConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddInstanceGroups asynchronously, invoking a callback when done
 -- @param AddInstanceGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddInstanceGroupsAsync(AddInstanceGroupsInput, cb)
 	assert(AddInstanceGroupsInput, "You must provide a AddInstanceGroupsInput")
 	local headers = {
@@ -7330,19 +7338,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddInstanceGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddInstanceGroupsSync(AddInstanceGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddInstanceGroupsAsync(AddInstanceGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddInstanceGroupsAsync(AddInstanceGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBootstrapActions asynchronously, invoking a callback when done
 -- @param ListBootstrapActionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBootstrapActionsAsync(ListBootstrapActionsInput, cb)
 	assert(ListBootstrapActionsInput, "You must provide a ListBootstrapActionsInput")
 	local headers = {
@@ -7365,19 +7374,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBootstrapActionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBootstrapActionsSync(ListBootstrapActionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBootstrapActionsAsync(ListBootstrapActionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBootstrapActionsAsync(ListBootstrapActionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListClusters asynchronously, invoking a callback when done
 -- @param ListClustersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListClustersAsync(ListClustersInput, cb)
 	assert(ListClustersInput, "You must provide a ListClustersInput")
 	local headers = {
@@ -7400,19 +7410,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListClustersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListClustersSync(ListClustersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListClustersAsync(ListClustersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListClustersAsync(ListClustersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInstances asynchronously, invoking a callback when done
 -- @param ListInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInstancesAsync(ListInstancesInput, cb)
 	assert(ListInstancesInput, "You must provide a ListInstancesInput")
 	local headers = {
@@ -7435,19 +7446,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInstancesSync(ListInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInstancesAsync(ListInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInstancesAsync(ListInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCluster asynchronously, invoking a callback when done
 -- @param DescribeClusterInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterAsync(DescribeClusterInput, cb)
 	assert(DescribeClusterInput, "You must provide a DescribeClusterInput")
 	local headers = {
@@ -7470,19 +7482,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterSync(DescribeClusterInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterAsync(DescribeClusterInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterAsync(DescribeClusterInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSteps asynchronously, invoking a callback when done
 -- @param ListStepsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStepsAsync(ListStepsInput, cb)
 	assert(ListStepsInput, "You must provide a ListStepsInput")
 	local headers = {
@@ -7505,19 +7518,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStepsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStepsSync(ListStepsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStepsAsync(ListStepsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStepsAsync(ListStepsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTags asynchronously, invoking a callback when done
 -- @param RemoveTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsAsync(RemoveTagsInput, cb)
 	assert(RemoveTagsInput, "You must provide a RemoveTagsInput")
 	local headers = {
@@ -7540,19 +7554,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsSync(RemoveTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsAsync(RemoveTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsAsync(RemoveTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyInstanceGroups asynchronously, invoking a callback when done
 -- @param ModifyInstanceGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyInstanceGroupsAsync(ModifyInstanceGroupsInput, cb)
 	assert(ModifyInstanceGroupsInput, "You must provide a ModifyInstanceGroupsInput")
 	local headers = {
@@ -7575,19 +7590,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyInstanceGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyInstanceGroupsSync(ModifyInstanceGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyInstanceGroupsAsync(ModifyInstanceGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyInstanceGroupsAsync(ModifyInstanceGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutAutoScalingPolicy asynchronously, invoking a callback when done
 -- @param PutAutoScalingPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutAutoScalingPolicyAsync(PutAutoScalingPolicyInput, cb)
 	assert(PutAutoScalingPolicyInput, "You must provide a PutAutoScalingPolicyInput")
 	local headers = {
@@ -7610,19 +7626,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutAutoScalingPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutAutoScalingPolicySync(PutAutoScalingPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutAutoScalingPolicyAsync(PutAutoScalingPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutAutoScalingPolicyAsync(PutAutoScalingPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddInstanceFleet asynchronously, invoking a callback when done
 -- @param AddInstanceFleetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddInstanceFleetAsync(AddInstanceFleetInput, cb)
 	assert(AddInstanceFleetInput, "You must provide a AddInstanceFleetInput")
 	local headers = {
@@ -7645,19 +7662,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddInstanceFleetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddInstanceFleetSync(AddInstanceFleetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddInstanceFleetAsync(AddInstanceFleetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddInstanceFleetAsync(AddInstanceFleetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetVisibleToAllUsers asynchronously, invoking a callback when done
 -- @param SetVisibleToAllUsersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetVisibleToAllUsersAsync(SetVisibleToAllUsersInput, cb)
 	assert(SetVisibleToAllUsersInput, "You must provide a SetVisibleToAllUsersInput")
 	local headers = {
@@ -7680,19 +7698,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetVisibleToAllUsersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetVisibleToAllUsersSync(SetVisibleToAllUsersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetVisibleToAllUsersAsync(SetVisibleToAllUsersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetVisibleToAllUsersAsync(SetVisibleToAllUsersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInstanceFleets asynchronously, invoking a callback when done
 -- @param ListInstanceFleetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInstanceFleetsAsync(ListInstanceFleetsInput, cb)
 	assert(ListInstanceFleetsInput, "You must provide a ListInstanceFleetsInput")
 	local headers = {
@@ -7715,19 +7734,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInstanceFleetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInstanceFleetsSync(ListInstanceFleetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInstanceFleetsAsync(ListInstanceFleetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInstanceFleetsAsync(ListInstanceFleetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateJobFlows asynchronously, invoking a callback when done
 -- @param TerminateJobFlowsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateJobFlowsAsync(TerminateJobFlowsInput, cb)
 	assert(TerminateJobFlowsInput, "You must provide a TerminateJobFlowsInput")
 	local headers = {
@@ -7750,19 +7770,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateJobFlowsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateJobFlowsSync(TerminateJobFlowsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateJobFlowsAsync(TerminateJobFlowsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateJobFlowsAsync(TerminateJobFlowsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTags asynchronously, invoking a callback when done
 -- @param AddTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsAsync(AddTagsInput, cb)
 	assert(AddTagsInput, "You must provide a AddTagsInput")
 	local headers = {
@@ -7785,19 +7806,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsSync(AddTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsAsync(AddTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsAsync(AddTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyInstanceFleet asynchronously, invoking a callback when done
 -- @param ModifyInstanceFleetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyInstanceFleetAsync(ModifyInstanceFleetInput, cb)
 	assert(ModifyInstanceFleetInput, "You must provide a ModifyInstanceFleetInput")
 	local headers = {
@@ -7820,19 +7842,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyInstanceFleetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyInstanceFleetSync(ModifyInstanceFleetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyInstanceFleetAsync(ModifyInstanceFleetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyInstanceFleetAsync(ModifyInstanceFleetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddJobFlowSteps asynchronously, invoking a callback when done
 -- @param AddJobFlowStepsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddJobFlowStepsAsync(AddJobFlowStepsInput, cb)
 	assert(AddJobFlowStepsInput, "You must provide a AddJobFlowStepsInput")
 	local headers = {
@@ -7855,19 +7878,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddJobFlowStepsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddJobFlowStepsSync(AddJobFlowStepsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddJobFlowStepsAsync(AddJobFlowStepsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddJobFlowStepsAsync(AddJobFlowStepsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInstanceGroups asynchronously, invoking a callback when done
 -- @param ListInstanceGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInstanceGroupsAsync(ListInstanceGroupsInput, cb)
 	assert(ListInstanceGroupsInput, "You must provide a ListInstanceGroupsInput")
 	local headers = {
@@ -7890,19 +7914,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInstanceGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInstanceGroupsSync(ListInstanceGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInstanceGroupsAsync(ListInstanceGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInstanceGroupsAsync(ListInstanceGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStep asynchronously, invoking a callback when done
 -- @param DescribeStepInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStepAsync(DescribeStepInput, cb)
 	assert(DescribeStepInput, "You must provide a DescribeStepInput")
 	local headers = {
@@ -7925,12 +7950,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStepInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStepSync(DescribeStepInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStepAsync(DescribeStepInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStepAsync(DescribeStepInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/elastictranscoder.lua
+++ b/aws-sdk/elastictranscoder.lua
@@ -4357,7 +4357,7 @@ end
 --
 --- Call ReadPreset asynchronously, invoking a callback when done
 -- @param ReadPresetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReadPresetAsync(ReadPresetRequest, cb)
 	assert(ReadPresetRequest, "You must provide a ReadPresetRequest")
 	local headers = {
@@ -4380,19 +4380,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReadPresetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReadPresetSync(ReadPresetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReadPresetAsync(ReadPresetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReadPresetAsync(ReadPresetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJob asynchronously, invoking a callback when done
 -- @param CreateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobAsync(CreateJobRequest, cb)
 	assert(CreateJobRequest, "You must provide a CreateJobRequest")
 	local headers = {
@@ -4415,19 +4416,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobSync(CreateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobAsync(CreateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobAsync(CreateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePreset asynchronously, invoking a callback when done
 -- @param CreatePresetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePresetAsync(CreatePresetRequest, cb)
 	assert(CreatePresetRequest, "You must provide a CreatePresetRequest")
 	local headers = {
@@ -4450,19 +4452,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePresetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePresetSync(CreatePresetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePresetAsync(CreatePresetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePresetAsync(CreatePresetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePipelineNotifications asynchronously, invoking a callback when done
 -- @param UpdatePipelineNotificationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePipelineNotificationsAsync(UpdatePipelineNotificationsRequest, cb)
 	assert(UpdatePipelineNotificationsRequest, "You must provide a UpdatePipelineNotificationsRequest")
 	local headers = {
@@ -4485,19 +4488,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePipelineNotificationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePipelineNotificationsSync(UpdatePipelineNotificationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePipelineNotificationsAsync(UpdatePipelineNotificationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePipelineNotificationsAsync(UpdatePipelineNotificationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPipelines asynchronously, invoking a callback when done
 -- @param ListPipelinesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPipelinesAsync(ListPipelinesRequest, cb)
 	assert(ListPipelinesRequest, "You must provide a ListPipelinesRequest")
 	local headers = {
@@ -4520,19 +4524,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPipelinesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPipelinesSync(ListPipelinesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPipelinesAsync(ListPipelinesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPipelinesAsync(ListPipelinesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePipeline asynchronously, invoking a callback when done
 -- @param DeletePipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePipelineAsync(DeletePipelineRequest, cb)
 	assert(DeletePipelineRequest, "You must provide a DeletePipelineRequest")
 	local headers = {
@@ -4555,19 +4560,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePipelineSync(DeletePipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePipelineAsync(DeletePipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePipelineAsync(DeletePipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReadJob asynchronously, invoking a callback when done
 -- @param ReadJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReadJobAsync(ReadJobRequest, cb)
 	assert(ReadJobRequest, "You must provide a ReadJobRequest")
 	local headers = {
@@ -4590,19 +4596,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReadJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReadJobSync(ReadJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReadJobAsync(ReadJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReadJobAsync(ReadJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePipeline asynchronously, invoking a callback when done
 -- @param UpdatePipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePipelineAsync(UpdatePipelineRequest, cb)
 	assert(UpdatePipelineRequest, "You must provide a UpdatePipelineRequest")
 	local headers = {
@@ -4625,19 +4632,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePipelineSync(UpdatePipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePipelineAsync(UpdatePipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePipelineAsync(UpdatePipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPresets asynchronously, invoking a callback when done
 -- @param ListPresetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPresetsAsync(ListPresetsRequest, cb)
 	assert(ListPresetsRequest, "You must provide a ListPresetsRequest")
 	local headers = {
@@ -4660,19 +4668,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPresetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPresetsSync(ListPresetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPresetsAsync(ListPresetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPresetsAsync(ListPresetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePreset asynchronously, invoking a callback when done
 -- @param DeletePresetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePresetAsync(DeletePresetRequest, cb)
 	assert(DeletePresetRequest, "You must provide a DeletePresetRequest")
 	local headers = {
@@ -4695,19 +4704,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePresetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePresetSync(DeletePresetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePresetAsync(DeletePresetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePresetAsync(DeletePresetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobsByPipeline asynchronously, invoking a callback when done
 -- @param ListJobsByPipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsByPipelineAsync(ListJobsByPipelineRequest, cb)
 	assert(ListJobsByPipelineRequest, "You must provide a ListJobsByPipelineRequest")
 	local headers = {
@@ -4730,19 +4740,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsByPipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsByPipelineSync(ListJobsByPipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsByPipelineAsync(ListJobsByPipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsByPipelineAsync(ListJobsByPipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelJob asynchronously, invoking a callback when done
 -- @param CancelJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelJobAsync(CancelJobRequest, cb)
 	assert(CancelJobRequest, "You must provide a CancelJobRequest")
 	local headers = {
@@ -4765,19 +4776,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelJobSync(CancelJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelJobAsync(CancelJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelJobAsync(CancelJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePipelineStatus asynchronously, invoking a callback when done
 -- @param UpdatePipelineStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePipelineStatusAsync(UpdatePipelineStatusRequest, cb)
 	assert(UpdatePipelineStatusRequest, "You must provide a UpdatePipelineStatusRequest")
 	local headers = {
@@ -4800,19 +4812,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePipelineStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePipelineStatusSync(UpdatePipelineStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePipelineStatusAsync(UpdatePipelineStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePipelineStatusAsync(UpdatePipelineStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePipeline asynchronously, invoking a callback when done
 -- @param CreatePipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePipelineAsync(CreatePipelineRequest, cb)
 	assert(CreatePipelineRequest, "You must provide a CreatePipelineRequest")
 	local headers = {
@@ -4835,19 +4848,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePipelineSync(CreatePipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePipelineAsync(CreatePipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePipelineAsync(CreatePipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReadPipeline asynchronously, invoking a callback when done
 -- @param ReadPipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReadPipelineAsync(ReadPipelineRequest, cb)
 	assert(ReadPipelineRequest, "You must provide a ReadPipelineRequest")
 	local headers = {
@@ -4870,19 +4884,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReadPipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReadPipelineSync(ReadPipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReadPipelineAsync(ReadPipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReadPipelineAsync(ReadPipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobsByStatus asynchronously, invoking a callback when done
 -- @param ListJobsByStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsByStatusAsync(ListJobsByStatusRequest, cb)
 	assert(ListJobsByStatusRequest, "You must provide a ListJobsByStatusRequest")
 	local headers = {
@@ -4905,12 +4920,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsByStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsByStatusSync(ListJobsByStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsByStatusAsync(ListJobsByStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsByStatusAsync(ListJobsByStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/email.lua
+++ b/aws-sdk/email.lua
@@ -8338,7 +8338,7 @@ end
 --
 --- Call UpdateConfigurationSetTrackingOptions asynchronously, invoking a callback when done
 -- @param UpdateConfigurationSetTrackingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConfigurationSetTrackingOptionsAsync(UpdateConfigurationSetTrackingOptionsRequest, cb)
 	assert(UpdateConfigurationSetTrackingOptionsRequest, "You must provide a UpdateConfigurationSetTrackingOptionsRequest")
 	local headers = {
@@ -8361,19 +8361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConfigurationSetTrackingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConfigurationSetTrackingOptionsSync(UpdateConfigurationSetTrackingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConfigurationSetTrackingOptionsAsync(UpdateConfigurationSetTrackingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConfigurationSetTrackingOptionsAsync(UpdateConfigurationSetTrackingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReceiptRule asynchronously, invoking a callback when done
 -- @param CreateReceiptRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReceiptRuleAsync(CreateReceiptRuleRequest, cb)
 	assert(CreateReceiptRuleRequest, "You must provide a CreateReceiptRuleRequest")
 	local headers = {
@@ -8396,18 +8397,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReceiptRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReceiptRuleSync(CreateReceiptRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReceiptRuleAsync(CreateReceiptRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReceiptRuleAsync(CreateReceiptRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSendStatistics asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSendStatisticsAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -8426,19 +8428,20 @@ end
 --- Call GetSendStatistics synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSendStatisticsSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSendStatisticsAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSendStatisticsAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReorderReceiptRuleSet asynchronously, invoking a callback when done
 -- @param ReorderReceiptRuleSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReorderReceiptRuleSetAsync(ReorderReceiptRuleSetRequest, cb)
 	assert(ReorderReceiptRuleSetRequest, "You must provide a ReorderReceiptRuleSetRequest")
 	local headers = {
@@ -8461,19 +8464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReorderReceiptRuleSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReorderReceiptRuleSetSync(ReorderReceiptRuleSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReorderReceiptRuleSetAsync(ReorderReceiptRuleSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReorderReceiptRuleSetAsync(ReorderReceiptRuleSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityPolicies asynchronously, invoking a callback when done
 -- @param GetIdentityPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityPoliciesAsync(GetIdentityPoliciesRequest, cb)
 	assert(GetIdentityPoliciesRequest, "You must provide a GetIdentityPoliciesRequest")
 	local headers = {
@@ -8496,18 +8500,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityPoliciesSync(GetIdentityPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityPoliciesAsync(GetIdentityPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityPoliciesAsync(GetIdentityPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountSendingEnabled asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountSendingEnabledAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -8526,19 +8531,20 @@ end
 --- Call GetAccountSendingEnabled synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountSendingEnabledSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountSendingEnabledAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountSendingEnabledAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConfigurationSetSendingEnabled asynchronously, invoking a callback when done
 -- @param UpdateConfigurationSetSendingEnabledRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConfigurationSetSendingEnabledAsync(UpdateConfigurationSetSendingEnabledRequest, cb)
 	assert(UpdateConfigurationSetSendingEnabledRequest, "You must provide a UpdateConfigurationSetSendingEnabledRequest")
 	local headers = {
@@ -8561,19 +8567,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConfigurationSetSendingEnabledRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConfigurationSetSendingEnabledSync(UpdateConfigurationSetSendingEnabledRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConfigurationSetSendingEnabledAsync(UpdateConfigurationSetSendingEnabledRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConfigurationSetSendingEnabledAsync(UpdateConfigurationSetSendingEnabledRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call VerifyEmailAddress asynchronously, invoking a callback when done
 -- @param VerifyEmailAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.VerifyEmailAddressAsync(VerifyEmailAddressRequest, cb)
 	assert(VerifyEmailAddressRequest, "You must provide a VerifyEmailAddressRequest")
 	local headers = {
@@ -8596,19 +8603,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param VerifyEmailAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.VerifyEmailAddressSync(VerifyEmailAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.VerifyEmailAddressAsync(VerifyEmailAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.VerifyEmailAddressAsync(VerifyEmailAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIdentityMailFromDomain asynchronously, invoking a callback when done
 -- @param SetIdentityMailFromDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIdentityMailFromDomainAsync(SetIdentityMailFromDomainRequest, cb)
 	assert(SetIdentityMailFromDomainRequest, "You must provide a SetIdentityMailFromDomainRequest")
 	local headers = {
@@ -8631,19 +8639,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIdentityMailFromDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIdentityMailFromDomainSync(SetIdentityMailFromDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIdentityMailFromDomainAsync(SetIdentityMailFromDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIdentityMailFromDomainAsync(SetIdentityMailFromDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConfigurationSet asynchronously, invoking a callback when done
 -- @param DeleteConfigurationSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConfigurationSetAsync(DeleteConfigurationSetRequest, cb)
 	assert(DeleteConfigurationSetRequest, "You must provide a DeleteConfigurationSetRequest")
 	local headers = {
@@ -8666,19 +8675,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConfigurationSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConfigurationSetSync(DeleteConfigurationSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConfigurationSetAsync(DeleteConfigurationSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConfigurationSetAsync(DeleteConfigurationSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListReceiptFilters asynchronously, invoking a callback when done
 -- @param ListReceiptFiltersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListReceiptFiltersAsync(ListReceiptFiltersRequest, cb)
 	assert(ListReceiptFiltersRequest, "You must provide a ListReceiptFiltersRequest")
 	local headers = {
@@ -8701,19 +8711,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListReceiptFiltersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListReceiptFiltersSync(ListReceiptFiltersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListReceiptFiltersAsync(ListReceiptFiltersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListReceiptFiltersAsync(ListReceiptFiltersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReceiptRuleSet asynchronously, invoking a callback when done
 -- @param DescribeReceiptRuleSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReceiptRuleSetAsync(DescribeReceiptRuleSetRequest, cb)
 	assert(DescribeReceiptRuleSetRequest, "You must provide a DescribeReceiptRuleSetRequest")
 	local headers = {
@@ -8736,19 +8747,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReceiptRuleSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReceiptRuleSetSync(DescribeReceiptRuleSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReceiptRuleSetAsync(DescribeReceiptRuleSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReceiptRuleSetAsync(DescribeReceiptRuleSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReceiptFilter asynchronously, invoking a callback when done
 -- @param DeleteReceiptFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReceiptFilterAsync(DeleteReceiptFilterRequest, cb)
 	assert(DeleteReceiptFilterRequest, "You must provide a DeleteReceiptFilterRequest")
 	local headers = {
@@ -8771,19 +8783,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReceiptFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReceiptFilterSync(DeleteReceiptFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReceiptFilterAsync(DeleteReceiptFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReceiptFilterAsync(DeleteReceiptFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConfigurationSetEventDestination asynchronously, invoking a callback when done
 -- @param UpdateConfigurationSetEventDestinationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConfigurationSetEventDestinationAsync(UpdateConfigurationSetEventDestinationRequest, cb)
 	assert(UpdateConfigurationSetEventDestinationRequest, "You must provide a UpdateConfigurationSetEventDestinationRequest")
 	local headers = {
@@ -8806,19 +8819,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConfigurationSetEventDestinationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConfigurationSetEventDestinationSync(UpdateConfigurationSetEventDestinationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConfigurationSetEventDestinationAsync(UpdateConfigurationSetEventDestinationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConfigurationSetEventDestinationAsync(UpdateConfigurationSetEventDestinationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIdentityFeedbackForwardingEnabled asynchronously, invoking a callback when done
 -- @param SetIdentityFeedbackForwardingEnabledRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIdentityFeedbackForwardingEnabledAsync(SetIdentityFeedbackForwardingEnabledRequest, cb)
 	assert(SetIdentityFeedbackForwardingEnabledRequest, "You must provide a SetIdentityFeedbackForwardingEnabledRequest")
 	local headers = {
@@ -8841,19 +8855,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIdentityFeedbackForwardingEnabledRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIdentityFeedbackForwardingEnabledSync(SetIdentityFeedbackForwardingEnabledRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIdentityFeedbackForwardingEnabledAsync(SetIdentityFeedbackForwardingEnabledRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIdentityFeedbackForwardingEnabledAsync(SetIdentityFeedbackForwardingEnabledRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateReceiptRule asynchronously, invoking a callback when done
 -- @param UpdateReceiptRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateReceiptRuleAsync(UpdateReceiptRuleRequest, cb)
 	assert(UpdateReceiptRuleRequest, "You must provide a UpdateReceiptRuleRequest")
 	local headers = {
@@ -8876,19 +8891,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateReceiptRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateReceiptRuleSync(UpdateReceiptRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateReceiptRuleAsync(UpdateReceiptRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateReceiptRuleAsync(UpdateReceiptRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendBounce asynchronously, invoking a callback when done
 -- @param SendBounceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendBounceAsync(SendBounceRequest, cb)
 	assert(SendBounceRequest, "You must provide a SendBounceRequest")
 	local headers = {
@@ -8911,19 +8927,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendBounceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendBounceSync(SendBounceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendBounceAsync(SendBounceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendBounceAsync(SendBounceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConfigurationSetEventDestination asynchronously, invoking a callback when done
 -- @param CreateConfigurationSetEventDestinationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConfigurationSetEventDestinationAsync(CreateConfigurationSetEventDestinationRequest, cb)
 	assert(CreateConfigurationSetEventDestinationRequest, "You must provide a CreateConfigurationSetEventDestinationRequest")
 	local headers = {
@@ -8946,19 +8963,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConfigurationSetEventDestinationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConfigurationSetEventDestinationSync(CreateConfigurationSetEventDestinationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConfigurationSetEventDestinationAsync(CreateConfigurationSetEventDestinationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConfigurationSetEventDestinationAsync(CreateConfigurationSetEventDestinationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityDkimAttributes asynchronously, invoking a callback when done
 -- @param GetIdentityDkimAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityDkimAttributesAsync(GetIdentityDkimAttributesRequest, cb)
 	assert(GetIdentityDkimAttributesRequest, "You must provide a GetIdentityDkimAttributesRequest")
 	local headers = {
@@ -8981,19 +8999,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityDkimAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityDkimAttributesSync(GetIdentityDkimAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityDkimAttributesAsync(GetIdentityDkimAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityDkimAttributesAsync(GetIdentityDkimAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityMailFromDomainAttributes asynchronously, invoking a callback when done
 -- @param GetIdentityMailFromDomainAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityMailFromDomainAttributesAsync(GetIdentityMailFromDomainAttributesRequest, cb)
 	assert(GetIdentityMailFromDomainAttributesRequest, "You must provide a GetIdentityMailFromDomainAttributesRequest")
 	local headers = {
@@ -9016,19 +9035,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityMailFromDomainAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityMailFromDomainAttributesSync(GetIdentityMailFromDomainAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityMailFromDomainAttributesAsync(GetIdentityMailFromDomainAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityMailFromDomainAttributesAsync(GetIdentityMailFromDomainAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReceiptRule asynchronously, invoking a callback when done
 -- @param DeleteReceiptRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReceiptRuleAsync(DeleteReceiptRuleRequest, cb)
 	assert(DeleteReceiptRuleRequest, "You must provide a DeleteReceiptRuleRequest")
 	local headers = {
@@ -9051,19 +9071,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReceiptRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReceiptRuleSync(DeleteReceiptRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReceiptRuleAsync(DeleteReceiptRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReceiptRuleAsync(DeleteReceiptRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationSet asynchronously, invoking a callback when done
 -- @param DescribeConfigurationSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationSetAsync(DescribeConfigurationSetRequest, cb)
 	assert(DescribeConfigurationSetRequest, "You must provide a DescribeConfigurationSetRequest")
 	local headers = {
@@ -9086,18 +9107,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationSetSync(DescribeConfigurationSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationSetAsync(DescribeConfigurationSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationSetAsync(DescribeConfigurationSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVerifiedEmailAddresses asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVerifiedEmailAddressesAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -9116,19 +9138,20 @@ end
 --- Call ListVerifiedEmailAddresses synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVerifiedEmailAddressesSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVerifiedEmailAddressesAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVerifiedEmailAddressesAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTemplate asynchronously, invoking a callback when done
 -- @param DeleteTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTemplateAsync(DeleteTemplateRequest, cb)
 	assert(DeleteTemplateRequest, "You must provide a DeleteTemplateRequest")
 	local headers = {
@@ -9151,19 +9174,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTemplateSync(DeleteTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTemplateAsync(DeleteTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTemplateAsync(DeleteTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CloneReceiptRuleSet asynchronously, invoking a callback when done
 -- @param CloneReceiptRuleSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CloneReceiptRuleSetAsync(CloneReceiptRuleSetRequest, cb)
 	assert(CloneReceiptRuleSetRequest, "You must provide a CloneReceiptRuleSetRequest")
 	local headers = {
@@ -9186,19 +9210,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CloneReceiptRuleSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CloneReceiptRuleSetSync(CloneReceiptRuleSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CloneReceiptRuleSetAsync(CloneReceiptRuleSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CloneReceiptRuleSetAsync(CloneReceiptRuleSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendCustomVerificationEmail asynchronously, invoking a callback when done
 -- @param SendCustomVerificationEmailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendCustomVerificationEmailAsync(SendCustomVerificationEmailRequest, cb)
 	assert(SendCustomVerificationEmailRequest, "You must provide a SendCustomVerificationEmailRequest")
 	local headers = {
@@ -9221,19 +9246,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendCustomVerificationEmailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendCustomVerificationEmailSync(SendCustomVerificationEmailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendCustomVerificationEmailAsync(SendCustomVerificationEmailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendCustomVerificationEmailAsync(SendCustomVerificationEmailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestRenderTemplate asynchronously, invoking a callback when done
 -- @param TestRenderTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestRenderTemplateAsync(TestRenderTemplateRequest, cb)
 	assert(TestRenderTemplateRequest, "You must provide a TestRenderTemplateRequest")
 	local headers = {
@@ -9256,19 +9282,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestRenderTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestRenderTemplateSync(TestRenderTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestRenderTemplateAsync(TestRenderTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestRenderTemplateAsync(TestRenderTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call VerifyDomainIdentity asynchronously, invoking a callback when done
 -- @param VerifyDomainIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.VerifyDomainIdentityAsync(VerifyDomainIdentityRequest, cb)
 	assert(VerifyDomainIdentityRequest, "You must provide a VerifyDomainIdentityRequest")
 	local headers = {
@@ -9291,19 +9318,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param VerifyDomainIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.VerifyDomainIdentitySync(VerifyDomainIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.VerifyDomainIdentityAsync(VerifyDomainIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.VerifyDomainIdentityAsync(VerifyDomainIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCustomVerificationEmailTemplate asynchronously, invoking a callback when done
 -- @param UpdateCustomVerificationEmailTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCustomVerificationEmailTemplateAsync(UpdateCustomVerificationEmailTemplateRequest, cb)
 	assert(UpdateCustomVerificationEmailTemplateRequest, "You must provide a UpdateCustomVerificationEmailTemplateRequest")
 	local headers = {
@@ -9326,19 +9354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCustomVerificationEmailTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCustomVerificationEmailTemplateSync(UpdateCustomVerificationEmailTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCustomVerificationEmailTemplateAsync(UpdateCustomVerificationEmailTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCustomVerificationEmailTemplateAsync(UpdateCustomVerificationEmailTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call VerifyEmailIdentity asynchronously, invoking a callback when done
 -- @param VerifyEmailIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.VerifyEmailIdentityAsync(VerifyEmailIdentityRequest, cb)
 	assert(VerifyEmailIdentityRequest, "You must provide a VerifyEmailIdentityRequest")
 	local headers = {
@@ -9361,19 +9390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param VerifyEmailIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.VerifyEmailIdentitySync(VerifyEmailIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.VerifyEmailIdentityAsync(VerifyEmailIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.VerifyEmailIdentityAsync(VerifyEmailIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeActiveReceiptRuleSet asynchronously, invoking a callback when done
 -- @param DescribeActiveReceiptRuleSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeActiveReceiptRuleSetAsync(DescribeActiveReceiptRuleSetRequest, cb)
 	assert(DescribeActiveReceiptRuleSetRequest, "You must provide a DescribeActiveReceiptRuleSetRequest")
 	local headers = {
@@ -9396,19 +9426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeActiveReceiptRuleSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeActiveReceiptRuleSetSync(DescribeActiveReceiptRuleSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeActiveReceiptRuleSetAsync(DescribeActiveReceiptRuleSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeActiveReceiptRuleSetAsync(DescribeActiveReceiptRuleSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIdentityPolicy asynchronously, invoking a callback when done
 -- @param DeleteIdentityPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIdentityPolicyAsync(DeleteIdentityPolicyRequest, cb)
 	assert(DeleteIdentityPolicyRequest, "You must provide a DeleteIdentityPolicyRequest")
 	local headers = {
@@ -9431,19 +9462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIdentityPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIdentityPolicySync(DeleteIdentityPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIdentityPolicyAsync(DeleteIdentityPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIdentityPolicyAsync(DeleteIdentityPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetActiveReceiptRuleSet asynchronously, invoking a callback when done
 -- @param SetActiveReceiptRuleSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetActiveReceiptRuleSetAsync(SetActiveReceiptRuleSetRequest, cb)
 	assert(SetActiveReceiptRuleSetRequest, "You must provide a SetActiveReceiptRuleSetRequest")
 	local headers = {
@@ -9466,19 +9498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetActiveReceiptRuleSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetActiveReceiptRuleSetSync(SetActiveReceiptRuleSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetActiveReceiptRuleSetAsync(SetActiveReceiptRuleSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetActiveReceiptRuleSetAsync(SetActiveReceiptRuleSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReceiptRuleSet asynchronously, invoking a callback when done
 -- @param DeleteReceiptRuleSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReceiptRuleSetAsync(DeleteReceiptRuleSetRequest, cb)
 	assert(DeleteReceiptRuleSetRequest, "You must provide a DeleteReceiptRuleSetRequest")
 	local headers = {
@@ -9501,19 +9534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReceiptRuleSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReceiptRuleSetSync(DeleteReceiptRuleSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReceiptRuleSetAsync(DeleteReceiptRuleSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReceiptRuleSetAsync(DeleteReceiptRuleSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIdentityDkimEnabled asynchronously, invoking a callback when done
 -- @param SetIdentityDkimEnabledRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIdentityDkimEnabledAsync(SetIdentityDkimEnabledRequest, cb)
 	assert(SetIdentityDkimEnabledRequest, "You must provide a SetIdentityDkimEnabledRequest")
 	local headers = {
@@ -9536,19 +9570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIdentityDkimEnabledRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIdentityDkimEnabledSync(SetIdentityDkimEnabledRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIdentityDkimEnabledAsync(SetIdentityDkimEnabledRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIdentityDkimEnabledAsync(SetIdentityDkimEnabledRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTemplate asynchronously, invoking a callback when done
 -- @param GetTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTemplateAsync(GetTemplateRequest, cb)
 	assert(GetTemplateRequest, "You must provide a GetTemplateRequest")
 	local headers = {
@@ -9571,19 +9606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTemplateSync(GetTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTemplateAsync(GetTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTemplateAsync(GetTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTemplates asynchronously, invoking a callback when done
 -- @param ListTemplatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTemplatesAsync(ListTemplatesRequest, cb)
 	assert(ListTemplatesRequest, "You must provide a ListTemplatesRequest")
 	local headers = {
@@ -9606,19 +9642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTemplatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTemplatesSync(ListTemplatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTemplatesAsync(ListTemplatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTemplatesAsync(ListTemplatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReceiptRule asynchronously, invoking a callback when done
 -- @param DescribeReceiptRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReceiptRuleAsync(DescribeReceiptRuleRequest, cb)
 	assert(DescribeReceiptRuleRequest, "You must provide a DescribeReceiptRuleRequest")
 	local headers = {
@@ -9641,19 +9678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReceiptRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReceiptRuleSync(DescribeReceiptRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReceiptRuleAsync(DescribeReceiptRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReceiptRuleAsync(DescribeReceiptRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendBulkTemplatedEmail asynchronously, invoking a callback when done
 -- @param SendBulkTemplatedEmailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendBulkTemplatedEmailAsync(SendBulkTemplatedEmailRequest, cb)
 	assert(SendBulkTemplatedEmailRequest, "You must provide a SendBulkTemplatedEmailRequest")
 	local headers = {
@@ -9676,19 +9714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendBulkTemplatedEmailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendBulkTemplatedEmailSync(SendBulkTemplatedEmailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendBulkTemplatedEmailAsync(SendBulkTemplatedEmailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendBulkTemplatedEmailAsync(SendBulkTemplatedEmailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConfigurationSetReputationMetricsEnabled asynchronously, invoking a callback when done
 -- @param UpdateConfigurationSetReputationMetricsEnabledRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConfigurationSetReputationMetricsEnabledAsync(UpdateConfigurationSetReputationMetricsEnabledRequest, cb)
 	assert(UpdateConfigurationSetReputationMetricsEnabledRequest, "You must provide a UpdateConfigurationSetReputationMetricsEnabledRequest")
 	local headers = {
@@ -9711,18 +9750,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConfigurationSetReputationMetricsEnabledRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConfigurationSetReputationMetricsEnabledSync(UpdateConfigurationSetReputationMetricsEnabledRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConfigurationSetReputationMetricsEnabledAsync(UpdateConfigurationSetReputationMetricsEnabledRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConfigurationSetReputationMetricsEnabledAsync(UpdateConfigurationSetReputationMetricsEnabledRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSendQuota asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSendQuotaAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -9741,19 +9781,20 @@ end
 --- Call GetSendQuota synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSendQuotaSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSendQuotaAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSendQuotaAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCustomVerificationEmailTemplate asynchronously, invoking a callback when done
 -- @param GetCustomVerificationEmailTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCustomVerificationEmailTemplateAsync(GetCustomVerificationEmailTemplateRequest, cb)
 	assert(GetCustomVerificationEmailTemplateRequest, "You must provide a GetCustomVerificationEmailTemplateRequest")
 	local headers = {
@@ -9776,19 +9817,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCustomVerificationEmailTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCustomVerificationEmailTemplateSync(GetCustomVerificationEmailTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCustomVerificationEmailTemplateAsync(GetCustomVerificationEmailTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCustomVerificationEmailTemplateAsync(GetCustomVerificationEmailTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAccountSendingEnabled asynchronously, invoking a callback when done
 -- @param UpdateAccountSendingEnabledRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAccountSendingEnabledAsync(UpdateAccountSendingEnabledRequest, cb)
 	assert(UpdateAccountSendingEnabledRequest, "You must provide a UpdateAccountSendingEnabledRequest")
 	local headers = {
@@ -9811,19 +9853,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAccountSendingEnabledRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAccountSendingEnabledSync(UpdateAccountSendingEnabledRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAccountSendingEnabledAsync(UpdateAccountSendingEnabledRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAccountSendingEnabledAsync(UpdateAccountSendingEnabledRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetReceiptRulePosition asynchronously, invoking a callback when done
 -- @param SetReceiptRulePositionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetReceiptRulePositionAsync(SetReceiptRulePositionRequest, cb)
 	assert(SetReceiptRulePositionRequest, "You must provide a SetReceiptRulePositionRequest")
 	local headers = {
@@ -9846,19 +9889,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetReceiptRulePositionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetReceiptRulePositionSync(SetReceiptRulePositionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetReceiptRulePositionAsync(SetReceiptRulePositionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetReceiptRulePositionAsync(SetReceiptRulePositionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConfigurationSet asynchronously, invoking a callback when done
 -- @param CreateConfigurationSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConfigurationSetAsync(CreateConfigurationSetRequest, cb)
 	assert(CreateConfigurationSetRequest, "You must provide a CreateConfigurationSetRequest")
 	local headers = {
@@ -9881,19 +9925,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConfigurationSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConfigurationSetSync(CreateConfigurationSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConfigurationSetAsync(CreateConfigurationSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConfigurationSetAsync(CreateConfigurationSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVerifiedEmailAddress asynchronously, invoking a callback when done
 -- @param DeleteVerifiedEmailAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVerifiedEmailAddressAsync(DeleteVerifiedEmailAddressRequest, cb)
 	assert(DeleteVerifiedEmailAddressRequest, "You must provide a DeleteVerifiedEmailAddressRequest")
 	local headers = {
@@ -9916,19 +9961,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVerifiedEmailAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVerifiedEmailAddressSync(DeleteVerifiedEmailAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVerifiedEmailAddressAsync(DeleteVerifiedEmailAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVerifiedEmailAddressAsync(DeleteVerifiedEmailAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListConfigurationSets asynchronously, invoking a callback when done
 -- @param ListConfigurationSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListConfigurationSetsAsync(ListConfigurationSetsRequest, cb)
 	assert(ListConfigurationSetsRequest, "You must provide a ListConfigurationSetsRequest")
 	local headers = {
@@ -9951,19 +9997,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListConfigurationSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListConfigurationSetsSync(ListConfigurationSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListConfigurationSetsAsync(ListConfigurationSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListConfigurationSetsAsync(ListConfigurationSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReceiptFilter asynchronously, invoking a callback when done
 -- @param CreateReceiptFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReceiptFilterAsync(CreateReceiptFilterRequest, cb)
 	assert(CreateReceiptFilterRequest, "You must provide a CreateReceiptFilterRequest")
 	local headers = {
@@ -9986,19 +10033,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReceiptFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReceiptFilterSync(CreateReceiptFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReceiptFilterAsync(CreateReceiptFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReceiptFilterAsync(CreateReceiptFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendTemplatedEmail asynchronously, invoking a callback when done
 -- @param SendTemplatedEmailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendTemplatedEmailAsync(SendTemplatedEmailRequest, cb)
 	assert(SendTemplatedEmailRequest, "You must provide a SendTemplatedEmailRequest")
 	local headers = {
@@ -10021,19 +10069,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendTemplatedEmailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendTemplatedEmailSync(SendTemplatedEmailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendTemplatedEmailAsync(SendTemplatedEmailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendTemplatedEmailAsync(SendTemplatedEmailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConfigurationSetTrackingOptions asynchronously, invoking a callback when done
 -- @param CreateConfigurationSetTrackingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConfigurationSetTrackingOptionsAsync(CreateConfigurationSetTrackingOptionsRequest, cb)
 	assert(CreateConfigurationSetTrackingOptionsRequest, "You must provide a CreateConfigurationSetTrackingOptionsRequest")
 	local headers = {
@@ -10056,19 +10105,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConfigurationSetTrackingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConfigurationSetTrackingOptionsSync(CreateConfigurationSetTrackingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConfigurationSetTrackingOptionsAsync(CreateConfigurationSetTrackingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConfigurationSetTrackingOptionsAsync(CreateConfigurationSetTrackingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListReceiptRuleSets asynchronously, invoking a callback when done
 -- @param ListReceiptRuleSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListReceiptRuleSetsAsync(ListReceiptRuleSetsRequest, cb)
 	assert(ListReceiptRuleSetsRequest, "You must provide a ListReceiptRuleSetsRequest")
 	local headers = {
@@ -10091,19 +10141,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListReceiptRuleSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListReceiptRuleSetsSync(ListReceiptRuleSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListReceiptRuleSetsAsync(ListReceiptRuleSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListReceiptRuleSetsAsync(ListReceiptRuleSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTemplate asynchronously, invoking a callback when done
 -- @param CreateTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTemplateAsync(CreateTemplateRequest, cb)
 	assert(CreateTemplateRequest, "You must provide a CreateTemplateRequest")
 	local headers = {
@@ -10126,19 +10177,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTemplateSync(CreateTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTemplateAsync(CreateTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTemplateAsync(CreateTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityNotificationAttributes asynchronously, invoking a callback when done
 -- @param GetIdentityNotificationAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityNotificationAttributesAsync(GetIdentityNotificationAttributesRequest, cb)
 	assert(GetIdentityNotificationAttributesRequest, "You must provide a GetIdentityNotificationAttributesRequest")
 	local headers = {
@@ -10161,19 +10213,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityNotificationAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityNotificationAttributesSync(GetIdentityNotificationAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityNotificationAttributesAsync(GetIdentityNotificationAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityNotificationAttributesAsync(GetIdentityNotificationAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIdentityHeadersInNotificationsEnabled asynchronously, invoking a callback when done
 -- @param SetIdentityHeadersInNotificationsEnabledRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIdentityHeadersInNotificationsEnabledAsync(SetIdentityHeadersInNotificationsEnabledRequest, cb)
 	assert(SetIdentityHeadersInNotificationsEnabledRequest, "You must provide a SetIdentityHeadersInNotificationsEnabledRequest")
 	local headers = {
@@ -10196,19 +10249,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIdentityHeadersInNotificationsEnabledRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIdentityHeadersInNotificationsEnabledSync(SetIdentityHeadersInNotificationsEnabledRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIdentityHeadersInNotificationsEnabledAsync(SetIdentityHeadersInNotificationsEnabledRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIdentityHeadersInNotificationsEnabledAsync(SetIdentityHeadersInNotificationsEnabledRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendEmail asynchronously, invoking a callback when done
 -- @param SendEmailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendEmailAsync(SendEmailRequest, cb)
 	assert(SendEmailRequest, "You must provide a SendEmailRequest")
 	local headers = {
@@ -10231,19 +10285,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendEmailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendEmailSync(SendEmailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendEmailAsync(SendEmailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendEmailAsync(SendEmailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIdentity asynchronously, invoking a callback when done
 -- @param DeleteIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIdentityAsync(DeleteIdentityRequest, cb)
 	assert(DeleteIdentityRequest, "You must provide a DeleteIdentityRequest")
 	local headers = {
@@ -10266,19 +10321,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIdentitySync(DeleteIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIdentityAsync(DeleteIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIdentityAsync(DeleteIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call VerifyDomainDkim asynchronously, invoking a callback when done
 -- @param VerifyDomainDkimRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.VerifyDomainDkimAsync(VerifyDomainDkimRequest, cb)
 	assert(VerifyDomainDkimRequest, "You must provide a VerifyDomainDkimRequest")
 	local headers = {
@@ -10301,19 +10357,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param VerifyDomainDkimRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.VerifyDomainDkimSync(VerifyDomainDkimRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.VerifyDomainDkimAsync(VerifyDomainDkimRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.VerifyDomainDkimAsync(VerifyDomainDkimRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCustomVerificationEmailTemplate asynchronously, invoking a callback when done
 -- @param CreateCustomVerificationEmailTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCustomVerificationEmailTemplateAsync(CreateCustomVerificationEmailTemplateRequest, cb)
 	assert(CreateCustomVerificationEmailTemplateRequest, "You must provide a CreateCustomVerificationEmailTemplateRequest")
 	local headers = {
@@ -10336,19 +10393,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCustomVerificationEmailTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCustomVerificationEmailTemplateSync(CreateCustomVerificationEmailTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCustomVerificationEmailTemplateAsync(CreateCustomVerificationEmailTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCustomVerificationEmailTemplateAsync(CreateCustomVerificationEmailTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIdentityPolicies asynchronously, invoking a callback when done
 -- @param ListIdentityPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIdentityPoliciesAsync(ListIdentityPoliciesRequest, cb)
 	assert(ListIdentityPoliciesRequest, "You must provide a ListIdentityPoliciesRequest")
 	local headers = {
@@ -10371,19 +10429,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIdentityPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIdentityPoliciesSync(ListIdentityPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIdentityPoliciesAsync(ListIdentityPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIdentityPoliciesAsync(ListIdentityPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConfigurationSetEventDestination asynchronously, invoking a callback when done
 -- @param DeleteConfigurationSetEventDestinationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConfigurationSetEventDestinationAsync(DeleteConfigurationSetEventDestinationRequest, cb)
 	assert(DeleteConfigurationSetEventDestinationRequest, "You must provide a DeleteConfigurationSetEventDestinationRequest")
 	local headers = {
@@ -10406,19 +10465,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConfigurationSetEventDestinationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConfigurationSetEventDestinationSync(DeleteConfigurationSetEventDestinationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConfigurationSetEventDestinationAsync(DeleteConfigurationSetEventDestinationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConfigurationSetEventDestinationAsync(DeleteConfigurationSetEventDestinationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConfigurationSetTrackingOptions asynchronously, invoking a callback when done
 -- @param DeleteConfigurationSetTrackingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConfigurationSetTrackingOptionsAsync(DeleteConfigurationSetTrackingOptionsRequest, cb)
 	assert(DeleteConfigurationSetTrackingOptionsRequest, "You must provide a DeleteConfigurationSetTrackingOptionsRequest")
 	local headers = {
@@ -10441,19 +10501,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConfigurationSetTrackingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConfigurationSetTrackingOptionsSync(DeleteConfigurationSetTrackingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConfigurationSetTrackingOptionsAsync(DeleteConfigurationSetTrackingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConfigurationSetTrackingOptionsAsync(DeleteConfigurationSetTrackingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIdentities asynchronously, invoking a callback when done
 -- @param ListIdentitiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIdentitiesAsync(ListIdentitiesRequest, cb)
 	assert(ListIdentitiesRequest, "You must provide a ListIdentitiesRequest")
 	local headers = {
@@ -10476,19 +10537,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIdentitiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIdentitiesSync(ListIdentitiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIdentitiesAsync(ListIdentitiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIdentitiesAsync(ListIdentitiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIdentityVerificationAttributes asynchronously, invoking a callback when done
 -- @param GetIdentityVerificationAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIdentityVerificationAttributesAsync(GetIdentityVerificationAttributesRequest, cb)
 	assert(GetIdentityVerificationAttributesRequest, "You must provide a GetIdentityVerificationAttributesRequest")
 	local headers = {
@@ -10511,19 +10573,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIdentityVerificationAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIdentityVerificationAttributesSync(GetIdentityVerificationAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIdentityVerificationAttributesAsync(GetIdentityVerificationAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIdentityVerificationAttributesAsync(GetIdentityVerificationAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTemplate asynchronously, invoking a callback when done
 -- @param UpdateTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTemplateAsync(UpdateTemplateRequest, cb)
 	assert(UpdateTemplateRequest, "You must provide a UpdateTemplateRequest")
 	local headers = {
@@ -10546,19 +10609,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTemplateSync(UpdateTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTemplateAsync(UpdateTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTemplateAsync(UpdateTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCustomVerificationEmailTemplates asynchronously, invoking a callback when done
 -- @param ListCustomVerificationEmailTemplatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCustomVerificationEmailTemplatesAsync(ListCustomVerificationEmailTemplatesRequest, cb)
 	assert(ListCustomVerificationEmailTemplatesRequest, "You must provide a ListCustomVerificationEmailTemplatesRequest")
 	local headers = {
@@ -10581,19 +10645,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCustomVerificationEmailTemplatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCustomVerificationEmailTemplatesSync(ListCustomVerificationEmailTemplatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCustomVerificationEmailTemplatesAsync(ListCustomVerificationEmailTemplatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCustomVerificationEmailTemplatesAsync(ListCustomVerificationEmailTemplatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCustomVerificationEmailTemplate asynchronously, invoking a callback when done
 -- @param DeleteCustomVerificationEmailTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCustomVerificationEmailTemplateAsync(DeleteCustomVerificationEmailTemplateRequest, cb)
 	assert(DeleteCustomVerificationEmailTemplateRequest, "You must provide a DeleteCustomVerificationEmailTemplateRequest")
 	local headers = {
@@ -10616,19 +10681,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCustomVerificationEmailTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCustomVerificationEmailTemplateSync(DeleteCustomVerificationEmailTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCustomVerificationEmailTemplateAsync(DeleteCustomVerificationEmailTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCustomVerificationEmailTemplateAsync(DeleteCustomVerificationEmailTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetIdentityNotificationTopic asynchronously, invoking a callback when done
 -- @param SetIdentityNotificationTopicRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetIdentityNotificationTopicAsync(SetIdentityNotificationTopicRequest, cb)
 	assert(SetIdentityNotificationTopicRequest, "You must provide a SetIdentityNotificationTopicRequest")
 	local headers = {
@@ -10651,19 +10717,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetIdentityNotificationTopicRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetIdentityNotificationTopicSync(SetIdentityNotificationTopicRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetIdentityNotificationTopicAsync(SetIdentityNotificationTopicRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetIdentityNotificationTopicAsync(SetIdentityNotificationTopicRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutIdentityPolicy asynchronously, invoking a callback when done
 -- @param PutIdentityPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutIdentityPolicyAsync(PutIdentityPolicyRequest, cb)
 	assert(PutIdentityPolicyRequest, "You must provide a PutIdentityPolicyRequest")
 	local headers = {
@@ -10686,19 +10753,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutIdentityPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutIdentityPolicySync(PutIdentityPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutIdentityPolicyAsync(PutIdentityPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutIdentityPolicyAsync(PutIdentityPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendRawEmail asynchronously, invoking a callback when done
 -- @param SendRawEmailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendRawEmailAsync(SendRawEmailRequest, cb)
 	assert(SendRawEmailRequest, "You must provide a SendRawEmailRequest")
 	local headers = {
@@ -10721,19 +10789,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendRawEmailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendRawEmailSync(SendRawEmailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendRawEmailAsync(SendRawEmailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendRawEmailAsync(SendRawEmailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReceiptRuleSet asynchronously, invoking a callback when done
 -- @param CreateReceiptRuleSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReceiptRuleSetAsync(CreateReceiptRuleSetRequest, cb)
 	assert(CreateReceiptRuleSetRequest, "You must provide a CreateReceiptRuleSetRequest")
 	local headers = {
@@ -10756,12 +10825,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReceiptRuleSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReceiptRuleSetSync(CreateReceiptRuleSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReceiptRuleSetAsync(CreateReceiptRuleSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReceiptRuleSetAsync(CreateReceiptRuleSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/entitlement_marketplace.lua
+++ b/aws-sdk/entitlement_marketplace.lua
@@ -514,7 +514,7 @@ end
 --
 --- Call GetEntitlements asynchronously, invoking a callback when done
 -- @param GetEntitlementsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEntitlementsAsync(GetEntitlementsRequest, cb)
 	assert(GetEntitlementsRequest, "You must provide a GetEntitlementsRequest")
 	local headers = {
@@ -537,12 +537,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEntitlementsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEntitlementsSync(GetEntitlementsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEntitlementsAsync(GetEntitlementsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEntitlementsAsync(GetEntitlementsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/es.lua
+++ b/aws-sdk/es.lua
@@ -4398,7 +4398,7 @@ end
 --
 --- Call DescribeElasticsearchInstanceTypeLimits asynchronously, invoking a callback when done
 -- @param DescribeElasticsearchInstanceTypeLimitsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeElasticsearchInstanceTypeLimitsAsync(DescribeElasticsearchInstanceTypeLimitsRequest, cb)
 	assert(DescribeElasticsearchInstanceTypeLimitsRequest, "You must provide a DescribeElasticsearchInstanceTypeLimitsRequest")
 	local headers = {
@@ -4421,19 +4421,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeElasticsearchInstanceTypeLimitsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeElasticsearchInstanceTypeLimitsSync(DescribeElasticsearchInstanceTypeLimitsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeElasticsearchInstanceTypeLimitsAsync(DescribeElasticsearchInstanceTypeLimitsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeElasticsearchInstanceTypeLimitsAsync(DescribeElasticsearchInstanceTypeLimitsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseReservedElasticsearchInstanceOffering asynchronously, invoking a callback when done
 -- @param PurchaseReservedElasticsearchInstanceOfferingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseReservedElasticsearchInstanceOfferingAsync(PurchaseReservedElasticsearchInstanceOfferingRequest, cb)
 	assert(PurchaseReservedElasticsearchInstanceOfferingRequest, "You must provide a PurchaseReservedElasticsearchInstanceOfferingRequest")
 	local headers = {
@@ -4456,19 +4457,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseReservedElasticsearchInstanceOfferingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseReservedElasticsearchInstanceOfferingSync(PurchaseReservedElasticsearchInstanceOfferingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseReservedElasticsearchInstanceOfferingAsync(PurchaseReservedElasticsearchInstanceOfferingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseReservedElasticsearchInstanceOfferingAsync(PurchaseReservedElasticsearchInstanceOfferingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeElasticsearchDomainConfig asynchronously, invoking a callback when done
 -- @param DescribeElasticsearchDomainConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeElasticsearchDomainConfigAsync(DescribeElasticsearchDomainConfigRequest, cb)
 	assert(DescribeElasticsearchDomainConfigRequest, "You must provide a DescribeElasticsearchDomainConfigRequest")
 	local headers = {
@@ -4491,19 +4493,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeElasticsearchDomainConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeElasticsearchDomainConfigSync(DescribeElasticsearchDomainConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeElasticsearchDomainConfigAsync(DescribeElasticsearchDomainConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeElasticsearchDomainConfigAsync(DescribeElasticsearchDomainConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateElasticsearchDomain asynchronously, invoking a callback when done
 -- @param CreateElasticsearchDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateElasticsearchDomainAsync(CreateElasticsearchDomainRequest, cb)
 	assert(CreateElasticsearchDomainRequest, "You must provide a CreateElasticsearchDomainRequest")
 	local headers = {
@@ -4526,19 +4529,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateElasticsearchDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateElasticsearchDomainSync(CreateElasticsearchDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateElasticsearchDomainAsync(CreateElasticsearchDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateElasticsearchDomainAsync(CreateElasticsearchDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListElasticsearchInstanceTypes asynchronously, invoking a callback when done
 -- @param ListElasticsearchInstanceTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListElasticsearchInstanceTypesAsync(ListElasticsearchInstanceTypesRequest, cb)
 	assert(ListElasticsearchInstanceTypesRequest, "You must provide a ListElasticsearchInstanceTypesRequest")
 	local headers = {
@@ -4561,19 +4565,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListElasticsearchInstanceTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListElasticsearchInstanceTypesSync(ListElasticsearchInstanceTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListElasticsearchInstanceTypesAsync(ListElasticsearchInstanceTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListElasticsearchInstanceTypesAsync(ListElasticsearchInstanceTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUpgradeStatus asynchronously, invoking a callback when done
 -- @param GetUpgradeStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUpgradeStatusAsync(GetUpgradeStatusRequest, cb)
 	assert(GetUpgradeStatusRequest, "You must provide a GetUpgradeStatusRequest")
 	local headers = {
@@ -4596,18 +4601,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUpgradeStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUpgradeStatusSync(GetUpgradeStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUpgradeStatusAsync(GetUpgradeStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUpgradeStatusAsync(GetUpgradeStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDomainNames asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDomainNamesAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -4626,19 +4632,20 @@ end
 --- Call ListDomainNames synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDomainNamesSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDomainNamesAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDomainNamesAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartElasticsearchServiceSoftwareUpdate asynchronously, invoking a callback when done
 -- @param StartElasticsearchServiceSoftwareUpdateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartElasticsearchServiceSoftwareUpdateAsync(StartElasticsearchServiceSoftwareUpdateRequest, cb)
 	assert(StartElasticsearchServiceSoftwareUpdateRequest, "You must provide a StartElasticsearchServiceSoftwareUpdateRequest")
 	local headers = {
@@ -4661,18 +4668,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartElasticsearchServiceSoftwareUpdateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartElasticsearchServiceSoftwareUpdateSync(StartElasticsearchServiceSoftwareUpdateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartElasticsearchServiceSoftwareUpdateAsync(StartElasticsearchServiceSoftwareUpdateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartElasticsearchServiceSoftwareUpdateAsync(StartElasticsearchServiceSoftwareUpdateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteElasticsearchServiceRole asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteElasticsearchServiceRoleAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -4691,19 +4699,20 @@ end
 --- Call DeleteElasticsearchServiceRole synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteElasticsearchServiceRoleSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteElasticsearchServiceRoleAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteElasticsearchServiceRoleAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeElasticsearchDomains asynchronously, invoking a callback when done
 -- @param DescribeElasticsearchDomainsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeElasticsearchDomainsAsync(DescribeElasticsearchDomainsRequest, cb)
 	assert(DescribeElasticsearchDomainsRequest, "You must provide a DescribeElasticsearchDomainsRequest")
 	local headers = {
@@ -4726,19 +4735,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeElasticsearchDomainsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeElasticsearchDomainsSync(DescribeElasticsearchDomainsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeElasticsearchDomainsAsync(DescribeElasticsearchDomainsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeElasticsearchDomainsAsync(DescribeElasticsearchDomainsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateElasticsearchDomainConfig asynchronously, invoking a callback when done
 -- @param UpdateElasticsearchDomainConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateElasticsearchDomainConfigAsync(UpdateElasticsearchDomainConfigRequest, cb)
 	assert(UpdateElasticsearchDomainConfigRequest, "You must provide a UpdateElasticsearchDomainConfigRequest")
 	local headers = {
@@ -4761,19 +4771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateElasticsearchDomainConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateElasticsearchDomainConfigSync(UpdateElasticsearchDomainConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateElasticsearchDomainConfigAsync(UpdateElasticsearchDomainConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateElasticsearchDomainConfigAsync(UpdateElasticsearchDomainConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTags asynchronously, invoking a callback when done
 -- @param RemoveTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsAsync(RemoveTagsRequest, cb)
 	assert(RemoveTagsRequest, "You must provide a RemoveTagsRequest")
 	local headers = {
@@ -4796,19 +4807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsSync(RemoveTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsAsync(RemoveTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsAsync(RemoveTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -4831,19 +4843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelElasticsearchServiceSoftwareUpdate asynchronously, invoking a callback when done
 -- @param CancelElasticsearchServiceSoftwareUpdateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelElasticsearchServiceSoftwareUpdateAsync(CancelElasticsearchServiceSoftwareUpdateRequest, cb)
 	assert(CancelElasticsearchServiceSoftwareUpdateRequest, "You must provide a CancelElasticsearchServiceSoftwareUpdateRequest")
 	local headers = {
@@ -4866,19 +4879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelElasticsearchServiceSoftwareUpdateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelElasticsearchServiceSoftwareUpdateSync(CancelElasticsearchServiceSoftwareUpdateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelElasticsearchServiceSoftwareUpdateAsync(CancelElasticsearchServiceSoftwareUpdateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelElasticsearchServiceSoftwareUpdateAsync(CancelElasticsearchServiceSoftwareUpdateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListElasticsearchVersions asynchronously, invoking a callback when done
 -- @param ListElasticsearchVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListElasticsearchVersionsAsync(ListElasticsearchVersionsRequest, cb)
 	assert(ListElasticsearchVersionsRequest, "You must provide a ListElasticsearchVersionsRequest")
 	local headers = {
@@ -4901,19 +4915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListElasticsearchVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListElasticsearchVersionsSync(ListElasticsearchVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListElasticsearchVersionsAsync(ListElasticsearchVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListElasticsearchVersionsAsync(ListElasticsearchVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpgradeElasticsearchDomain asynchronously, invoking a callback when done
 -- @param UpgradeElasticsearchDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpgradeElasticsearchDomainAsync(UpgradeElasticsearchDomainRequest, cb)
 	assert(UpgradeElasticsearchDomainRequest, "You must provide a UpgradeElasticsearchDomainRequest")
 	local headers = {
@@ -4936,19 +4951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpgradeElasticsearchDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpgradeElasticsearchDomainSync(UpgradeElasticsearchDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpgradeElasticsearchDomainAsync(UpgradeElasticsearchDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpgradeElasticsearchDomainAsync(UpgradeElasticsearchDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteElasticsearchDomain asynchronously, invoking a callback when done
 -- @param DeleteElasticsearchDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteElasticsearchDomainAsync(DeleteElasticsearchDomainRequest, cb)
 	assert(DeleteElasticsearchDomainRequest, "You must provide a DeleteElasticsearchDomainRequest")
 	local headers = {
@@ -4971,19 +4987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteElasticsearchDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteElasticsearchDomainSync(DeleteElasticsearchDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteElasticsearchDomainAsync(DeleteElasticsearchDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteElasticsearchDomainAsync(DeleteElasticsearchDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTags asynchronously, invoking a callback when done
 -- @param AddTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsAsync(AddTagsRequest, cb)
 	assert(AddTagsRequest, "You must provide a AddTagsRequest")
 	local headers = {
@@ -5006,19 +5023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsSync(AddTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsAsync(AddTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsAsync(AddTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCompatibleElasticsearchVersions asynchronously, invoking a callback when done
 -- @param GetCompatibleElasticsearchVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCompatibleElasticsearchVersionsAsync(GetCompatibleElasticsearchVersionsRequest, cb)
 	assert(GetCompatibleElasticsearchVersionsRequest, "You must provide a GetCompatibleElasticsearchVersionsRequest")
 	local headers = {
@@ -5041,19 +5059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCompatibleElasticsearchVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCompatibleElasticsearchVersionsSync(GetCompatibleElasticsearchVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCompatibleElasticsearchVersionsAsync(GetCompatibleElasticsearchVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCompatibleElasticsearchVersionsAsync(GetCompatibleElasticsearchVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeElasticsearchDomain asynchronously, invoking a callback when done
 -- @param DescribeElasticsearchDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeElasticsearchDomainAsync(DescribeElasticsearchDomainRequest, cb)
 	assert(DescribeElasticsearchDomainRequest, "You must provide a DescribeElasticsearchDomainRequest")
 	local headers = {
@@ -5076,19 +5095,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeElasticsearchDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeElasticsearchDomainSync(DescribeElasticsearchDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeElasticsearchDomainAsync(DescribeElasticsearchDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeElasticsearchDomainAsync(DescribeElasticsearchDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedElasticsearchInstanceOfferings asynchronously, invoking a callback when done
 -- @param DescribeReservedElasticsearchInstanceOfferingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedElasticsearchInstanceOfferingsAsync(DescribeReservedElasticsearchInstanceOfferingsRequest, cb)
 	assert(DescribeReservedElasticsearchInstanceOfferingsRequest, "You must provide a DescribeReservedElasticsearchInstanceOfferingsRequest")
 	local headers = {
@@ -5111,19 +5131,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedElasticsearchInstanceOfferingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedElasticsearchInstanceOfferingsSync(DescribeReservedElasticsearchInstanceOfferingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedElasticsearchInstanceOfferingsAsync(DescribeReservedElasticsearchInstanceOfferingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedElasticsearchInstanceOfferingsAsync(DescribeReservedElasticsearchInstanceOfferingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUpgradeHistory asynchronously, invoking a callback when done
 -- @param GetUpgradeHistoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUpgradeHistoryAsync(GetUpgradeHistoryRequest, cb)
 	assert(GetUpgradeHistoryRequest, "You must provide a GetUpgradeHistoryRequest")
 	local headers = {
@@ -5146,19 +5167,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUpgradeHistoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUpgradeHistorySync(GetUpgradeHistoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUpgradeHistoryAsync(GetUpgradeHistoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUpgradeHistoryAsync(GetUpgradeHistoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedElasticsearchInstances asynchronously, invoking a callback when done
 -- @param DescribeReservedElasticsearchInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedElasticsearchInstancesAsync(DescribeReservedElasticsearchInstancesRequest, cb)
 	assert(DescribeReservedElasticsearchInstancesRequest, "You must provide a DescribeReservedElasticsearchInstancesRequest")
 	local headers = {
@@ -5181,12 +5203,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedElasticsearchInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedElasticsearchInstancesSync(DescribeReservedElasticsearchInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedElasticsearchInstancesAsync(DescribeReservedElasticsearchInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedElasticsearchInstancesAsync(DescribeReservedElasticsearchInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/events.lua
+++ b/aws-sdk/events.lua
@@ -2543,7 +2543,7 @@ end
 --
 --- Call PutEvents asynchronously, invoking a callback when done
 -- @param PutEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutEventsAsync(PutEventsRequest, cb)
 	assert(PutEventsRequest, "You must provide a PutEventsRequest")
 	local headers = {
@@ -2566,19 +2566,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutEventsSync(PutEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutEventsAsync(PutEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutEventsAsync(PutEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableRule asynchronously, invoking a callback when done
 -- @param EnableRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableRuleAsync(EnableRuleRequest, cb)
 	assert(EnableRuleRequest, "You must provide a EnableRuleRequest")
 	local headers = {
@@ -2601,19 +2602,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableRuleSync(EnableRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableRuleAsync(EnableRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableRuleAsync(EnableRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRule asynchronously, invoking a callback when done
 -- @param DescribeRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRuleAsync(DescribeRuleRequest, cb)
 	assert(DescribeRuleRequest, "You must provide a DescribeRuleRequest")
 	local headers = {
@@ -2636,19 +2638,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRuleSync(DescribeRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRuleAsync(DescribeRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRuleAsync(DescribeRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTargetsByRule asynchronously, invoking a callback when done
 -- @param ListTargetsByRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTargetsByRuleAsync(ListTargetsByRuleRequest, cb)
 	assert(ListTargetsByRuleRequest, "You must provide a ListTargetsByRuleRequest")
 	local headers = {
@@ -2671,19 +2674,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTargetsByRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTargetsByRuleSync(ListTargetsByRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTargetsByRuleAsync(ListTargetsByRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTargetsByRuleAsync(ListTargetsByRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutPermission asynchronously, invoking a callback when done
 -- @param PutPermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutPermissionAsync(PutPermissionRequest, cb)
 	assert(PutPermissionRequest, "You must provide a PutPermissionRequest")
 	local headers = {
@@ -2706,19 +2710,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutPermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutPermissionSync(PutPermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutPermissionAsync(PutPermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutPermissionAsync(PutPermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutTargets asynchronously, invoking a callback when done
 -- @param PutTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutTargetsAsync(PutTargetsRequest, cb)
 	assert(PutTargetsRequest, "You must provide a PutTargetsRequest")
 	local headers = {
@@ -2741,19 +2746,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutTargetsSync(PutTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutTargetsAsync(PutTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutTargetsAsync(PutTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRule asynchronously, invoking a callback when done
 -- @param DeleteRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRuleAsync(DeleteRuleRequest, cb)
 	assert(DeleteRuleRequest, "You must provide a DeleteRuleRequest")
 	local headers = {
@@ -2776,19 +2782,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRuleSync(DeleteRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRuleAsync(DeleteRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRuleAsync(DeleteRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRuleNamesByTarget asynchronously, invoking a callback when done
 -- @param ListRuleNamesByTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRuleNamesByTargetAsync(ListRuleNamesByTargetRequest, cb)
 	assert(ListRuleNamesByTargetRequest, "You must provide a ListRuleNamesByTargetRequest")
 	local headers = {
@@ -2811,19 +2818,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRuleNamesByTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRuleNamesByTargetSync(ListRuleNamesByTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRuleNamesByTargetAsync(ListRuleNamesByTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRuleNamesByTargetAsync(ListRuleNamesByTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventBus asynchronously, invoking a callback when done
 -- @param DescribeEventBusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventBusAsync(DescribeEventBusRequest, cb)
 	assert(DescribeEventBusRequest, "You must provide a DescribeEventBusRequest")
 	local headers = {
@@ -2846,19 +2854,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventBusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventBusSync(DescribeEventBusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventBusAsync(DescribeEventBusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventBusAsync(DescribeEventBusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestEventPattern asynchronously, invoking a callback when done
 -- @param TestEventPatternRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestEventPatternAsync(TestEventPatternRequest, cb)
 	assert(TestEventPatternRequest, "You must provide a TestEventPatternRequest")
 	local headers = {
@@ -2881,19 +2890,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestEventPatternRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestEventPatternSync(TestEventPatternRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestEventPatternAsync(TestEventPatternRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestEventPatternAsync(TestEventPatternRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemovePermission asynchronously, invoking a callback when done
 -- @param RemovePermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemovePermissionAsync(RemovePermissionRequest, cb)
 	assert(RemovePermissionRequest, "You must provide a RemovePermissionRequest")
 	local headers = {
@@ -2916,19 +2926,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemovePermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemovePermissionSync(RemovePermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemovePermissionAsync(RemovePermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemovePermissionAsync(RemovePermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRules asynchronously, invoking a callback when done
 -- @param ListRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRulesAsync(ListRulesRequest, cb)
 	assert(ListRulesRequest, "You must provide a ListRulesRequest")
 	local headers = {
@@ -2951,19 +2962,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRulesSync(ListRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRulesAsync(ListRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRulesAsync(ListRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableRule asynchronously, invoking a callback when done
 -- @param DisableRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableRuleAsync(DisableRuleRequest, cb)
 	assert(DisableRuleRequest, "You must provide a DisableRuleRequest")
 	local headers = {
@@ -2986,19 +2998,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableRuleSync(DisableRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableRuleAsync(DisableRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableRuleAsync(DisableRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRule asynchronously, invoking a callback when done
 -- @param PutRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRuleAsync(PutRuleRequest, cb)
 	assert(PutRuleRequest, "You must provide a PutRuleRequest")
 	local headers = {
@@ -3021,19 +3034,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRuleSync(PutRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRuleAsync(PutRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRuleAsync(PutRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTargets asynchronously, invoking a callback when done
 -- @param RemoveTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTargetsAsync(RemoveTargetsRequest, cb)
 	assert(RemoveTargetsRequest, "You must provide a RemoveTargetsRequest")
 	local headers = {
@@ -3056,12 +3070,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTargetsSync(RemoveTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTargetsAsync(RemoveTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTargetsAsync(RemoveTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/firehose.lua
+++ b/aws-sdk/firehose.lua
@@ -4444,7 +4444,7 @@ end
 --
 --- Call CreateDeliveryStream asynchronously, invoking a callback when done
 -- @param CreateDeliveryStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeliveryStreamAsync(CreateDeliveryStreamInput, cb)
 	assert(CreateDeliveryStreamInput, "You must provide a CreateDeliveryStreamInput")
 	local headers = {
@@ -4467,19 +4467,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeliveryStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeliveryStreamSync(CreateDeliveryStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeliveryStreamAsync(CreateDeliveryStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeliveryStreamAsync(CreateDeliveryStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDeliveryStream asynchronously, invoking a callback when done
 -- @param DescribeDeliveryStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDeliveryStreamAsync(DescribeDeliveryStreamInput, cb)
 	assert(DescribeDeliveryStreamInput, "You must provide a DescribeDeliveryStreamInput")
 	local headers = {
@@ -4502,19 +4503,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDeliveryStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDeliveryStreamSync(DescribeDeliveryStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDeliveryStreamAsync(DescribeDeliveryStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDeliveryStreamAsync(DescribeDeliveryStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDestination asynchronously, invoking a callback when done
 -- @param UpdateDestinationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDestinationAsync(UpdateDestinationInput, cb)
 	assert(UpdateDestinationInput, "You must provide a UpdateDestinationInput")
 	local headers = {
@@ -4537,19 +4539,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDestinationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDestinationSync(UpdateDestinationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDestinationAsync(UpdateDestinationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDestinationAsync(UpdateDestinationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagDeliveryStream asynchronously, invoking a callback when done
 -- @param TagDeliveryStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagDeliveryStreamAsync(TagDeliveryStreamInput, cb)
 	assert(TagDeliveryStreamInput, "You must provide a TagDeliveryStreamInput")
 	local headers = {
@@ -4572,19 +4575,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagDeliveryStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagDeliveryStreamSync(TagDeliveryStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagDeliveryStreamAsync(TagDeliveryStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagDeliveryStreamAsync(TagDeliveryStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDeliveryStream asynchronously, invoking a callback when done
 -- @param DeleteDeliveryStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDeliveryStreamAsync(DeleteDeliveryStreamInput, cb)
 	assert(DeleteDeliveryStreamInput, "You must provide a DeleteDeliveryStreamInput")
 	local headers = {
@@ -4607,19 +4611,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDeliveryStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDeliveryStreamSync(DeleteDeliveryStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDeliveryStreamAsync(DeleteDeliveryStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDeliveryStreamAsync(DeleteDeliveryStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeliveryStreams asynchronously, invoking a callback when done
 -- @param ListDeliveryStreamsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeliveryStreamsAsync(ListDeliveryStreamsInput, cb)
 	assert(ListDeliveryStreamsInput, "You must provide a ListDeliveryStreamsInput")
 	local headers = {
@@ -4642,19 +4647,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeliveryStreamsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeliveryStreamsSync(ListDeliveryStreamsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeliveryStreamsAsync(ListDeliveryStreamsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeliveryStreamsAsync(ListDeliveryStreamsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRecordBatch asynchronously, invoking a callback when done
 -- @param PutRecordBatchInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRecordBatchAsync(PutRecordBatchInput, cb)
 	assert(PutRecordBatchInput, "You must provide a PutRecordBatchInput")
 	local headers = {
@@ -4677,19 +4683,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRecordBatchInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRecordBatchSync(PutRecordBatchInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRecordBatchAsync(PutRecordBatchInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRecordBatchAsync(PutRecordBatchInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagDeliveryStream asynchronously, invoking a callback when done
 -- @param UntagDeliveryStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagDeliveryStreamAsync(UntagDeliveryStreamInput, cb)
 	assert(UntagDeliveryStreamInput, "You must provide a UntagDeliveryStreamInput")
 	local headers = {
@@ -4712,19 +4719,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagDeliveryStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagDeliveryStreamSync(UntagDeliveryStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagDeliveryStreamAsync(UntagDeliveryStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagDeliveryStreamAsync(UntagDeliveryStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRecord asynchronously, invoking a callback when done
 -- @param PutRecordInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRecordAsync(PutRecordInput, cb)
 	assert(PutRecordInput, "You must provide a PutRecordInput")
 	local headers = {
@@ -4747,19 +4755,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRecordInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRecordSync(PutRecordInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRecordAsync(PutRecordInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRecordAsync(PutRecordInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForDeliveryStream asynchronously, invoking a callback when done
 -- @param ListTagsForDeliveryStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForDeliveryStreamAsync(ListTagsForDeliveryStreamInput, cb)
 	assert(ListTagsForDeliveryStreamInput, "You must provide a ListTagsForDeliveryStreamInput")
 	local headers = {
@@ -4782,12 +4791,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForDeliveryStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForDeliveryStreamSync(ListTagsForDeliveryStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForDeliveryStreamAsync(ListTagsForDeliveryStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForDeliveryStreamAsync(ListTagsForDeliveryStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/fms.lua
+++ b/aws-sdk/fms.lua
@@ -1705,7 +1705,7 @@ end
 --
 --- Call PutPolicy asynchronously, invoking a callback when done
 -- @param PutPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutPolicyAsync(PutPolicyRequest, cb)
 	assert(PutPolicyRequest, "You must provide a PutPolicyRequest")
 	local headers = {
@@ -1728,19 +1728,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutPolicySync(PutPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutPolicyAsync(PutPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutPolicyAsync(PutPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetComplianceDetail asynchronously, invoking a callback when done
 -- @param GetComplianceDetailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetComplianceDetailAsync(GetComplianceDetailRequest, cb)
 	assert(GetComplianceDetailRequest, "You must provide a GetComplianceDetailRequest")
 	local headers = {
@@ -1763,19 +1764,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetComplianceDetailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetComplianceDetailSync(GetComplianceDetailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetComplianceDetailAsync(GetComplianceDetailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetComplianceDetailAsync(GetComplianceDetailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListComplianceStatus asynchronously, invoking a callback when done
 -- @param ListComplianceStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListComplianceStatusAsync(ListComplianceStatusRequest, cb)
 	assert(ListComplianceStatusRequest, "You must provide a ListComplianceStatusRequest")
 	local headers = {
@@ -1798,19 +1800,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListComplianceStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListComplianceStatusSync(ListComplianceStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListComplianceStatusAsync(ListComplianceStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListComplianceStatusAsync(ListComplianceStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNotificationChannel asynchronously, invoking a callback when done
 -- @param DeleteNotificationChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNotificationChannelAsync(DeleteNotificationChannelRequest, cb)
 	assert(DeleteNotificationChannelRequest, "You must provide a DeleteNotificationChannelRequest")
 	local headers = {
@@ -1833,19 +1836,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNotificationChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNotificationChannelSync(DeleteNotificationChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNotificationChannelAsync(DeleteNotificationChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNotificationChannelAsync(DeleteNotificationChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetNotificationChannel asynchronously, invoking a callback when done
 -- @param GetNotificationChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetNotificationChannelAsync(GetNotificationChannelRequest, cb)
 	assert(GetNotificationChannelRequest, "You must provide a GetNotificationChannelRequest")
 	local headers = {
@@ -1868,19 +1872,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetNotificationChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetNotificationChannelSync(GetNotificationChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetNotificationChannelAsync(GetNotificationChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetNotificationChannelAsync(GetNotificationChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutNotificationChannel asynchronously, invoking a callback when done
 -- @param PutNotificationChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutNotificationChannelAsync(PutNotificationChannelRequest, cb)
 	assert(PutNotificationChannelRequest, "You must provide a PutNotificationChannelRequest")
 	local headers = {
@@ -1903,19 +1908,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutNotificationChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutNotificationChannelSync(PutNotificationChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutNotificationChannelAsync(PutNotificationChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutNotificationChannelAsync(PutNotificationChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPolicies asynchronously, invoking a callback when done
 -- @param ListPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPoliciesAsync(ListPoliciesRequest, cb)
 	assert(ListPoliciesRequest, "You must provide a ListPoliciesRequest")
 	local headers = {
@@ -1938,19 +1944,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPoliciesSync(ListPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAdminAccount asynchronously, invoking a callback when done
 -- @param GetAdminAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAdminAccountAsync(GetAdminAccountRequest, cb)
 	assert(GetAdminAccountRequest, "You must provide a GetAdminAccountRequest")
 	local headers = {
@@ -1973,19 +1980,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAdminAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAdminAccountSync(GetAdminAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAdminAccountAsync(GetAdminAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAdminAccountAsync(GetAdminAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePolicy asynchronously, invoking a callback when done
 -- @param DeletePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePolicyAsync(DeletePolicyRequest, cb)
 	assert(DeletePolicyRequest, "You must provide a DeletePolicyRequest")
 	local headers = {
@@ -2008,19 +2016,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePolicySync(DeletePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateAdminAccount asynchronously, invoking a callback when done
 -- @param DisassociateAdminAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateAdminAccountAsync(DisassociateAdminAccountRequest, cb)
 	assert(DisassociateAdminAccountRequest, "You must provide a DisassociateAdminAccountRequest")
 	local headers = {
@@ -2043,19 +2052,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateAdminAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateAdminAccountSync(DisassociateAdminAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateAdminAccountAsync(DisassociateAdminAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateAdminAccountAsync(DisassociateAdminAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMemberAccounts asynchronously, invoking a callback when done
 -- @param ListMemberAccountsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMemberAccountsAsync(ListMemberAccountsRequest, cb)
 	assert(ListMemberAccountsRequest, "You must provide a ListMemberAccountsRequest")
 	local headers = {
@@ -2078,19 +2088,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMemberAccountsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMemberAccountsSync(ListMemberAccountsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMemberAccountsAsync(ListMemberAccountsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMemberAccountsAsync(ListMemberAccountsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPolicy asynchronously, invoking a callback when done
 -- @param GetPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPolicyAsync(GetPolicyRequest, cb)
 	assert(GetPolicyRequest, "You must provide a GetPolicyRequest")
 	local headers = {
@@ -2113,19 +2124,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPolicySync(GetPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPolicyAsync(GetPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPolicyAsync(GetPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateAdminAccount asynchronously, invoking a callback when done
 -- @param AssociateAdminAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateAdminAccountAsync(AssociateAdminAccountRequest, cb)
 	assert(AssociateAdminAccountRequest, "You must provide a AssociateAdminAccountRequest")
 	local headers = {
@@ -2148,12 +2160,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateAdminAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateAdminAccountSync(AssociateAdminAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateAdminAccountAsync(AssociateAdminAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateAdminAccountAsync(AssociateAdminAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/gamelift.lua
+++ b/aws-sdk/gamelift.lua
@@ -9451,7 +9451,7 @@ end
 --
 --- Call RequestUploadCredentials asynchronously, invoking a callback when done
 -- @param RequestUploadCredentialsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RequestUploadCredentialsAsync(RequestUploadCredentialsInput, cb)
 	assert(RequestUploadCredentialsInput, "You must provide a RequestUploadCredentialsInput")
 	local headers = {
@@ -9474,19 +9474,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RequestUploadCredentialsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RequestUploadCredentialsSync(RequestUploadCredentialsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RequestUploadCredentialsAsync(RequestUploadCredentialsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RequestUploadCredentialsAsync(RequestUploadCredentialsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRuntimeConfiguration asynchronously, invoking a callback when done
 -- @param UpdateRuntimeConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRuntimeConfigurationAsync(UpdateRuntimeConfigurationInput, cb)
 	assert(UpdateRuntimeConfigurationInput, "You must provide a UpdateRuntimeConfigurationInput")
 	local headers = {
@@ -9509,19 +9510,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRuntimeConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRuntimeConfigurationSync(UpdateRuntimeConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRuntimeConfigurationAsync(UpdateRuntimeConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRuntimeConfigurationAsync(UpdateRuntimeConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFleet asynchronously, invoking a callback when done
 -- @param DeleteFleetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFleetAsync(DeleteFleetInput, cb)
 	assert(DeleteFleetInput, "You must provide a DeleteFleetInput")
 	local headers = {
@@ -9544,19 +9546,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFleetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFleetSync(DeleteFleetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFleetAsync(DeleteFleetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFleetAsync(DeleteFleetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFleetCapacity asynchronously, invoking a callback when done
 -- @param UpdateFleetCapacityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFleetCapacityAsync(UpdateFleetCapacityInput, cb)
 	assert(UpdateFleetCapacityInput, "You must provide a UpdateFleetCapacityInput")
 	local headers = {
@@ -9579,19 +9582,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFleetCapacityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFleetCapacitySync(UpdateFleetCapacityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFleetCapacityAsync(UpdateFleetCapacityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFleetCapacityAsync(UpdateFleetCapacityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartFleetActions asynchronously, invoking a callback when done
 -- @param StartFleetActionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartFleetActionsAsync(StartFleetActionsInput, cb)
 	assert(StartFleetActionsInput, "You must provide a StartFleetActionsInput")
 	local headers = {
@@ -9614,19 +9618,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartFleetActionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartFleetActionsSync(StartFleetActionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartFleetActionsAsync(StartFleetActionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartFleetActionsAsync(StartFleetActionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRuntimeConfiguration asynchronously, invoking a callback when done
 -- @param DescribeRuntimeConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRuntimeConfigurationAsync(DescribeRuntimeConfigurationInput, cb)
 	assert(DescribeRuntimeConfigurationInput, "You must provide a DescribeRuntimeConfigurationInput")
 	local headers = {
@@ -9649,19 +9654,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRuntimeConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRuntimeConfigurationSync(DescribeRuntimeConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRuntimeConfigurationAsync(DescribeRuntimeConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRuntimeConfigurationAsync(DescribeRuntimeConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGameSessions asynchronously, invoking a callback when done
 -- @param DescribeGameSessionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGameSessionsAsync(DescribeGameSessionsInput, cb)
 	assert(DescribeGameSessionsInput, "You must provide a DescribeGameSessionsInput")
 	local headers = {
@@ -9684,19 +9690,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGameSessionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGameSessionsSync(DescribeGameSessionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGameSessionsAsync(DescribeGameSessionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGameSessionsAsync(DescribeGameSessionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchGameSessions asynchronously, invoking a callback when done
 -- @param SearchGameSessionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchGameSessionsAsync(SearchGameSessionsInput, cb)
 	assert(SearchGameSessionsInput, "You must provide a SearchGameSessionsInput")
 	local headers = {
@@ -9719,19 +9726,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchGameSessionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchGameSessionsSync(SearchGameSessionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchGameSessionsAsync(SearchGameSessionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchGameSessionsAsync(SearchGameSessionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePlayerSessions asynchronously, invoking a callback when done
 -- @param CreatePlayerSessionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePlayerSessionsAsync(CreatePlayerSessionsInput, cb)
 	assert(CreatePlayerSessionsInput, "You must provide a CreatePlayerSessionsInput")
 	local headers = {
@@ -9754,19 +9762,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePlayerSessionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePlayerSessionsSync(CreatePlayerSessionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePlayerSessionsAsync(CreatePlayerSessionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePlayerSessionsAsync(CreatePlayerSessionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartMatchmaking asynchronously, invoking a callback when done
 -- @param StartMatchmakingInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartMatchmakingAsync(StartMatchmakingInput, cb)
 	assert(StartMatchmakingInput, "You must provide a StartMatchmakingInput")
 	local headers = {
@@ -9789,19 +9798,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartMatchmakingInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartMatchmakingSync(StartMatchmakingInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartMatchmakingAsync(StartMatchmakingInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartMatchmakingAsync(StartMatchmakingInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMatchmakingRuleSets asynchronously, invoking a callback when done
 -- @param DescribeMatchmakingRuleSetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMatchmakingRuleSetsAsync(DescribeMatchmakingRuleSetsInput, cb)
 	assert(DescribeMatchmakingRuleSetsInput, "You must provide a DescribeMatchmakingRuleSetsInput")
 	local headers = {
@@ -9824,19 +9834,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMatchmakingRuleSetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMatchmakingRuleSetsSync(DescribeMatchmakingRuleSetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMatchmakingRuleSetsAsync(DescribeMatchmakingRuleSetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMatchmakingRuleSetsAsync(DescribeMatchmakingRuleSetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFleetPortSettings asynchronously, invoking a callback when done
 -- @param UpdateFleetPortSettingsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFleetPortSettingsAsync(UpdateFleetPortSettingsInput, cb)
 	assert(UpdateFleetPortSettingsInput, "You must provide a UpdateFleetPortSettingsInput")
 	local headers = {
@@ -9859,19 +9870,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFleetPortSettingsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFleetPortSettingsSync(UpdateFleetPortSettingsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFleetPortSettingsAsync(UpdateFleetPortSettingsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFleetPortSettingsAsync(UpdateFleetPortSettingsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFleets asynchronously, invoking a callback when done
 -- @param ListFleetsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFleetsAsync(ListFleetsInput, cb)
 	assert(ListFleetsInput, "You must provide a ListFleetsInput")
 	local headers = {
@@ -9894,19 +9906,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFleetsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFleetsSync(ListFleetsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFleetsAsync(ListFleetsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFleetsAsync(ListFleetsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGameSession asynchronously, invoking a callback when done
 -- @param UpdateGameSessionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGameSessionAsync(UpdateGameSessionInput, cb)
 	assert(UpdateGameSessionInput, "You must provide a UpdateGameSessionInput")
 	local headers = {
@@ -9929,19 +9942,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGameSessionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGameSessionSync(UpdateGameSessionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGameSessionAsync(UpdateGameSessionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGameSessionAsync(UpdateGameSessionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGameSession asynchronously, invoking a callback when done
 -- @param CreateGameSessionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGameSessionAsync(CreateGameSessionInput, cb)
 	assert(CreateGameSessionInput, "You must provide a CreateGameSessionInput")
 	local headers = {
@@ -9964,19 +9978,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGameSessionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGameSessionSync(CreateGameSessionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGameSessionAsync(CreateGameSessionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGameSessionAsync(CreateGameSessionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleetCapacity asynchronously, invoking a callback when done
 -- @param DescribeFleetCapacityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetCapacityAsync(DescribeFleetCapacityInput, cb)
 	assert(DescribeFleetCapacityInput, "You must provide a DescribeFleetCapacityInput")
 	local headers = {
@@ -9999,19 +10014,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetCapacityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetCapacitySync(DescribeFleetCapacityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetCapacityAsync(DescribeFleetCapacityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetCapacityAsync(DescribeFleetCapacityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGameSessionPlacement asynchronously, invoking a callback when done
 -- @param DescribeGameSessionPlacementInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGameSessionPlacementAsync(DescribeGameSessionPlacementInput, cb)
 	assert(DescribeGameSessionPlacementInput, "You must provide a DescribeGameSessionPlacementInput")
 	local headers = {
@@ -10034,19 +10050,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGameSessionPlacementInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGameSessionPlacementSync(DescribeGameSessionPlacementInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGameSessionPlacementAsync(DescribeGameSessionPlacementInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGameSessionPlacementAsync(DescribeGameSessionPlacementInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAliases asynchronously, invoking a callback when done
 -- @param ListAliasesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAliasesAsync(ListAliasesInput, cb)
 	assert(ListAliasesInput, "You must provide a ListAliasesInput")
 	local headers = {
@@ -10069,19 +10086,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAliasesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAliasesSync(ListAliasesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAliasesAsync(ListAliasesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAliasesAsync(ListAliasesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateBuild asynchronously, invoking a callback when done
 -- @param UpdateBuildInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateBuildAsync(UpdateBuildInput, cb)
 	assert(UpdateBuildInput, "You must provide a UpdateBuildInput")
 	local headers = {
@@ -10104,19 +10122,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateBuildInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateBuildSync(UpdateBuildInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateBuildAsync(UpdateBuildInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateBuildAsync(UpdateBuildInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMatchmakingConfiguration asynchronously, invoking a callback when done
 -- @param UpdateMatchmakingConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMatchmakingConfigurationAsync(UpdateMatchmakingConfigurationInput, cb)
 	assert(UpdateMatchmakingConfigurationInput, "You must provide a UpdateMatchmakingConfigurationInput")
 	local headers = {
@@ -10139,19 +10158,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMatchmakingConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMatchmakingConfigurationSync(UpdateMatchmakingConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMatchmakingConfigurationAsync(UpdateMatchmakingConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMatchmakingConfigurationAsync(UpdateMatchmakingConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBuild asynchronously, invoking a callback when done
 -- @param DeleteBuildInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBuildAsync(DeleteBuildInput, cb)
 	assert(DeleteBuildInput, "You must provide a DeleteBuildInput")
 	local headers = {
@@ -10174,19 +10194,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBuildInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBuildSync(DeleteBuildInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBuildAsync(DeleteBuildInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBuildAsync(DeleteBuildInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutScalingPolicy asynchronously, invoking a callback when done
 -- @param PutScalingPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutScalingPolicyAsync(PutScalingPolicyInput, cb)
 	assert(PutScalingPolicyInput, "You must provide a PutScalingPolicyInput")
 	local headers = {
@@ -10209,19 +10230,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutScalingPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutScalingPolicySync(PutScalingPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutScalingPolicyAsync(PutScalingPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutScalingPolicyAsync(PutScalingPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcPeeringAuthorizations asynchronously, invoking a callback when done
 -- @param DescribeVpcPeeringAuthorizationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcPeeringAuthorizationsAsync(DescribeVpcPeeringAuthorizationsInput, cb)
 	assert(DescribeVpcPeeringAuthorizationsInput, "You must provide a DescribeVpcPeeringAuthorizationsInput")
 	local headers = {
@@ -10244,19 +10266,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcPeeringAuthorizationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcPeeringAuthorizationsSync(DescribeVpcPeeringAuthorizationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcPeeringAuthorizationsAsync(DescribeVpcPeeringAuthorizationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcPeeringAuthorizationsAsync(DescribeVpcPeeringAuthorizationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeScalingPolicies asynchronously, invoking a callback when done
 -- @param DescribeScalingPoliciesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScalingPoliciesAsync(DescribeScalingPoliciesInput, cb)
 	assert(DescribeScalingPoliciesInput, "You must provide a DescribeScalingPoliciesInput")
 	local headers = {
@@ -10279,19 +10302,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScalingPoliciesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScalingPoliciesSync(DescribeScalingPoliciesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScalingPoliciesAsync(DescribeScalingPoliciesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScalingPoliciesAsync(DescribeScalingPoliciesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstances asynchronously, invoking a callback when done
 -- @param DescribeInstancesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstancesAsync(DescribeInstancesInput, cb)
 	assert(DescribeInstancesInput, "You must provide a DescribeInstancesInput")
 	local headers = {
@@ -10314,19 +10338,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstancesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstancesSync(DescribeInstancesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstancesAsync(DescribeInstancesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstancesAsync(DescribeInstancesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBuild asynchronously, invoking a callback when done
 -- @param CreateBuildInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBuildAsync(CreateBuildInput, cb)
 	assert(CreateBuildInput, "You must provide a CreateBuildInput")
 	local headers = {
@@ -10349,19 +10374,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBuildInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBuildSync(CreateBuildInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBuildAsync(CreateBuildInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBuildAsync(CreateBuildInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGameSessionQueue asynchronously, invoking a callback when done
 -- @param DeleteGameSessionQueueInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGameSessionQueueAsync(DeleteGameSessionQueueInput, cb)
 	assert(DeleteGameSessionQueueInput, "You must provide a DeleteGameSessionQueueInput")
 	local headers = {
@@ -10384,19 +10410,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGameSessionQueueInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGameSessionQueueSync(DeleteGameSessionQueueInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGameSessionQueueAsync(DeleteGameSessionQueueInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGameSessionQueueAsync(DeleteGameSessionQueueInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePlayerSession asynchronously, invoking a callback when done
 -- @param CreatePlayerSessionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePlayerSessionAsync(CreatePlayerSessionInput, cb)
 	assert(CreatePlayerSessionInput, "You must provide a CreatePlayerSessionInput")
 	local headers = {
@@ -10419,19 +10446,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePlayerSessionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePlayerSessionSync(CreatePlayerSessionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePlayerSessionAsync(CreatePlayerSessionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePlayerSessionAsync(CreatePlayerSessionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartMatchBackfill asynchronously, invoking a callback when done
 -- @param StartMatchBackfillInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartMatchBackfillAsync(StartMatchBackfillInput, cb)
 	assert(StartMatchBackfillInput, "You must provide a StartMatchBackfillInput")
 	local headers = {
@@ -10454,19 +10482,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartMatchBackfillInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartMatchBackfillSync(StartMatchBackfillInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartMatchBackfillAsync(StartMatchBackfillInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartMatchBackfillAsync(StartMatchBackfillInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAlias asynchronously, invoking a callback when done
 -- @param DeleteAliasInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAliasAsync(DeleteAliasInput, cb)
 	assert(DeleteAliasInput, "You must provide a DeleteAliasInput")
 	local headers = {
@@ -10489,19 +10518,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAliasInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAliasSync(DeleteAliasInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAliasAsync(DeleteAliasInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAliasAsync(DeleteAliasInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGameSessionQueue asynchronously, invoking a callback when done
 -- @param UpdateGameSessionQueueInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGameSessionQueueAsync(UpdateGameSessionQueueInput, cb)
 	assert(UpdateGameSessionQueueInput, "You must provide a UpdateGameSessionQueueInput")
 	local headers = {
@@ -10524,19 +10554,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGameSessionQueueInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGameSessionQueueSync(UpdateGameSessionQueueInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGameSessionQueueAsync(UpdateGameSessionQueueInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGameSessionQueueAsync(UpdateGameSessionQueueInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleetPortSettings asynchronously, invoking a callback when done
 -- @param DescribeFleetPortSettingsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetPortSettingsAsync(DescribeFleetPortSettingsInput, cb)
 	assert(DescribeFleetPortSettingsInput, "You must provide a DescribeFleetPortSettingsInput")
 	local headers = {
@@ -10559,19 +10590,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetPortSettingsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetPortSettingsSync(DescribeFleetPortSettingsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetPortSettingsAsync(DescribeFleetPortSettingsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetPortSettingsAsync(DescribeFleetPortSettingsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBuilds asynchronously, invoking a callback when done
 -- @param ListBuildsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBuildsAsync(ListBuildsInput, cb)
 	assert(ListBuildsInput, "You must provide a ListBuildsInput")
 	local headers = {
@@ -10594,19 +10626,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBuildsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBuildsSync(ListBuildsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBuildsAsync(ListBuildsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBuildsAsync(ListBuildsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePlayerSessions asynchronously, invoking a callback when done
 -- @param DescribePlayerSessionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePlayerSessionsAsync(DescribePlayerSessionsInput, cb)
 	assert(DescribePlayerSessionsInput, "You must provide a DescribePlayerSessionsInput")
 	local headers = {
@@ -10629,19 +10662,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePlayerSessionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePlayerSessionsSync(DescribePlayerSessionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePlayerSessionsAsync(DescribePlayerSessionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePlayerSessionsAsync(DescribePlayerSessionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteScalingPolicy asynchronously, invoking a callback when done
 -- @param DeleteScalingPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteScalingPolicyAsync(DeleteScalingPolicyInput, cb)
 	assert(DeleteScalingPolicyInput, "You must provide a DeleteScalingPolicyInput")
 	local headers = {
@@ -10664,19 +10698,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteScalingPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteScalingPolicySync(DeleteScalingPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteScalingPolicyAsync(DeleteScalingPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteScalingPolicyAsync(DeleteScalingPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGameSessionQueues asynchronously, invoking a callback when done
 -- @param DescribeGameSessionQueuesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGameSessionQueuesAsync(DescribeGameSessionQueuesInput, cb)
 	assert(DescribeGameSessionQueuesInput, "You must provide a DescribeGameSessionQueuesInput")
 	local headers = {
@@ -10699,19 +10734,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGameSessionQueuesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGameSessionQueuesSync(DescribeGameSessionQueuesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGameSessionQueuesAsync(DescribeGameSessionQueuesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGameSessionQueuesAsync(DescribeGameSessionQueuesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAlias asynchronously, invoking a callback when done
 -- @param CreateAliasInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAliasAsync(CreateAliasInput, cb)
 	assert(CreateAliasInput, "You must provide a CreateAliasInput")
 	local headers = {
@@ -10734,19 +10770,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAliasInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAliasSync(CreateAliasInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAliasAsync(CreateAliasInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAliasAsync(CreateAliasInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAlias asynchronously, invoking a callback when done
 -- @param UpdateAliasInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAliasAsync(UpdateAliasInput, cb)
 	assert(UpdateAliasInput, "You must provide a UpdateAliasInput")
 	local headers = {
@@ -10769,19 +10806,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAliasInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAliasSync(UpdateAliasInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAliasAsync(UpdateAliasInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAliasAsync(UpdateAliasInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMatchmakingConfiguration asynchronously, invoking a callback when done
 -- @param DeleteMatchmakingConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMatchmakingConfigurationAsync(DeleteMatchmakingConfigurationInput, cb)
 	assert(DeleteMatchmakingConfigurationInput, "You must provide a DeleteMatchmakingConfigurationInput")
 	local headers = {
@@ -10804,19 +10842,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMatchmakingConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMatchmakingConfigurationSync(DeleteMatchmakingConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMatchmakingConfigurationAsync(DeleteMatchmakingConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMatchmakingConfigurationAsync(DeleteMatchmakingConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFleet asynchronously, invoking a callback when done
 -- @param CreateFleetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFleetAsync(CreateFleetInput, cb)
 	assert(CreateFleetInput, "You must provide a CreateFleetInput")
 	local headers = {
@@ -10839,19 +10878,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFleetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFleetSync(CreateFleetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFleetAsync(CreateFleetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFleetAsync(CreateFleetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpcPeeringConnection asynchronously, invoking a callback when done
 -- @param DeleteVpcPeeringConnectionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcPeeringConnectionAsync(DeleteVpcPeeringConnectionInput, cb)
 	assert(DeleteVpcPeeringConnectionInput, "You must provide a DeleteVpcPeeringConnectionInput")
 	local headers = {
@@ -10874,19 +10914,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcPeeringConnectionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcPeeringConnectionSync(DeleteVpcPeeringConnectionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcPeeringConnectionAsync(DeleteVpcPeeringConnectionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcPeeringConnectionAsync(DeleteVpcPeeringConnectionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceAccess asynchronously, invoking a callback when done
 -- @param GetInstanceAccessInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceAccessAsync(GetInstanceAccessInput, cb)
 	assert(GetInstanceAccessInput, "You must provide a GetInstanceAccessInput")
 	local headers = {
@@ -10909,19 +10950,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceAccessInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceAccessSync(GetInstanceAccessInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceAccessAsync(GetInstanceAccessInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceAccessAsync(GetInstanceAccessInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpcPeeringAuthorization asynchronously, invoking a callback when done
 -- @param CreateVpcPeeringAuthorizationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcPeeringAuthorizationAsync(CreateVpcPeeringAuthorizationInput, cb)
 	assert(CreateVpcPeeringAuthorizationInput, "You must provide a CreateVpcPeeringAuthorizationInput")
 	local headers = {
@@ -10944,19 +10986,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcPeeringAuthorizationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcPeeringAuthorizationSync(CreateVpcPeeringAuthorizationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcPeeringAuthorizationAsync(CreateVpcPeeringAuthorizationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcPeeringAuthorizationAsync(CreateVpcPeeringAuthorizationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVpcPeeringAuthorization asynchronously, invoking a callback when done
 -- @param DeleteVpcPeeringAuthorizationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVpcPeeringAuthorizationAsync(DeleteVpcPeeringAuthorizationInput, cb)
 	assert(DeleteVpcPeeringAuthorizationInput, "You must provide a DeleteVpcPeeringAuthorizationInput")
 	local headers = {
@@ -10979,19 +11022,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVpcPeeringAuthorizationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVpcPeeringAuthorizationSync(DeleteVpcPeeringAuthorizationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVpcPeeringAuthorizationAsync(DeleteVpcPeeringAuthorizationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVpcPeeringAuthorizationAsync(DeleteVpcPeeringAuthorizationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFleetAttributes asynchronously, invoking a callback when done
 -- @param UpdateFleetAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFleetAttributesAsync(UpdateFleetAttributesInput, cb)
 	assert(UpdateFleetAttributesInput, "You must provide a UpdateFleetAttributesInput")
 	local headers = {
@@ -11014,19 +11058,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFleetAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFleetAttributesSync(UpdateFleetAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFleetAttributesAsync(UpdateFleetAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFleetAttributesAsync(UpdateFleetAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleetAttributes asynchronously, invoking a callback when done
 -- @param DescribeFleetAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetAttributesAsync(DescribeFleetAttributesInput, cb)
 	assert(DescribeFleetAttributesInput, "You must provide a DescribeFleetAttributesInput")
 	local headers = {
@@ -11049,19 +11094,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetAttributesSync(DescribeFleetAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetAttributesAsync(DescribeFleetAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetAttributesAsync(DescribeFleetAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopMatchmaking asynchronously, invoking a callback when done
 -- @param StopMatchmakingInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopMatchmakingAsync(StopMatchmakingInput, cb)
 	assert(StopMatchmakingInput, "You must provide a StopMatchmakingInput")
 	local headers = {
@@ -11084,19 +11130,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopMatchmakingInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopMatchmakingSync(StopMatchmakingInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopMatchmakingAsync(StopMatchmakingInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopMatchmakingAsync(StopMatchmakingInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResolveAlias asynchronously, invoking a callback when done
 -- @param ResolveAliasInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResolveAliasAsync(ResolveAliasInput, cb)
 	assert(ResolveAliasInput, "You must provide a ResolveAliasInput")
 	local headers = {
@@ -11119,19 +11166,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResolveAliasInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResolveAliasSync(ResolveAliasInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResolveAliasAsync(ResolveAliasInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResolveAliasAsync(ResolveAliasInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGameSessionDetails asynchronously, invoking a callback when done
 -- @param DescribeGameSessionDetailsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGameSessionDetailsAsync(DescribeGameSessionDetailsInput, cb)
 	assert(DescribeGameSessionDetailsInput, "You must provide a DescribeGameSessionDetailsInput")
 	local headers = {
@@ -11154,19 +11202,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGameSessionDetailsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGameSessionDetailsSync(DescribeGameSessionDetailsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGameSessionDetailsAsync(DescribeGameSessionDetailsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGameSessionDetailsAsync(DescribeGameSessionDetailsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMatchmakingConfigurations asynchronously, invoking a callback when done
 -- @param DescribeMatchmakingConfigurationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMatchmakingConfigurationsAsync(DescribeMatchmakingConfigurationsInput, cb)
 	assert(DescribeMatchmakingConfigurationsInput, "You must provide a DescribeMatchmakingConfigurationsInput")
 	local headers = {
@@ -11189,19 +11238,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMatchmakingConfigurationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMatchmakingConfigurationsSync(DescribeMatchmakingConfigurationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMatchmakingConfigurationsAsync(DescribeMatchmakingConfigurationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMatchmakingConfigurationsAsync(DescribeMatchmakingConfigurationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMatchmakingConfiguration asynchronously, invoking a callback when done
 -- @param CreateMatchmakingConfigurationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMatchmakingConfigurationAsync(CreateMatchmakingConfigurationInput, cb)
 	assert(CreateMatchmakingConfigurationInput, "You must provide a CreateMatchmakingConfigurationInput")
 	local headers = {
@@ -11224,19 +11274,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMatchmakingConfigurationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMatchmakingConfigurationSync(CreateMatchmakingConfigurationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMatchmakingConfigurationAsync(CreateMatchmakingConfigurationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMatchmakingConfigurationAsync(CreateMatchmakingConfigurationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ValidateMatchmakingRuleSet asynchronously, invoking a callback when done
 -- @param ValidateMatchmakingRuleSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ValidateMatchmakingRuleSetAsync(ValidateMatchmakingRuleSetInput, cb)
 	assert(ValidateMatchmakingRuleSetInput, "You must provide a ValidateMatchmakingRuleSetInput")
 	local headers = {
@@ -11259,19 +11310,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ValidateMatchmakingRuleSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ValidateMatchmakingRuleSetSync(ValidateMatchmakingRuleSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ValidateMatchmakingRuleSetAsync(ValidateMatchmakingRuleSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ValidateMatchmakingRuleSetAsync(ValidateMatchmakingRuleSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopFleetActions asynchronously, invoking a callback when done
 -- @param StopFleetActionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopFleetActionsAsync(StopFleetActionsInput, cb)
 	assert(StopFleetActionsInput, "You must provide a StopFleetActionsInput")
 	local headers = {
@@ -11294,19 +11346,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopFleetActionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopFleetActionsSync(StopFleetActionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopFleetActionsAsync(StopFleetActionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopFleetActionsAsync(StopFleetActionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopGameSessionPlacement asynchronously, invoking a callback when done
 -- @param StopGameSessionPlacementInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopGameSessionPlacementAsync(StopGameSessionPlacementInput, cb)
 	assert(StopGameSessionPlacementInput, "You must provide a StopGameSessionPlacementInput")
 	local headers = {
@@ -11329,19 +11382,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopGameSessionPlacementInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopGameSessionPlacementSync(StopGameSessionPlacementInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopGameSessionPlacementAsync(StopGameSessionPlacementInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopGameSessionPlacementAsync(StopGameSessionPlacementInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGameSessionQueue asynchronously, invoking a callback when done
 -- @param CreateGameSessionQueueInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGameSessionQueueAsync(CreateGameSessionQueueInput, cb)
 	assert(CreateGameSessionQueueInput, "You must provide a CreateGameSessionQueueInput")
 	local headers = {
@@ -11364,19 +11418,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGameSessionQueueInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGameSessionQueueSync(CreateGameSessionQueueInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGameSessionQueueAsync(CreateGameSessionQueueInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGameSessionQueueAsync(CreateGameSessionQueueInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMatchmaking asynchronously, invoking a callback when done
 -- @param DescribeMatchmakingInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMatchmakingAsync(DescribeMatchmakingInput, cb)
 	assert(DescribeMatchmakingInput, "You must provide a DescribeMatchmakingInput")
 	local headers = {
@@ -11399,19 +11454,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMatchmakingInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMatchmakingSync(DescribeMatchmakingInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMatchmakingAsync(DescribeMatchmakingInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMatchmakingAsync(DescribeMatchmakingInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAlias asynchronously, invoking a callback when done
 -- @param DescribeAliasInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAliasAsync(DescribeAliasInput, cb)
 	assert(DescribeAliasInput, "You must provide a DescribeAliasInput")
 	local headers = {
@@ -11434,19 +11490,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAliasInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAliasSync(DescribeAliasInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAliasAsync(DescribeAliasInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAliasAsync(DescribeAliasInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartGameSessionPlacement asynchronously, invoking a callback when done
 -- @param StartGameSessionPlacementInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartGameSessionPlacementAsync(StartGameSessionPlacementInput, cb)
 	assert(StartGameSessionPlacementInput, "You must provide a StartGameSessionPlacementInput")
 	local headers = {
@@ -11469,19 +11526,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartGameSessionPlacementInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartGameSessionPlacementSync(StartGameSessionPlacementInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartGameSessionPlacementAsync(StartGameSessionPlacementInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartGameSessionPlacementAsync(StartGameSessionPlacementInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVpcPeeringConnection asynchronously, invoking a callback when done
 -- @param CreateVpcPeeringConnectionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVpcPeeringConnectionAsync(CreateVpcPeeringConnectionInput, cb)
 	assert(CreateVpcPeeringConnectionInput, "You must provide a CreateVpcPeeringConnectionInput")
 	local headers = {
@@ -11504,19 +11562,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVpcPeeringConnectionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVpcPeeringConnectionSync(CreateVpcPeeringConnectionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVpcPeeringConnectionAsync(CreateVpcPeeringConnectionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVpcPeeringConnectionAsync(CreateVpcPeeringConnectionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEC2InstanceLimits asynchronously, invoking a callback when done
 -- @param DescribeEC2InstanceLimitsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEC2InstanceLimitsAsync(DescribeEC2InstanceLimitsInput, cb)
 	assert(DescribeEC2InstanceLimitsInput, "You must provide a DescribeEC2InstanceLimitsInput")
 	local headers = {
@@ -11539,19 +11598,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEC2InstanceLimitsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEC2InstanceLimitsSync(DescribeEC2InstanceLimitsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEC2InstanceLimitsAsync(DescribeEC2InstanceLimitsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEC2InstanceLimitsAsync(DescribeEC2InstanceLimitsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVpcPeeringConnections asynchronously, invoking a callback when done
 -- @param DescribeVpcPeeringConnectionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVpcPeeringConnectionsAsync(DescribeVpcPeeringConnectionsInput, cb)
 	assert(DescribeVpcPeeringConnectionsInput, "You must provide a DescribeVpcPeeringConnectionsInput")
 	local headers = {
@@ -11574,19 +11634,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVpcPeeringConnectionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVpcPeeringConnectionsSync(DescribeVpcPeeringConnectionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVpcPeeringConnectionsAsync(DescribeVpcPeeringConnectionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVpcPeeringConnectionsAsync(DescribeVpcPeeringConnectionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGameSessionLogUrl asynchronously, invoking a callback when done
 -- @param GetGameSessionLogUrlInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGameSessionLogUrlAsync(GetGameSessionLogUrlInput, cb)
 	assert(GetGameSessionLogUrlInput, "You must provide a GetGameSessionLogUrlInput")
 	local headers = {
@@ -11609,19 +11670,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGameSessionLogUrlInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGameSessionLogUrlSync(GetGameSessionLogUrlInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGameSessionLogUrlAsync(GetGameSessionLogUrlInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGameSessionLogUrlAsync(GetGameSessionLogUrlInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBuild asynchronously, invoking a callback when done
 -- @param DescribeBuildInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBuildAsync(DescribeBuildInput, cb)
 	assert(DescribeBuildInput, "You must provide a DescribeBuildInput")
 	local headers = {
@@ -11644,19 +11706,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBuildInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBuildSync(DescribeBuildInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBuildAsync(DescribeBuildInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBuildAsync(DescribeBuildInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleetEvents asynchronously, invoking a callback when done
 -- @param DescribeFleetEventsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetEventsAsync(DescribeFleetEventsInput, cb)
 	assert(DescribeFleetEventsInput, "You must provide a DescribeFleetEventsInput")
 	local headers = {
@@ -11679,19 +11742,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetEventsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetEventsSync(DescribeFleetEventsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetEventsAsync(DescribeFleetEventsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetEventsAsync(DescribeFleetEventsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFleetUtilization asynchronously, invoking a callback when done
 -- @param DescribeFleetUtilizationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFleetUtilizationAsync(DescribeFleetUtilizationInput, cb)
 	assert(DescribeFleetUtilizationInput, "You must provide a DescribeFleetUtilizationInput")
 	local headers = {
@@ -11714,19 +11778,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFleetUtilizationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFleetUtilizationSync(DescribeFleetUtilizationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFleetUtilizationAsync(DescribeFleetUtilizationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFleetUtilizationAsync(DescribeFleetUtilizationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptMatch asynchronously, invoking a callback when done
 -- @param AcceptMatchInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptMatchAsync(AcceptMatchInput, cb)
 	assert(AcceptMatchInput, "You must provide a AcceptMatchInput")
 	local headers = {
@@ -11749,19 +11814,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptMatchInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptMatchSync(AcceptMatchInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptMatchAsync(AcceptMatchInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptMatchAsync(AcceptMatchInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMatchmakingRuleSet asynchronously, invoking a callback when done
 -- @param CreateMatchmakingRuleSetInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMatchmakingRuleSetAsync(CreateMatchmakingRuleSetInput, cb)
 	assert(CreateMatchmakingRuleSetInput, "You must provide a CreateMatchmakingRuleSetInput")
 	local headers = {
@@ -11784,12 +11850,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMatchmakingRuleSetInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMatchmakingRuleSetSync(CreateMatchmakingRuleSetInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMatchmakingRuleSetAsync(CreateMatchmakingRuleSetInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMatchmakingRuleSetAsync(CreateMatchmakingRuleSetInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/glacier.lua
+++ b/aws-sdk/glacier.lua
@@ -4263,7 +4263,7 @@ end
 --
 --- Call ListTagsForVault asynchronously, invoking a callback when done
 -- @param ListTagsForVaultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForVaultAsync(ListTagsForVaultInput, cb)
 	assert(ListTagsForVaultInput, "You must provide a ListTagsForVaultInput")
 	local headers = {
@@ -4286,19 +4286,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForVaultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForVaultSync(ListTagsForVaultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForVaultAsync(ListTagsForVaultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForVaultAsync(ListTagsForVaultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobs asynchronously, invoking a callback when done
 -- @param ListJobsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsAsync(ListJobsInput, cb)
 	assert(ListJobsInput, "You must provide a ListJobsInput")
 	local headers = {
@@ -4321,19 +4322,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsSync(ListJobsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsAsync(ListJobsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsAsync(ListJobsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVault asynchronously, invoking a callback when done
 -- @param DeleteVaultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVaultAsync(DeleteVaultInput, cb)
 	assert(DeleteVaultInput, "You must provide a DeleteVaultInput")
 	local headers = {
@@ -4356,19 +4358,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVaultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVaultSync(DeleteVaultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVaultAsync(DeleteVaultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVaultAsync(DeleteVaultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVaultNotifications asynchronously, invoking a callback when done
 -- @param DeleteVaultNotificationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVaultNotificationsAsync(DeleteVaultNotificationsInput, cb)
 	assert(DeleteVaultNotificationsInput, "You must provide a DeleteVaultNotificationsInput")
 	local headers = {
@@ -4391,19 +4394,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVaultNotificationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVaultNotificationsSync(DeleteVaultNotificationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVaultNotificationsAsync(DeleteVaultNotificationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVaultNotificationsAsync(DeleteVaultNotificationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListParts asynchronously, invoking a callback when done
 -- @param ListPartsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPartsAsync(ListPartsInput, cb)
 	assert(ListPartsInput, "You must provide a ListPartsInput")
 	local headers = {
@@ -4426,19 +4430,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPartsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPartsSync(ListPartsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPartsAsync(ListPartsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPartsAsync(ListPartsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProvisionedCapacity asynchronously, invoking a callback when done
 -- @param ListProvisionedCapacityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProvisionedCapacityAsync(ListProvisionedCapacityInput, cb)
 	assert(ListProvisionedCapacityInput, "You must provide a ListProvisionedCapacityInput")
 	local headers = {
@@ -4461,19 +4466,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProvisionedCapacityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProvisionedCapacitySync(ListProvisionedCapacityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProvisionedCapacityAsync(ListProvisionedCapacityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProvisionedCapacityAsync(ListProvisionedCapacityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteArchive asynchronously, invoking a callback when done
 -- @param DeleteArchiveInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteArchiveAsync(DeleteArchiveInput, cb)
 	assert(DeleteArchiveInput, "You must provide a DeleteArchiveInput")
 	local headers = {
@@ -4496,19 +4502,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteArchiveInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteArchiveSync(DeleteArchiveInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteArchiveAsync(DeleteArchiveInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteArchiveAsync(DeleteArchiveInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseProvisionedCapacity asynchronously, invoking a callback when done
 -- @param PurchaseProvisionedCapacityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseProvisionedCapacityAsync(PurchaseProvisionedCapacityInput, cb)
 	assert(PurchaseProvisionedCapacityInput, "You must provide a PurchaseProvisionedCapacityInput")
 	local headers = {
@@ -4531,19 +4538,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseProvisionedCapacityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseProvisionedCapacitySync(PurchaseProvisionedCapacityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseProvisionedCapacityAsync(PurchaseProvisionedCapacityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseProvisionedCapacityAsync(PurchaseProvisionedCapacityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobOutput asynchronously, invoking a callback when done
 -- @param GetJobOutputInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobOutputAsync(GetJobOutputInput, cb)
 	assert(GetJobOutputInput, "You must provide a GetJobOutputInput")
 	local headers = {
@@ -4566,19 +4574,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobOutputInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobOutputSync(GetJobOutputInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobOutputAsync(GetJobOutputInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobOutputAsync(GetJobOutputInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToVault asynchronously, invoking a callback when done
 -- @param AddTagsToVaultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToVaultAsync(AddTagsToVaultInput, cb)
 	assert(AddTagsToVaultInput, "You must provide a AddTagsToVaultInput")
 	local headers = {
@@ -4601,19 +4610,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToVaultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToVaultSync(AddTagsToVaultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToVaultAsync(AddTagsToVaultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToVaultAsync(AddTagsToVaultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitiateVaultLock asynchronously, invoking a callback when done
 -- @param InitiateVaultLockInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitiateVaultLockAsync(InitiateVaultLockInput, cb)
 	assert(InitiateVaultLockInput, "You must provide a InitiateVaultLockInput")
 	local headers = {
@@ -4636,19 +4646,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitiateVaultLockInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitiateVaultLockSync(InitiateVaultLockInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitiateVaultLockAsync(InitiateVaultLockInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitiateVaultLockAsync(InitiateVaultLockInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVaults asynchronously, invoking a callback when done
 -- @param ListVaultsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVaultsAsync(ListVaultsInput, cb)
 	assert(ListVaultsInput, "You must provide a ListVaultsInput")
 	local headers = {
@@ -4671,19 +4682,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVaultsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVaultsSync(ListVaultsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVaultsAsync(ListVaultsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVaultsAsync(ListVaultsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetVaultLock asynchronously, invoking a callback when done
 -- @param GetVaultLockInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetVaultLockAsync(GetVaultLockInput, cb)
 	assert(GetVaultLockInput, "You must provide a GetVaultLockInput")
 	local headers = {
@@ -4706,19 +4718,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetVaultLockInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetVaultLockSync(GetVaultLockInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetVaultLockAsync(GetVaultLockInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetVaultLockAsync(GetVaultLockInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJob asynchronously, invoking a callback when done
 -- @param DescribeJobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobAsync(DescribeJobInput, cb)
 	assert(DescribeJobInput, "You must provide a DescribeJobInput")
 	local headers = {
@@ -4741,19 +4754,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobSync(DescribeJobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobAsync(DescribeJobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobAsync(DescribeJobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetVaultAccessPolicy asynchronously, invoking a callback when done
 -- @param GetVaultAccessPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetVaultAccessPolicyAsync(GetVaultAccessPolicyInput, cb)
 	assert(GetVaultAccessPolicyInput, "You must provide a GetVaultAccessPolicyInput")
 	local headers = {
@@ -4776,19 +4790,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetVaultAccessPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetVaultAccessPolicySync(GetVaultAccessPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetVaultAccessPolicyAsync(GetVaultAccessPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetVaultAccessPolicyAsync(GetVaultAccessPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CompleteMultipartUpload asynchronously, invoking a callback when done
 -- @param CompleteMultipartUploadInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CompleteMultipartUploadAsync(CompleteMultipartUploadInput, cb)
 	assert(CompleteMultipartUploadInput, "You must provide a CompleteMultipartUploadInput")
 	local headers = {
@@ -4811,19 +4826,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CompleteMultipartUploadInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CompleteMultipartUploadSync(CompleteMultipartUploadInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CompleteMultipartUploadAsync(CompleteMultipartUploadInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CompleteMultipartUploadAsync(CompleteMultipartUploadInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetVaultAccessPolicy asynchronously, invoking a callback when done
 -- @param SetVaultAccessPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetVaultAccessPolicyAsync(SetVaultAccessPolicyInput, cb)
 	assert(SetVaultAccessPolicyInput, "You must provide a SetVaultAccessPolicyInput")
 	local headers = {
@@ -4846,19 +4862,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetVaultAccessPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetVaultAccessPolicySync(SetVaultAccessPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetVaultAccessPolicyAsync(SetVaultAccessPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetVaultAccessPolicyAsync(SetVaultAccessPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadMultipartPart asynchronously, invoking a callback when done
 -- @param UploadMultipartPartInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadMultipartPartAsync(UploadMultipartPartInput, cb)
 	assert(UploadMultipartPartInput, "You must provide a UploadMultipartPartInput")
 	local headers = {
@@ -4881,19 +4898,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadMultipartPartInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadMultipartPartSync(UploadMultipartPartInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadMultipartPartAsync(UploadMultipartPartInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadMultipartPartAsync(UploadMultipartPartInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetVaultNotifications asynchronously, invoking a callback when done
 -- @param GetVaultNotificationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetVaultNotificationsAsync(GetVaultNotificationsInput, cb)
 	assert(GetVaultNotificationsInput, "You must provide a GetVaultNotificationsInput")
 	local headers = {
@@ -4916,19 +4934,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetVaultNotificationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetVaultNotificationsSync(GetVaultNotificationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetVaultNotificationsAsync(GetVaultNotificationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetVaultNotificationsAsync(GetVaultNotificationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVaultAccessPolicy asynchronously, invoking a callback when done
 -- @param DeleteVaultAccessPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVaultAccessPolicyAsync(DeleteVaultAccessPolicyInput, cb)
 	assert(DeleteVaultAccessPolicyInput, "You must provide a DeleteVaultAccessPolicyInput")
 	local headers = {
@@ -4951,19 +4970,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVaultAccessPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVaultAccessPolicySync(DeleteVaultAccessPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVaultAccessPolicyAsync(DeleteVaultAccessPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVaultAccessPolicyAsync(DeleteVaultAccessPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVault asynchronously, invoking a callback when done
 -- @param DescribeVaultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVaultAsync(DescribeVaultInput, cb)
 	assert(DescribeVaultInput, "You must provide a DescribeVaultInput")
 	local headers = {
@@ -4986,19 +5006,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVaultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVaultSync(DescribeVaultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVaultAsync(DescribeVaultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVaultAsync(DescribeVaultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMultipartUploads asynchronously, invoking a callback when done
 -- @param ListMultipartUploadsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMultipartUploadsAsync(ListMultipartUploadsInput, cb)
 	assert(ListMultipartUploadsInput, "You must provide a ListMultipartUploadsInput")
 	local headers = {
@@ -5021,19 +5042,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMultipartUploadsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMultipartUploadsSync(ListMultipartUploadsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMultipartUploadsAsync(ListMultipartUploadsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMultipartUploadsAsync(ListMultipartUploadsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CompleteVaultLock asynchronously, invoking a callback when done
 -- @param CompleteVaultLockInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CompleteVaultLockAsync(CompleteVaultLockInput, cb)
 	assert(CompleteVaultLockInput, "You must provide a CompleteVaultLockInput")
 	local headers = {
@@ -5056,19 +5078,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CompleteVaultLockInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CompleteVaultLockSync(CompleteVaultLockInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CompleteVaultLockAsync(CompleteVaultLockInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CompleteVaultLockAsync(CompleteVaultLockInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetDataRetrievalPolicy asynchronously, invoking a callback when done
 -- @param SetDataRetrievalPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetDataRetrievalPolicyAsync(SetDataRetrievalPolicyInput, cb)
 	assert(SetDataRetrievalPolicyInput, "You must provide a SetDataRetrievalPolicyInput")
 	local headers = {
@@ -5091,19 +5114,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetDataRetrievalPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetDataRetrievalPolicySync(SetDataRetrievalPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetDataRetrievalPolicyAsync(SetDataRetrievalPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetDataRetrievalPolicyAsync(SetDataRetrievalPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AbortVaultLock asynchronously, invoking a callback when done
 -- @param AbortVaultLockInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AbortVaultLockAsync(AbortVaultLockInput, cb)
 	assert(AbortVaultLockInput, "You must provide a AbortVaultLockInput")
 	local headers = {
@@ -5126,19 +5150,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AbortVaultLockInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AbortVaultLockSync(AbortVaultLockInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AbortVaultLockAsync(AbortVaultLockInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AbortVaultLockAsync(AbortVaultLockInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AbortMultipartUpload asynchronously, invoking a callback when done
 -- @param AbortMultipartUploadInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AbortMultipartUploadAsync(AbortMultipartUploadInput, cb)
 	assert(AbortMultipartUploadInput, "You must provide a AbortMultipartUploadInput")
 	local headers = {
@@ -5161,19 +5186,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AbortMultipartUploadInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AbortMultipartUploadSync(AbortMultipartUploadInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AbortMultipartUploadAsync(AbortMultipartUploadInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AbortMultipartUploadAsync(AbortMultipartUploadInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromVault asynchronously, invoking a callback when done
 -- @param RemoveTagsFromVaultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromVaultAsync(RemoveTagsFromVaultInput, cb)
 	assert(RemoveTagsFromVaultInput, "You must provide a RemoveTagsFromVaultInput")
 	local headers = {
@@ -5196,19 +5222,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromVaultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromVaultSync(RemoveTagsFromVaultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromVaultAsync(RemoveTagsFromVaultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromVaultAsync(RemoveTagsFromVaultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVault asynchronously, invoking a callback when done
 -- @param CreateVaultInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVaultAsync(CreateVaultInput, cb)
 	assert(CreateVaultInput, "You must provide a CreateVaultInput")
 	local headers = {
@@ -5231,19 +5258,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVaultInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVaultSync(CreateVaultInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVaultAsync(CreateVaultInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVaultAsync(CreateVaultInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitiateJob asynchronously, invoking a callback when done
 -- @param InitiateJobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitiateJobAsync(InitiateJobInput, cb)
 	assert(InitiateJobInput, "You must provide a InitiateJobInput")
 	local headers = {
@@ -5266,19 +5294,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitiateJobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitiateJobSync(InitiateJobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitiateJobAsync(InitiateJobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitiateJobAsync(InitiateJobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitiateMultipartUpload asynchronously, invoking a callback when done
 -- @param InitiateMultipartUploadInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitiateMultipartUploadAsync(InitiateMultipartUploadInput, cb)
 	assert(InitiateMultipartUploadInput, "You must provide a InitiateMultipartUploadInput")
 	local headers = {
@@ -5301,19 +5330,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitiateMultipartUploadInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitiateMultipartUploadSync(InitiateMultipartUploadInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitiateMultipartUploadAsync(InitiateMultipartUploadInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitiateMultipartUploadAsync(InitiateMultipartUploadInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDataRetrievalPolicy asynchronously, invoking a callback when done
 -- @param GetDataRetrievalPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDataRetrievalPolicyAsync(GetDataRetrievalPolicyInput, cb)
 	assert(GetDataRetrievalPolicyInput, "You must provide a GetDataRetrievalPolicyInput")
 	local headers = {
@@ -5336,19 +5366,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDataRetrievalPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDataRetrievalPolicySync(GetDataRetrievalPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDataRetrievalPolicyAsync(GetDataRetrievalPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDataRetrievalPolicyAsync(GetDataRetrievalPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetVaultNotifications asynchronously, invoking a callback when done
 -- @param SetVaultNotificationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetVaultNotificationsAsync(SetVaultNotificationsInput, cb)
 	assert(SetVaultNotificationsInput, "You must provide a SetVaultNotificationsInput")
 	local headers = {
@@ -5371,19 +5402,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetVaultNotificationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetVaultNotificationsSync(SetVaultNotificationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetVaultNotificationsAsync(SetVaultNotificationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetVaultNotificationsAsync(SetVaultNotificationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadArchive asynchronously, invoking a callback when done
 -- @param UploadArchiveInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadArchiveAsync(UploadArchiveInput, cb)
 	assert(UploadArchiveInput, "You must provide a UploadArchiveInput")
 	local headers = {
@@ -5406,12 +5438,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadArchiveInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadArchiveSync(UploadArchiveInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadArchiveAsync(UploadArchiveInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadArchiveAsync(UploadArchiveInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/glue.lua
+++ b/aws-sdk/glue.lua
@@ -12961,7 +12961,7 @@ end
 --
 --- Call GetUserDefinedFunctions asynchronously, invoking a callback when done
 -- @param GetUserDefinedFunctionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserDefinedFunctionsAsync(GetUserDefinedFunctionsRequest, cb)
 	assert(GetUserDefinedFunctionsRequest, "You must provide a GetUserDefinedFunctionsRequest")
 	local headers = {
@@ -12984,19 +12984,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserDefinedFunctionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserDefinedFunctionsSync(GetUserDefinedFunctionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserDefinedFunctionsAsync(GetUserDefinedFunctionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserDefinedFunctionsAsync(GetUserDefinedFunctionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDeleteTable asynchronously, invoking a callback when done
 -- @param BatchDeleteTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDeleteTableAsync(BatchDeleteTableRequest, cb)
 	assert(BatchDeleteTableRequest, "You must provide a BatchDeleteTableRequest")
 	local headers = {
@@ -13019,19 +13020,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDeleteTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDeleteTableSync(BatchDeleteTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDeleteTableAsync(BatchDeleteTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDeleteTableAsync(BatchDeleteTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCrawlers asynchronously, invoking a callback when done
 -- @param GetCrawlersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCrawlersAsync(GetCrawlersRequest, cb)
 	assert(GetCrawlersRequest, "You must provide a GetCrawlersRequest")
 	local headers = {
@@ -13054,19 +13056,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCrawlersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCrawlersSync(GetCrawlersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCrawlersAsync(GetCrawlersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCrawlersAsync(GetCrawlersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopCrawler asynchronously, invoking a callback when done
 -- @param StopCrawlerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopCrawlerAsync(StopCrawlerRequest, cb)
 	assert(StopCrawlerRequest, "You must provide a StopCrawlerRequest")
 	local headers = {
@@ -13089,19 +13092,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopCrawlerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopCrawlerSync(StopCrawlerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopCrawlerAsync(StopCrawlerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopCrawlerAsync(StopCrawlerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartCrawler asynchronously, invoking a callback when done
 -- @param StartCrawlerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartCrawlerAsync(StartCrawlerRequest, cb)
 	assert(StartCrawlerRequest, "You must provide a StartCrawlerRequest")
 	local headers = {
@@ -13124,19 +13128,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartCrawlerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartCrawlerSync(StartCrawlerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartCrawlerAsync(StartCrawlerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartCrawlerAsync(StartCrawlerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPartitions asynchronously, invoking a callback when done
 -- @param GetPartitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPartitionsAsync(GetPartitionsRequest, cb)
 	assert(GetPartitionsRequest, "You must provide a GetPartitionsRequest")
 	local headers = {
@@ -13159,19 +13164,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPartitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPartitionsSync(GetPartitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPartitionsAsync(GetPartitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPartitionsAsync(GetPartitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUserDefinedFunction asynchronously, invoking a callback when done
 -- @param GetUserDefinedFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserDefinedFunctionAsync(GetUserDefinedFunctionRequest, cb)
 	assert(GetUserDefinedFunctionRequest, "You must provide a GetUserDefinedFunctionRequest")
 	local headers = {
@@ -13194,19 +13200,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserDefinedFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserDefinedFunctionSync(GetUserDefinedFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserDefinedFunctionAsync(GetUserDefinedFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserDefinedFunctionAsync(GetUserDefinedFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateJob asynchronously, invoking a callback when done
 -- @param UpdateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateJobAsync(UpdateJobRequest, cb)
 	assert(UpdateJobRequest, "You must provide a UpdateJobRequest")
 	local headers = {
@@ -13229,19 +13236,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateJobSync(UpdateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateJobAsync(UpdateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateJobAsync(UpdateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCrawlerMetrics asynchronously, invoking a callback when done
 -- @param GetCrawlerMetricsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCrawlerMetricsAsync(GetCrawlerMetricsRequest, cb)
 	assert(GetCrawlerMetricsRequest, "You must provide a GetCrawlerMetricsRequest")
 	local headers = {
@@ -13264,19 +13272,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCrawlerMetricsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCrawlerMetricsSync(GetCrawlerMetricsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCrawlerMetricsAsync(GetCrawlerMetricsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCrawlerMetricsAsync(GetCrawlerMetricsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCrawlerSchedule asynchronously, invoking a callback when done
 -- @param UpdateCrawlerScheduleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCrawlerScheduleAsync(UpdateCrawlerScheduleRequest, cb)
 	assert(UpdateCrawlerScheduleRequest, "You must provide a UpdateCrawlerScheduleRequest")
 	local headers = {
@@ -13299,19 +13308,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCrawlerScheduleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCrawlerScheduleSync(UpdateCrawlerScheduleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCrawlerScheduleAsync(UpdateCrawlerScheduleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCrawlerScheduleAsync(UpdateCrawlerScheduleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDevEndpoint asynchronously, invoking a callback when done
 -- @param DeleteDevEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDevEndpointAsync(DeleteDevEndpointRequest, cb)
 	assert(DeleteDevEndpointRequest, "You must provide a DeleteDevEndpointRequest")
 	local headers = {
@@ -13334,19 +13344,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDevEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDevEndpointSync(DeleteDevEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDevEndpointAsync(DeleteDevEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDevEndpointAsync(DeleteDevEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePartition asynchronously, invoking a callback when done
 -- @param CreatePartitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePartitionAsync(CreatePartitionRequest, cb)
 	assert(CreatePartitionRequest, "You must provide a CreatePartitionRequest")
 	local headers = {
@@ -13369,19 +13380,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePartitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePartitionSync(CreatePartitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePartitionAsync(CreatePartitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePartitionAsync(CreatePartitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDatabase asynchronously, invoking a callback when done
 -- @param DeleteDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDatabaseAsync(DeleteDatabaseRequest, cb)
 	assert(DeleteDatabaseRequest, "You must provide a DeleteDatabaseRequest")
 	local headers = {
@@ -13404,19 +13416,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDatabaseSync(DeleteDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDatabaseAsync(DeleteDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDatabaseAsync(DeleteDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDeleteTableVersion asynchronously, invoking a callback when done
 -- @param BatchDeleteTableVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDeleteTableVersionAsync(BatchDeleteTableVersionRequest, cb)
 	assert(BatchDeleteTableVersionRequest, "You must provide a BatchDeleteTableVersionRequest")
 	local headers = {
@@ -13439,19 +13452,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDeleteTableVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDeleteTableVersionSync(BatchDeleteTableVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDeleteTableVersionAsync(BatchDeleteTableVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDeleteTableVersionAsync(BatchDeleteTableVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetJobBookmark asynchronously, invoking a callback when done
 -- @param ResetJobBookmarkRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetJobBookmarkAsync(ResetJobBookmarkRequest, cb)
 	assert(ResetJobBookmarkRequest, "You must provide a ResetJobBookmarkRequest")
 	local headers = {
@@ -13474,19 +13488,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetJobBookmarkRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetJobBookmarkSync(ResetJobBookmarkRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetJobBookmarkAsync(ResetJobBookmarkRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetJobBookmarkAsync(ResetJobBookmarkRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDatabases asynchronously, invoking a callback when done
 -- @param GetDatabasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDatabasesAsync(GetDatabasesRequest, cb)
 	assert(GetDatabasesRequest, "You must provide a GetDatabasesRequest")
 	local headers = {
@@ -13509,19 +13524,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDatabasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDatabasesSync(GetDatabasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDatabasesAsync(GetDatabasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDatabasesAsync(GetDatabasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDeleteConnection asynchronously, invoking a callback when done
 -- @param BatchDeleteConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDeleteConnectionAsync(BatchDeleteConnectionRequest, cb)
 	assert(BatchDeleteConnectionRequest, "You must provide a BatchDeleteConnectionRequest")
 	local headers = {
@@ -13544,19 +13560,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDeleteConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDeleteConnectionSync(BatchDeleteConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDeleteConnectionAsync(BatchDeleteConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDeleteConnectionAsync(BatchDeleteConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetPartition asynchronously, invoking a callback when done
 -- @param BatchGetPartitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetPartitionAsync(BatchGetPartitionRequest, cb)
 	assert(BatchGetPartitionRequest, "You must provide a BatchGetPartitionRequest")
 	local headers = {
@@ -13579,19 +13596,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetPartitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetPartitionSync(BatchGetPartitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetPartitionAsync(BatchGetPartitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetPartitionAsync(BatchGetPartitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConnection asynchronously, invoking a callback when done
 -- @param DeleteConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConnectionAsync(DeleteConnectionRequest, cb)
 	assert(DeleteConnectionRequest, "You must provide a DeleteConnectionRequest")
 	local headers = {
@@ -13614,19 +13632,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConnectionSync(DeleteConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConnectionAsync(DeleteConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConnectionAsync(DeleteConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePartition asynchronously, invoking a callback when done
 -- @param DeletePartitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePartitionAsync(DeletePartitionRequest, cb)
 	assert(DeletePartitionRequest, "You must provide a DeletePartitionRequest")
 	local headers = {
@@ -13649,19 +13668,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePartitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePartitionSync(DeletePartitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePartitionAsync(DeletePartitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePartitionAsync(DeletePartitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateClassifier asynchronously, invoking a callback when done
 -- @param CreateClassifierRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClassifierAsync(CreateClassifierRequest, cb)
 	assert(CreateClassifierRequest, "You must provide a CreateClassifierRequest")
 	local headers = {
@@ -13684,19 +13704,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClassifierRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClassifierSync(CreateClassifierRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClassifierAsync(CreateClassifierRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClassifierAsync(CreateClassifierRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteJob asynchronously, invoking a callback when done
 -- @param DeleteJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteJobAsync(DeleteJobRequest, cb)
 	assert(DeleteJobRequest, "You must provide a DeleteJobRequest")
 	local headers = {
@@ -13719,19 +13740,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteJobSync(DeleteJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteJobAsync(DeleteJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteJobAsync(DeleteJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJob asynchronously, invoking a callback when done
 -- @param GetJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobAsync(GetJobRequest, cb)
 	assert(GetJobRequest, "You must provide a GetJobRequest")
 	local headers = {
@@ -13754,19 +13776,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobSync(GetJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobAsync(GetJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobAsync(GetJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDatabase asynchronously, invoking a callback when done
 -- @param GetDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDatabaseAsync(GetDatabaseRequest, cb)
 	assert(GetDatabaseRequest, "You must provide a GetDatabaseRequest")
 	local headers = {
@@ -13789,19 +13812,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDatabaseSync(GetDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDatabaseAsync(GetDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDatabaseAsync(GetDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchStopJobRun asynchronously, invoking a callback when done
 -- @param BatchStopJobRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchStopJobRunAsync(BatchStopJobRunRequest, cb)
 	assert(BatchStopJobRunRequest, "You must provide a BatchStopJobRunRequest")
 	local headers = {
@@ -13824,19 +13848,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchStopJobRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchStopJobRunSync(BatchStopJobRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchStopJobRunAsync(BatchStopJobRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchStopJobRunAsync(BatchStopJobRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTableVersion asynchronously, invoking a callback when done
 -- @param DeleteTableVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTableVersionAsync(DeleteTableVersionRequest, cb)
 	assert(DeleteTableVersionRequest, "You must provide a DeleteTableVersionRequest")
 	local headers = {
@@ -13859,19 +13884,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTableVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTableVersionSync(DeleteTableVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTableVersionAsync(DeleteTableVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTableVersionAsync(DeleteTableVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteClassifier asynchronously, invoking a callback when done
 -- @param DeleteClassifierRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClassifierAsync(DeleteClassifierRequest, cb)
 	assert(DeleteClassifierRequest, "You must provide a DeleteClassifierRequest")
 	local headers = {
@@ -13894,19 +13920,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClassifierRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClassifierSync(DeleteClassifierRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClassifierAsync(DeleteClassifierRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClassifierAsync(DeleteClassifierRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTableVersions asynchronously, invoking a callback when done
 -- @param GetTableVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTableVersionsAsync(GetTableVersionsRequest, cb)
 	assert(GetTableVersionsRequest, "You must provide a GetTableVersionsRequest")
 	local headers = {
@@ -13929,19 +13956,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTableVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTableVersionsSync(GetTableVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTableVersionsAsync(GetTableVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTableVersionsAsync(GetTableVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDevEndpoint asynchronously, invoking a callback when done
 -- @param UpdateDevEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDevEndpointAsync(UpdateDevEndpointRequest, cb)
 	assert(UpdateDevEndpointRequest, "You must provide a UpdateDevEndpointRequest")
 	local headers = {
@@ -13964,19 +13992,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDevEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDevEndpointSync(UpdateDevEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDevEndpointAsync(UpdateDevEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDevEndpointAsync(UpdateDevEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTriggers asynchronously, invoking a callback when done
 -- @param GetTriggersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTriggersAsync(GetTriggersRequest, cb)
 	assert(GetTriggersRequest, "You must provide a GetTriggersRequest")
 	local headers = {
@@ -13999,19 +14028,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTriggersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTriggersSync(GetTriggersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTriggersAsync(GetTriggersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTriggersAsync(GetTriggersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevEndpoint asynchronously, invoking a callback when done
 -- @param GetDevEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDevEndpointAsync(GetDevEndpointRequest, cb)
 	assert(GetDevEndpointRequest, "You must provide a GetDevEndpointRequest")
 	local headers = {
@@ -14034,19 +14064,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDevEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDevEndpointSync(GetDevEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDevEndpointAsync(GetDevEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDevEndpointAsync(GetDevEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobRuns asynchronously, invoking a callback when done
 -- @param GetJobRunsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobRunsAsync(GetJobRunsRequest, cb)
 	assert(GetJobRunsRequest, "You must provide a GetJobRunsRequest")
 	local headers = {
@@ -14069,19 +14100,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobRunsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobRunsSync(GetJobRunsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobRunsAsync(GetJobRunsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobRunsAsync(GetJobRunsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDatabase asynchronously, invoking a callback when done
 -- @param CreateDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDatabaseAsync(CreateDatabaseRequest, cb)
 	assert(CreateDatabaseRequest, "You must provide a CreateDatabaseRequest")
 	local headers = {
@@ -14104,19 +14136,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDatabaseSync(CreateDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDatabaseAsync(CreateDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDatabaseAsync(CreateDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartJobRun asynchronously, invoking a callback when done
 -- @param StartJobRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartJobRunAsync(StartJobRunRequest, cb)
 	assert(StartJobRunRequest, "You must provide a StartJobRunRequest")
 	local headers = {
@@ -14139,19 +14172,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartJobRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartJobRunSync(StartJobRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartJobRunAsync(StartJobRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartJobRunAsync(StartJobRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevEndpoints asynchronously, invoking a callback when done
 -- @param GetDevEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDevEndpointsAsync(GetDevEndpointsRequest, cb)
 	assert(GetDevEndpointsRequest, "You must provide a GetDevEndpointsRequest")
 	local headers = {
@@ -14174,19 +14208,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDevEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDevEndpointsSync(GetDevEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDevEndpointsAsync(GetDevEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDevEndpointsAsync(GetDevEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetClassifier asynchronously, invoking a callback when done
 -- @param GetClassifierRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetClassifierAsync(GetClassifierRequest, cb)
 	assert(GetClassifierRequest, "You must provide a GetClassifierRequest")
 	local headers = {
@@ -14209,19 +14244,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetClassifierRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetClassifierSync(GetClassifierRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetClassifierAsync(GetClassifierRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetClassifierAsync(GetClassifierRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTrigger asynchronously, invoking a callback when done
 -- @param UpdateTriggerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTriggerAsync(UpdateTriggerRequest, cb)
 	assert(UpdateTriggerRequest, "You must provide a UpdateTriggerRequest")
 	local headers = {
@@ -14244,19 +14280,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTriggerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTriggerSync(UpdateTriggerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTriggerAsync(UpdateTriggerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTriggerAsync(UpdateTriggerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPartition asynchronously, invoking a callback when done
 -- @param GetPartitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPartitionAsync(GetPartitionRequest, cb)
 	assert(GetPartitionRequest, "You must provide a GetPartitionRequest")
 	local headers = {
@@ -14279,19 +14316,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPartitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPartitionSync(GetPartitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPartitionAsync(GetPartitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPartitionAsync(GetPartitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSecurityConfiguration asynchronously, invoking a callback when done
 -- @param CreateSecurityConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSecurityConfigurationAsync(CreateSecurityConfigurationRequest, cb)
 	assert(CreateSecurityConfigurationRequest, "You must provide a CreateSecurityConfigurationRequest")
 	local headers = {
@@ -14314,19 +14352,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSecurityConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSecurityConfigurationSync(CreateSecurityConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSecurityConfigurationAsync(CreateSecurityConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSecurityConfigurationAsync(CreateSecurityConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResourcePolicy asynchronously, invoking a callback when done
 -- @param GetResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourcePolicyAsync(GetResourcePolicyRequest, cb)
 	assert(GetResourcePolicyRequest, "You must provide a GetResourcePolicyRequest")
 	local headers = {
@@ -14349,19 +14388,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourcePolicySync(GetResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourcePolicyAsync(GetResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourcePolicyAsync(GetResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTrigger asynchronously, invoking a callback when done
 -- @param GetTriggerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTriggerAsync(GetTriggerRequest, cb)
 	assert(GetTriggerRequest, "You must provide a GetTriggerRequest")
 	local headers = {
@@ -14384,19 +14424,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTriggerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTriggerSync(GetTriggerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTriggerAsync(GetTriggerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTriggerAsync(GetTriggerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartCrawlerSchedule asynchronously, invoking a callback when done
 -- @param StartCrawlerScheduleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartCrawlerScheduleAsync(StartCrawlerScheduleRequest, cb)
 	assert(StartCrawlerScheduleRequest, "You must provide a StartCrawlerScheduleRequest")
 	local headers = {
@@ -14419,19 +14460,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartCrawlerScheduleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartCrawlerScheduleSync(StartCrawlerScheduleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartCrawlerScheduleAsync(StartCrawlerScheduleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartCrawlerScheduleAsync(StartCrawlerScheduleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutResourcePolicy asynchronously, invoking a callback when done
 -- @param PutResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutResourcePolicyAsync(PutResourcePolicyRequest, cb)
 	assert(PutResourcePolicyRequest, "You must provide a PutResourcePolicyRequest")
 	local headers = {
@@ -14454,19 +14496,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutResourcePolicySync(PutResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutResourcePolicyAsync(PutResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutResourcePolicyAsync(PutResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTableVersion asynchronously, invoking a callback when done
 -- @param GetTableVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTableVersionAsync(GetTableVersionRequest, cb)
 	assert(GetTableVersionRequest, "You must provide a GetTableVersionRequest")
 	local headers = {
@@ -14489,19 +14532,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTableVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTableVersionSync(GetTableVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTableVersionAsync(GetTableVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTableVersionAsync(GetTableVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTrigger asynchronously, invoking a callback when done
 -- @param DeleteTriggerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTriggerAsync(DeleteTriggerRequest, cb)
 	assert(DeleteTriggerRequest, "You must provide a DeleteTriggerRequest")
 	local headers = {
@@ -14524,19 +14568,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTriggerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTriggerSync(DeleteTriggerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTriggerAsync(DeleteTriggerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTriggerAsync(DeleteTriggerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSecurityConfiguration asynchronously, invoking a callback when done
 -- @param DeleteSecurityConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSecurityConfigurationAsync(DeleteSecurityConfigurationRequest, cb)
 	assert(DeleteSecurityConfigurationRequest, "You must provide a DeleteSecurityConfigurationRequest")
 	local headers = {
@@ -14559,19 +14604,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSecurityConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSecurityConfigurationSync(DeleteSecurityConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSecurityConfigurationAsync(DeleteSecurityConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSecurityConfigurationAsync(DeleteSecurityConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResourcePolicy asynchronously, invoking a callback when done
 -- @param DeleteResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, cb)
 	assert(DeleteResourcePolicyRequest, "You must provide a DeleteResourcePolicyRequest")
 	local headers = {
@@ -14594,19 +14640,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourcePolicySync(DeleteResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDataCatalogEncryptionSettings asynchronously, invoking a callback when done
 -- @param GetDataCatalogEncryptionSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDataCatalogEncryptionSettingsAsync(GetDataCatalogEncryptionSettingsRequest, cb)
 	assert(GetDataCatalogEncryptionSettingsRequest, "You must provide a GetDataCatalogEncryptionSettingsRequest")
 	local headers = {
@@ -14629,19 +14676,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDataCatalogEncryptionSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDataCatalogEncryptionSettingsSync(GetDataCatalogEncryptionSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDataCatalogEncryptionSettingsAsync(GetDataCatalogEncryptionSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDataCatalogEncryptionSettingsAsync(GetDataCatalogEncryptionSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSecurityConfigurations asynchronously, invoking a callback when done
 -- @param GetSecurityConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSecurityConfigurationsAsync(GetSecurityConfigurationsRequest, cb)
 	assert(GetSecurityConfigurationsRequest, "You must provide a GetSecurityConfigurationsRequest")
 	local headers = {
@@ -14664,19 +14712,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSecurityConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSecurityConfigurationsSync(GetSecurityConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSecurityConfigurationsAsync(GetSecurityConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSecurityConfigurationsAsync(GetSecurityConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCrawler asynchronously, invoking a callback when done
 -- @param DeleteCrawlerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCrawlerAsync(DeleteCrawlerRequest, cb)
 	assert(DeleteCrawlerRequest, "You must provide a DeleteCrawlerRequest")
 	local headers = {
@@ -14699,19 +14748,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCrawlerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCrawlerSync(DeleteCrawlerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCrawlerAsync(DeleteCrawlerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCrawlerAsync(DeleteCrawlerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateClassifier asynchronously, invoking a callback when done
 -- @param UpdateClassifierRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateClassifierAsync(UpdateClassifierRequest, cb)
 	assert(UpdateClassifierRequest, "You must provide a UpdateClassifierRequest")
 	local headers = {
@@ -14734,19 +14784,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateClassifierRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateClassifierSync(UpdateClassifierRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateClassifierAsync(UpdateClassifierRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateClassifierAsync(UpdateClassifierRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCrawler asynchronously, invoking a callback when done
 -- @param CreateCrawlerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCrawlerAsync(CreateCrawlerRequest, cb)
 	assert(CreateCrawlerRequest, "You must provide a CreateCrawlerRequest")
 	local headers = {
@@ -14769,19 +14820,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCrawlerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCrawlerSync(CreateCrawlerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCrawlerAsync(CreateCrawlerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCrawlerAsync(CreateCrawlerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDevEndpoint asynchronously, invoking a callback when done
 -- @param CreateDevEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDevEndpointAsync(CreateDevEndpointRequest, cb)
 	assert(CreateDevEndpointRequest, "You must provide a CreateDevEndpointRequest")
 	local headers = {
@@ -14804,19 +14856,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDevEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDevEndpointSync(CreateDevEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDevEndpointAsync(CreateDevEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDevEndpointAsync(CreateDevEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConnection asynchronously, invoking a callback when done
 -- @param CreateConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConnectionAsync(CreateConnectionRequest, cb)
 	assert(CreateConnectionRequest, "You must provide a CreateConnectionRequest")
 	local headers = {
@@ -14839,19 +14892,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConnectionSync(CreateConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConnectionAsync(CreateConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConnectionAsync(CreateConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTable asynchronously, invoking a callback when done
 -- @param DeleteTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTableAsync(DeleteTableRequest, cb)
 	assert(DeleteTableRequest, "You must provide a DeleteTableRequest")
 	local headers = {
@@ -14874,19 +14928,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTableSync(DeleteTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTableAsync(DeleteTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTableAsync(DeleteTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobRun asynchronously, invoking a callback when done
 -- @param GetJobRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobRunAsync(GetJobRunRequest, cb)
 	assert(GetJobRunRequest, "You must provide a GetJobRunRequest")
 	local headers = {
@@ -14909,19 +14964,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobRunSync(GetJobRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobRunAsync(GetJobRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobRunAsync(GetJobRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchCreatePartition asynchronously, invoking a callback when done
 -- @param BatchCreatePartitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchCreatePartitionAsync(BatchCreatePartitionRequest, cb)
 	assert(BatchCreatePartitionRequest, "You must provide a BatchCreatePartitionRequest")
 	local headers = {
@@ -14944,19 +15000,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchCreatePartitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchCreatePartitionSync(BatchCreatePartitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchCreatePartitionAsync(BatchCreatePartitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchCreatePartitionAsync(BatchCreatePartitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartTrigger asynchronously, invoking a callback when done
 -- @param StartTriggerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartTriggerAsync(StartTriggerRequest, cb)
 	assert(StartTriggerRequest, "You must provide a StartTriggerRequest")
 	local headers = {
@@ -14979,19 +15036,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartTriggerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartTriggerSync(StartTriggerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartTriggerAsync(StartTriggerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartTriggerAsync(StartTriggerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutDataCatalogEncryptionSettings asynchronously, invoking a callback when done
 -- @param PutDataCatalogEncryptionSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutDataCatalogEncryptionSettingsAsync(PutDataCatalogEncryptionSettingsRequest, cb)
 	assert(PutDataCatalogEncryptionSettingsRequest, "You must provide a PutDataCatalogEncryptionSettingsRequest")
 	local headers = {
@@ -15014,19 +15072,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutDataCatalogEncryptionSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutDataCatalogEncryptionSettingsSync(PutDataCatalogEncryptionSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutDataCatalogEncryptionSettingsAsync(PutDataCatalogEncryptionSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutDataCatalogEncryptionSettingsAsync(PutDataCatalogEncryptionSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetClassifiers asynchronously, invoking a callback when done
 -- @param GetClassifiersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetClassifiersAsync(GetClassifiersRequest, cb)
 	assert(GetClassifiersRequest, "You must provide a GetClassifiersRequest")
 	local headers = {
@@ -15049,19 +15108,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetClassifiersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetClassifiersSync(GetClassifiersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetClassifiersAsync(GetClassifiersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetClassifiersAsync(GetClassifiersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePartition asynchronously, invoking a callback when done
 -- @param UpdatePartitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePartitionAsync(UpdatePartitionRequest, cb)
 	assert(UpdatePartitionRequest, "You must provide a UpdatePartitionRequest")
 	local headers = {
@@ -15084,19 +15144,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePartitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePartitionSync(UpdatePartitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePartitionAsync(UpdatePartitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePartitionAsync(UpdatePartitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobs asynchronously, invoking a callback when done
 -- @param GetJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobsAsync(GetJobsRequest, cb)
 	assert(GetJobsRequest, "You must provide a GetJobsRequest")
 	local headers = {
@@ -15119,19 +15180,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobsSync(GetJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobsAsync(GetJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobsAsync(GetJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserDefinedFunction asynchronously, invoking a callback when done
 -- @param UpdateUserDefinedFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserDefinedFunctionAsync(UpdateUserDefinedFunctionRequest, cb)
 	assert(UpdateUserDefinedFunctionRequest, "You must provide a UpdateUserDefinedFunctionRequest")
 	local headers = {
@@ -15154,19 +15216,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserDefinedFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserDefinedFunctionSync(UpdateUserDefinedFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserDefinedFunctionAsync(UpdateUserDefinedFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserDefinedFunctionAsync(UpdateUserDefinedFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConnections asynchronously, invoking a callback when done
 -- @param GetConnectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConnectionsAsync(GetConnectionsRequest, cb)
 	assert(GetConnectionsRequest, "You must provide a GetConnectionsRequest")
 	local headers = {
@@ -15189,19 +15252,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConnectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConnectionsSync(GetConnectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConnectionsAsync(GetConnectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConnectionsAsync(GetConnectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPlan asynchronously, invoking a callback when done
 -- @param GetPlanRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPlanAsync(GetPlanRequest, cb)
 	assert(GetPlanRequest, "You must provide a GetPlanRequest")
 	local headers = {
@@ -15224,19 +15288,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPlanRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPlanSync(GetPlanRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPlanAsync(GetPlanRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPlanAsync(GetPlanRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTable asynchronously, invoking a callback when done
 -- @param CreateTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTableAsync(CreateTableRequest, cb)
 	assert(CreateTableRequest, "You must provide a CreateTableRequest")
 	local headers = {
@@ -15259,19 +15324,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTableSync(CreateTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTableAsync(CreateTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTableAsync(CreateTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTrigger asynchronously, invoking a callback when done
 -- @param CreateTriggerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTriggerAsync(CreateTriggerRequest, cb)
 	assert(CreateTriggerRequest, "You must provide a CreateTriggerRequest")
 	local headers = {
@@ -15294,19 +15360,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTriggerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTriggerSync(CreateTriggerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTriggerAsync(CreateTriggerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTriggerAsync(CreateTriggerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopTrigger asynchronously, invoking a callback when done
 -- @param StopTriggerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopTriggerAsync(StopTriggerRequest, cb)
 	assert(StopTriggerRequest, "You must provide a StopTriggerRequest")
 	local headers = {
@@ -15329,19 +15396,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopTriggerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopTriggerSync(StopTriggerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopTriggerAsync(StopTriggerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopTriggerAsync(StopTriggerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserDefinedFunction asynchronously, invoking a callback when done
 -- @param DeleteUserDefinedFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserDefinedFunctionAsync(DeleteUserDefinedFunctionRequest, cb)
 	assert(DeleteUserDefinedFunctionRequest, "You must provide a DeleteUserDefinedFunctionRequest")
 	local headers = {
@@ -15364,19 +15432,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserDefinedFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserDefinedFunctionSync(DeleteUserDefinedFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserDefinedFunctionAsync(DeleteUserDefinedFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserDefinedFunctionAsync(DeleteUserDefinedFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSecurityConfiguration asynchronously, invoking a callback when done
 -- @param GetSecurityConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSecurityConfigurationAsync(GetSecurityConfigurationRequest, cb)
 	assert(GetSecurityConfigurationRequest, "You must provide a GetSecurityConfigurationRequest")
 	local headers = {
@@ -15399,19 +15468,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSecurityConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSecurityConfigurationSync(GetSecurityConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSecurityConfigurationAsync(GetSecurityConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSecurityConfigurationAsync(GetSecurityConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConnection asynchronously, invoking a callback when done
 -- @param GetConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConnectionAsync(GetConnectionRequest, cb)
 	assert(GetConnectionRequest, "You must provide a GetConnectionRequest")
 	local headers = {
@@ -15434,19 +15504,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConnectionSync(GetConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConnectionAsync(GetConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConnectionAsync(GetConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTables asynchronously, invoking a callback when done
 -- @param GetTablesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTablesAsync(GetTablesRequest, cb)
 	assert(GetTablesRequest, "You must provide a GetTablesRequest")
 	local headers = {
@@ -15469,19 +15540,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTablesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTablesSync(GetTablesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTablesAsync(GetTablesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTablesAsync(GetTablesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateScript asynchronously, invoking a callback when done
 -- @param CreateScriptRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateScriptAsync(CreateScriptRequest, cb)
 	assert(CreateScriptRequest, "You must provide a CreateScriptRequest")
 	local headers = {
@@ -15504,19 +15576,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateScriptRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateScriptSync(CreateScriptRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateScriptAsync(CreateScriptRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateScriptAsync(CreateScriptRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCatalogImportStatus asynchronously, invoking a callback when done
 -- @param GetCatalogImportStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCatalogImportStatusAsync(GetCatalogImportStatusRequest, cb)
 	assert(GetCatalogImportStatusRequest, "You must provide a GetCatalogImportStatusRequest")
 	local headers = {
@@ -15539,19 +15612,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCatalogImportStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCatalogImportStatusSync(GetCatalogImportStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCatalogImportStatusAsync(GetCatalogImportStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCatalogImportStatusAsync(GetCatalogImportStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopCrawlerSchedule asynchronously, invoking a callback when done
 -- @param StopCrawlerScheduleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopCrawlerScheduleAsync(StopCrawlerScheduleRequest, cb)
 	assert(StopCrawlerScheduleRequest, "You must provide a StopCrawlerScheduleRequest")
 	local headers = {
@@ -15574,19 +15648,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopCrawlerScheduleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopCrawlerScheduleSync(StopCrawlerScheduleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopCrawlerScheduleAsync(StopCrawlerScheduleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopCrawlerScheduleAsync(StopCrawlerScheduleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDataflowGraph asynchronously, invoking a callback when done
 -- @param GetDataflowGraphRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDataflowGraphAsync(GetDataflowGraphRequest, cb)
 	assert(GetDataflowGraphRequest, "You must provide a GetDataflowGraphRequest")
 	local headers = {
@@ -15609,19 +15684,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDataflowGraphRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDataflowGraphSync(GetDataflowGraphRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDataflowGraphAsync(GetDataflowGraphRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDataflowGraphAsync(GetDataflowGraphRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJob asynchronously, invoking a callback when done
 -- @param CreateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobAsync(CreateJobRequest, cb)
 	assert(CreateJobRequest, "You must provide a CreateJobRequest")
 	local headers = {
@@ -15644,19 +15720,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobSync(CreateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobAsync(CreateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobAsync(CreateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCrawler asynchronously, invoking a callback when done
 -- @param GetCrawlerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCrawlerAsync(GetCrawlerRequest, cb)
 	assert(GetCrawlerRequest, "You must provide a GetCrawlerRequest")
 	local headers = {
@@ -15679,19 +15756,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCrawlerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCrawlerSync(GetCrawlerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCrawlerAsync(GetCrawlerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCrawlerAsync(GetCrawlerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTable asynchronously, invoking a callback when done
 -- @param UpdateTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTableAsync(UpdateTableRequest, cb)
 	assert(UpdateTableRequest, "You must provide a UpdateTableRequest")
 	local headers = {
@@ -15714,19 +15792,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTableSync(UpdateTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTableAsync(UpdateTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTableAsync(UpdateTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDeletePartition asynchronously, invoking a callback when done
 -- @param BatchDeletePartitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDeletePartitionAsync(BatchDeletePartitionRequest, cb)
 	assert(BatchDeletePartitionRequest, "You must provide a BatchDeletePartitionRequest")
 	local headers = {
@@ -15749,19 +15828,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDeletePartitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDeletePartitionSync(BatchDeletePartitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDeletePartitionAsync(BatchDeletePartitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDeletePartitionAsync(BatchDeletePartitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCrawler asynchronously, invoking a callback when done
 -- @param UpdateCrawlerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCrawlerAsync(UpdateCrawlerRequest, cb)
 	assert(UpdateCrawlerRequest, "You must provide a UpdateCrawlerRequest")
 	local headers = {
@@ -15784,19 +15864,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCrawlerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCrawlerSync(UpdateCrawlerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCrawlerAsync(UpdateCrawlerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCrawlerAsync(UpdateCrawlerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUserDefinedFunction asynchronously, invoking a callback when done
 -- @param CreateUserDefinedFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserDefinedFunctionAsync(CreateUserDefinedFunctionRequest, cb)
 	assert(CreateUserDefinedFunctionRequest, "You must provide a CreateUserDefinedFunctionRequest")
 	local headers = {
@@ -15819,19 +15900,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserDefinedFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserDefinedFunctionSync(CreateUserDefinedFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserDefinedFunctionAsync(CreateUserDefinedFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserDefinedFunctionAsync(CreateUserDefinedFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportCatalogToGlue asynchronously, invoking a callback when done
 -- @param ImportCatalogToGlueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportCatalogToGlueAsync(ImportCatalogToGlueRequest, cb)
 	assert(ImportCatalogToGlueRequest, "You must provide a ImportCatalogToGlueRequest")
 	local headers = {
@@ -15854,19 +15936,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportCatalogToGlueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportCatalogToGlueSync(ImportCatalogToGlueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportCatalogToGlueAsync(ImportCatalogToGlueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportCatalogToGlueAsync(ImportCatalogToGlueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMapping asynchronously, invoking a callback when done
 -- @param GetMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMappingAsync(GetMappingRequest, cb)
 	assert(GetMappingRequest, "You must provide a GetMappingRequest")
 	local headers = {
@@ -15889,19 +15972,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMappingSync(GetMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMappingAsync(GetMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMappingAsync(GetMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTable asynchronously, invoking a callback when done
 -- @param GetTableRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTableAsync(GetTableRequest, cb)
 	assert(GetTableRequest, "You must provide a GetTableRequest")
 	local headers = {
@@ -15924,19 +16008,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTableRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTableSync(GetTableRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTableAsync(GetTableRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTableAsync(GetTableRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDatabase asynchronously, invoking a callback when done
 -- @param UpdateDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDatabaseAsync(UpdateDatabaseRequest, cb)
 	assert(UpdateDatabaseRequest, "You must provide a UpdateDatabaseRequest")
 	local headers = {
@@ -15959,19 +16044,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDatabaseSync(UpdateDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDatabaseAsync(UpdateDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDatabaseAsync(UpdateDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConnection asynchronously, invoking a callback when done
 -- @param UpdateConnectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConnectionAsync(UpdateConnectionRequest, cb)
 	assert(UpdateConnectionRequest, "You must provide a UpdateConnectionRequest")
 	local headers = {
@@ -15994,12 +16080,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConnectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConnectionSync(UpdateConnectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConnectionAsync(UpdateConnectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConnectionAsync(UpdateConnectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/greengrass.lua
+++ b/aws-sdk/greengrass.lua
@@ -8783,7 +8783,7 @@ end
 --
 --- Call GetDeviceDefinitionVersion asynchronously, invoking a callback when done
 -- @param GetDeviceDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeviceDefinitionVersionAsync(GetDeviceDefinitionVersionRequest, cb)
 	assert(GetDeviceDefinitionVersionRequest, "You must provide a GetDeviceDefinitionVersionRequest")
 	local headers = {
@@ -8806,19 +8806,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeviceDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeviceDefinitionVersionSync(GetDeviceDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeviceDefinitionVersionAsync(GetDeviceDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeviceDefinitionVersionAsync(GetDeviceDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeviceDefinitionVersions asynchronously, invoking a callback when done
 -- @param ListDeviceDefinitionVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeviceDefinitionVersionsAsync(ListDeviceDefinitionVersionsRequest, cb)
 	assert(ListDeviceDefinitionVersionsRequest, "You must provide a ListDeviceDefinitionVersionsRequest")
 	local headers = {
@@ -8841,19 +8842,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeviceDefinitionVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeviceDefinitionVersionsSync(ListDeviceDefinitionVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeviceDefinitionVersionsAsync(ListDeviceDefinitionVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeviceDefinitionVersionsAsync(ListDeviceDefinitionVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBulkDeployments asynchronously, invoking a callback when done
 -- @param ListBulkDeploymentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBulkDeploymentsAsync(ListBulkDeploymentsRequest, cb)
 	assert(ListBulkDeploymentsRequest, "You must provide a ListBulkDeploymentsRequest")
 	local headers = {
@@ -8876,19 +8878,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBulkDeploymentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBulkDeploymentsSync(ListBulkDeploymentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBulkDeploymentsAsync(ListBulkDeploymentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBulkDeploymentsAsync(ListBulkDeploymentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGroup asynchronously, invoking a callback when done
 -- @param UpdateGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGroupAsync(UpdateGroupRequest, cb)
 	assert(UpdateGroupRequest, "You must provide a UpdateGroupRequest")
 	local headers = {
@@ -8911,19 +8914,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGroupSync(UpdateGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGroupAsync(UpdateGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGroupAsync(UpdateGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateRoleToGroup asynchronously, invoking a callback when done
 -- @param AssociateRoleToGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateRoleToGroupAsync(AssociateRoleToGroupRequest, cb)
 	assert(AssociateRoleToGroupRequest, "You must provide a AssociateRoleToGroupRequest")
 	local headers = {
@@ -8946,19 +8950,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateRoleToGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateRoleToGroupSync(AssociateRoleToGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateRoleToGroupAsync(AssociateRoleToGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateRoleToGroupAsync(AssociateRoleToGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBulkDeploymentDetailedReports asynchronously, invoking a callback when done
 -- @param ListBulkDeploymentDetailedReportsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBulkDeploymentDetailedReportsAsync(ListBulkDeploymentDetailedReportsRequest, cb)
 	assert(ListBulkDeploymentDetailedReportsRequest, "You must provide a ListBulkDeploymentDetailedReportsRequest")
 	local headers = {
@@ -8981,19 +8986,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBulkDeploymentDetailedReportsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBulkDeploymentDetailedReportsSync(ListBulkDeploymentDetailedReportsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBulkDeploymentDetailedReportsAsync(ListBulkDeploymentDetailedReportsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBulkDeploymentDetailedReportsAsync(ListBulkDeploymentDetailedReportsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSubscriptionDefinitionVersions asynchronously, invoking a callback when done
 -- @param ListSubscriptionDefinitionVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSubscriptionDefinitionVersionsAsync(ListSubscriptionDefinitionVersionsRequest, cb)
 	assert(ListSubscriptionDefinitionVersionsRequest, "You must provide a ListSubscriptionDefinitionVersionsRequest")
 	local headers = {
@@ -9016,19 +9022,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSubscriptionDefinitionVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSubscriptionDefinitionVersionsSync(ListSubscriptionDefinitionVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSubscriptionDefinitionVersionsAsync(ListSubscriptionDefinitionVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSubscriptionDefinitionVersionsAsync(ListSubscriptionDefinitionVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCoreDefinitions asynchronously, invoking a callback when done
 -- @param ListCoreDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCoreDefinitionsAsync(ListCoreDefinitionsRequest, cb)
 	assert(ListCoreDefinitionsRequest, "You must provide a ListCoreDefinitionsRequest")
 	local headers = {
@@ -9051,19 +9058,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCoreDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCoreDefinitionsSync(ListCoreDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCoreDefinitionsAsync(ListCoreDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCoreDefinitionsAsync(ListCoreDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroupVersions asynchronously, invoking a callback when done
 -- @param ListGroupVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupVersionsAsync(ListGroupVersionsRequest, cb)
 	assert(ListGroupVersionsRequest, "You must provide a ListGroupVersionsRequest")
 	local headers = {
@@ -9086,19 +9094,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupVersionsSync(ListGroupVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupVersionsAsync(ListGroupVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupVersionsAsync(ListGroupVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCoreDefinition asynchronously, invoking a callback when done
 -- @param UpdateCoreDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCoreDefinitionAsync(UpdateCoreDefinitionRequest, cb)
 	assert(UpdateCoreDefinitionRequest, "You must provide a UpdateCoreDefinitionRequest")
 	local headers = {
@@ -9121,19 +9130,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCoreDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCoreDefinitionSync(UpdateCoreDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCoreDefinitionAsync(UpdateCoreDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCoreDefinitionAsync(UpdateCoreDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCoreDefinition asynchronously, invoking a callback when done
 -- @param CreateCoreDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCoreDefinitionAsync(CreateCoreDefinitionRequest, cb)
 	assert(CreateCoreDefinitionRequest, "You must provide a CreateCoreDefinitionRequest")
 	local headers = {
@@ -9156,19 +9166,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCoreDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCoreDefinitionSync(CreateCoreDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCoreDefinitionAsync(CreateCoreDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCoreDefinitionAsync(CreateCoreDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSubscriptionDefinition asynchronously, invoking a callback when done
 -- @param GetSubscriptionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSubscriptionDefinitionAsync(GetSubscriptionDefinitionRequest, cb)
 	assert(GetSubscriptionDefinitionRequest, "You must provide a GetSubscriptionDefinitionRequest")
 	local headers = {
@@ -9191,19 +9202,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSubscriptionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSubscriptionDefinitionSync(GetSubscriptionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSubscriptionDefinitionAsync(GetSubscriptionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSubscriptionDefinitionAsync(GetSubscriptionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeploymentStatus asynchronously, invoking a callback when done
 -- @param GetDeploymentStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeploymentStatusAsync(GetDeploymentStatusRequest, cb)
 	assert(GetDeploymentStatusRequest, "You must provide a GetDeploymentStatusRequest")
 	local headers = {
@@ -9226,19 +9238,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeploymentStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeploymentStatusSync(GetDeploymentStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeploymentStatusAsync(GetDeploymentStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeploymentStatusAsync(GetDeploymentStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResourceDefinitionVersion asynchronously, invoking a callback when done
 -- @param CreateResourceDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResourceDefinitionVersionAsync(CreateResourceDefinitionVersionRequest, cb)
 	assert(CreateResourceDefinitionVersionRequest, "You must provide a CreateResourceDefinitionVersionRequest")
 	local headers = {
@@ -9261,19 +9274,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResourceDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResourceDefinitionVersionSync(CreateResourceDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResourceDefinitionVersionAsync(CreateResourceDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResourceDefinitionVersionAsync(CreateResourceDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGroup asynchronously, invoking a callback when done
 -- @param CreateGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGroupAsync(CreateGroupRequest, cb)
 	assert(CreateGroupRequest, "You must provide a CreateGroupRequest")
 	local headers = {
@@ -9296,19 +9310,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGroupSync(CreateGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGroupAsync(CreateGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGroupAsync(CreateGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroupCertificateAuthority asynchronously, invoking a callback when done
 -- @param GetGroupCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupCertificateAuthorityAsync(GetGroupCertificateAuthorityRequest, cb)
 	assert(GetGroupCertificateAuthorityRequest, "You must provide a GetGroupCertificateAuthorityRequest")
 	local headers = {
@@ -9331,19 +9346,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupCertificateAuthoritySync(GetGroupCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupCertificateAuthorityAsync(GetGroupCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupCertificateAuthorityAsync(GetGroupCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeployment asynchronously, invoking a callback when done
 -- @param CreateDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeploymentAsync(CreateDeploymentRequest, cb)
 	assert(CreateDeploymentRequest, "You must provide a CreateDeploymentRequest")
 	local headers = {
@@ -9366,19 +9382,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeploymentSync(CreateDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeploymentAsync(CreateDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeploymentAsync(CreateDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResourceDefinition asynchronously, invoking a callback when done
 -- @param CreateResourceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResourceDefinitionAsync(CreateResourceDefinitionRequest, cb)
 	assert(CreateResourceDefinitionRequest, "You must provide a CreateResourceDefinitionRequest")
 	local headers = {
@@ -9401,19 +9418,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResourceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResourceDefinitionSync(CreateResourceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResourceDefinitionAsync(CreateResourceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResourceDefinitionAsync(CreateResourceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSubscriptionDefinitions asynchronously, invoking a callback when done
 -- @param ListSubscriptionDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSubscriptionDefinitionsAsync(ListSubscriptionDefinitionsRequest, cb)
 	assert(ListSubscriptionDefinitionsRequest, "You must provide a ListSubscriptionDefinitionsRequest")
 	local headers = {
@@ -9436,19 +9454,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSubscriptionDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSubscriptionDefinitionsSync(ListSubscriptionDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSubscriptionDefinitionsAsync(ListSubscriptionDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSubscriptionDefinitionsAsync(ListSubscriptionDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFunctionDefinitionVersions asynchronously, invoking a callback when done
 -- @param ListFunctionDefinitionVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFunctionDefinitionVersionsAsync(ListFunctionDefinitionVersionsRequest, cb)
 	assert(ListFunctionDefinitionVersionsRequest, "You must provide a ListFunctionDefinitionVersionsRequest")
 	local headers = {
@@ -9471,19 +9490,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFunctionDefinitionVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFunctionDefinitionVersionsSync(ListFunctionDefinitionVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFunctionDefinitionVersionsAsync(ListFunctionDefinitionVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFunctionDefinitionVersionsAsync(ListFunctionDefinitionVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDeviceDefinition asynchronously, invoking a callback when done
 -- @param UpdateDeviceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDeviceDefinitionAsync(UpdateDeviceDefinitionRequest, cb)
 	assert(UpdateDeviceDefinitionRequest, "You must provide a UpdateDeviceDefinitionRequest")
 	local headers = {
@@ -9506,19 +9526,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDeviceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDeviceDefinitionSync(UpdateDeviceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDeviceDefinitionAsync(UpdateDeviceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDeviceDefinitionAsync(UpdateDeviceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartBulkDeployment asynchronously, invoking a callback when done
 -- @param StartBulkDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartBulkDeploymentAsync(StartBulkDeploymentRequest, cb)
 	assert(StartBulkDeploymentRequest, "You must provide a StartBulkDeploymentRequest")
 	local headers = {
@@ -9541,19 +9562,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartBulkDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartBulkDeploymentSync(StartBulkDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartBulkDeploymentAsync(StartBulkDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartBulkDeploymentAsync(StartBulkDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLoggerDefinitionVersions asynchronously, invoking a callback when done
 -- @param ListLoggerDefinitionVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLoggerDefinitionVersionsAsync(ListLoggerDefinitionVersionsRequest, cb)
 	assert(ListLoggerDefinitionVersionsRequest, "You must provide a ListLoggerDefinitionVersionsRequest")
 	local headers = {
@@ -9576,19 +9598,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLoggerDefinitionVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLoggerDefinitionVersionsSync(ListLoggerDefinitionVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLoggerDefinitionVersionsAsync(ListLoggerDefinitionVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLoggerDefinitionVersionsAsync(ListLoggerDefinitionVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeviceDefinition asynchronously, invoking a callback when done
 -- @param CreateDeviceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeviceDefinitionAsync(CreateDeviceDefinitionRequest, cb)
 	assert(CreateDeviceDefinitionRequest, "You must provide a CreateDeviceDefinitionRequest")
 	local headers = {
@@ -9611,19 +9634,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeviceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeviceDefinitionSync(CreateDeviceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeviceDefinitionAsync(CreateDeviceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeviceDefinitionAsync(CreateDeviceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateServiceRoleToAccount asynchronously, invoking a callback when done
 -- @param AssociateServiceRoleToAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateServiceRoleToAccountAsync(AssociateServiceRoleToAccountRequest, cb)
 	assert(AssociateServiceRoleToAccountRequest, "You must provide a AssociateServiceRoleToAccountRequest")
 	local headers = {
@@ -9646,19 +9670,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateServiceRoleToAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateServiceRoleToAccountSync(AssociateServiceRoleToAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateServiceRoleToAccountAsync(AssociateServiceRoleToAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateServiceRoleToAccountAsync(AssociateServiceRoleToAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGroup asynchronously, invoking a callback when done
 -- @param DeleteGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGroupAsync(DeleteGroupRequest, cb)
 	assert(DeleteGroupRequest, "You must provide a DeleteGroupRequest")
 	local headers = {
@@ -9681,19 +9706,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGroupSync(DeleteGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeviceDefinitionVersion asynchronously, invoking a callback when done
 -- @param CreateDeviceDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeviceDefinitionVersionAsync(CreateDeviceDefinitionVersionRequest, cb)
 	assert(CreateDeviceDefinitionVersionRequest, "You must provide a CreateDeviceDefinitionVersionRequest")
 	local headers = {
@@ -9716,19 +9742,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeviceDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeviceDefinitionVersionSync(CreateDeviceDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeviceDefinitionVersionAsync(CreateDeviceDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeviceDefinitionVersionAsync(CreateDeviceDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceDefinitions asynchronously, invoking a callback when done
 -- @param ListResourceDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceDefinitionsAsync(ListResourceDefinitionsRequest, cb)
 	assert(ListResourceDefinitionsRequest, "You must provide a ListResourceDefinitionsRequest")
 	local headers = {
@@ -9751,19 +9778,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceDefinitionsSync(ListResourceDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceDefinitionsAsync(ListResourceDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceDefinitionsAsync(ListResourceDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCoreDefinition asynchronously, invoking a callback when done
 -- @param GetCoreDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCoreDefinitionAsync(GetCoreDefinitionRequest, cb)
 	assert(GetCoreDefinitionRequest, "You must provide a GetCoreDefinitionRequest")
 	local headers = {
@@ -9786,19 +9814,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCoreDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCoreDefinitionSync(GetCoreDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCoreDefinitionAsync(GetCoreDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCoreDefinitionAsync(GetCoreDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBulkDeploymentStatus asynchronously, invoking a callback when done
 -- @param GetBulkDeploymentStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBulkDeploymentStatusAsync(GetBulkDeploymentStatusRequest, cb)
 	assert(GetBulkDeploymentStatusRequest, "You must provide a GetBulkDeploymentStatusRequest")
 	local headers = {
@@ -9821,19 +9850,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBulkDeploymentStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBulkDeploymentStatusSync(GetBulkDeploymentStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBulkDeploymentStatusAsync(GetBulkDeploymentStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBulkDeploymentStatusAsync(GetBulkDeploymentStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroupCertificateAuthorities asynchronously, invoking a callback when done
 -- @param ListGroupCertificateAuthoritiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupCertificateAuthoritiesAsync(ListGroupCertificateAuthoritiesRequest, cb)
 	assert(ListGroupCertificateAuthoritiesRequest, "You must provide a ListGroupCertificateAuthoritiesRequest")
 	local headers = {
@@ -9856,19 +9886,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupCertificateAuthoritiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupCertificateAuthoritiesSync(ListGroupCertificateAuthoritiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupCertificateAuthoritiesAsync(ListGroupCertificateAuthoritiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupCertificateAuthoritiesAsync(ListGroupCertificateAuthoritiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResourceDefinition asynchronously, invoking a callback when done
 -- @param DeleteResourceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourceDefinitionAsync(DeleteResourceDefinitionRequest, cb)
 	assert(DeleteResourceDefinitionRequest, "You must provide a DeleteResourceDefinitionRequest")
 	local headers = {
@@ -9891,19 +9922,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourceDefinitionSync(DeleteResourceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourceDefinitionAsync(DeleteResourceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourceDefinitionAsync(DeleteResourceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopBulkDeployment asynchronously, invoking a callback when done
 -- @param StopBulkDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopBulkDeploymentAsync(StopBulkDeploymentRequest, cb)
 	assert(StopBulkDeploymentRequest, "You must provide a StopBulkDeploymentRequest")
 	local headers = {
@@ -9926,19 +9958,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopBulkDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopBulkDeploymentSync(StopBulkDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopBulkDeploymentAsync(StopBulkDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopBulkDeploymentAsync(StopBulkDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSubscriptionDefinitionVersion asynchronously, invoking a callback when done
 -- @param GetSubscriptionDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSubscriptionDefinitionVersionAsync(GetSubscriptionDefinitionVersionRequest, cb)
 	assert(GetSubscriptionDefinitionVersionRequest, "You must provide a GetSubscriptionDefinitionVersionRequest")
 	local headers = {
@@ -9961,19 +9994,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSubscriptionDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSubscriptionDefinitionVersionSync(GetSubscriptionDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSubscriptionDefinitionVersionAsync(GetSubscriptionDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSubscriptionDefinitionVersionAsync(GetSubscriptionDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFunctionDefinition asynchronously, invoking a callback when done
 -- @param GetFunctionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFunctionDefinitionAsync(GetFunctionDefinitionRequest, cb)
 	assert(GetFunctionDefinitionRequest, "You must provide a GetFunctionDefinitionRequest")
 	local headers = {
@@ -9996,19 +10030,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFunctionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFunctionDefinitionSync(GetFunctionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFunctionDefinitionAsync(GetFunctionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFunctionDefinitionAsync(GetFunctionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetDeployments asynchronously, invoking a callback when done
 -- @param ResetDeploymentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetDeploymentsAsync(ResetDeploymentsRequest, cb)
 	assert(ResetDeploymentsRequest, "You must provide a ResetDeploymentsRequest")
 	local headers = {
@@ -10031,19 +10066,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetDeploymentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetDeploymentsSync(ResetDeploymentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetDeploymentsAsync(ResetDeploymentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetDeploymentsAsync(ResetDeploymentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateResourceDefinition asynchronously, invoking a callback when done
 -- @param UpdateResourceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateResourceDefinitionAsync(UpdateResourceDefinitionRequest, cb)
 	assert(UpdateResourceDefinitionRequest, "You must provide a UpdateResourceDefinitionRequest")
 	local headers = {
@@ -10066,19 +10102,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateResourceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateResourceDefinitionSync(UpdateResourceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateResourceDefinitionAsync(UpdateResourceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateResourceDefinitionAsync(UpdateResourceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroup asynchronously, invoking a callback when done
 -- @param GetGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupAsync(GetGroupRequest, cb)
 	assert(GetGroupRequest, "You must provide a GetGroupRequest")
 	local headers = {
@@ -10101,19 +10138,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupSync(GetGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupAsync(GetGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupAsync(GetGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResourceDefinition asynchronously, invoking a callback when done
 -- @param GetResourceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourceDefinitionAsync(GetResourceDefinitionRequest, cb)
 	assert(GetResourceDefinitionRequest, "You must provide a GetResourceDefinitionRequest")
 	local headers = {
@@ -10136,19 +10174,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourceDefinitionSync(GetResourceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourceDefinitionAsync(GetResourceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourceDefinitionAsync(GetResourceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCoreDefinition asynchronously, invoking a callback when done
 -- @param DeleteCoreDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCoreDefinitionAsync(DeleteCoreDefinitionRequest, cb)
 	assert(DeleteCoreDefinitionRequest, "You must provide a DeleteCoreDefinitionRequest")
 	local headers = {
@@ -10171,19 +10210,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCoreDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCoreDefinitionSync(DeleteCoreDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCoreDefinitionAsync(DeleteCoreDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCoreDefinitionAsync(DeleteCoreDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGroupVersion asynchronously, invoking a callback when done
 -- @param CreateGroupVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGroupVersionAsync(CreateGroupVersionRequest, cb)
 	assert(CreateGroupVersionRequest, "You must provide a CreateGroupVersionRequest")
 	local headers = {
@@ -10206,19 +10246,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGroupVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGroupVersionSync(CreateGroupVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGroupVersionAsync(CreateGroupVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGroupVersionAsync(CreateGroupVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLoggerDefinitionVersion asynchronously, invoking a callback when done
 -- @param CreateLoggerDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLoggerDefinitionVersionAsync(CreateLoggerDefinitionVersionRequest, cb)
 	assert(CreateLoggerDefinitionVersionRequest, "You must provide a CreateLoggerDefinitionVersionRequest")
 	local headers = {
@@ -10241,19 +10282,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLoggerDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLoggerDefinitionVersionSync(CreateLoggerDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLoggerDefinitionVersionAsync(CreateLoggerDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLoggerDefinitionVersionAsync(CreateLoggerDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeviceDefinition asynchronously, invoking a callback when done
 -- @param GetDeviceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeviceDefinitionAsync(GetDeviceDefinitionRequest, cb)
 	assert(GetDeviceDefinitionRequest, "You must provide a GetDeviceDefinitionRequest")
 	local headers = {
@@ -10276,19 +10318,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeviceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeviceDefinitionSync(GetDeviceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeviceDefinitionAsync(GetDeviceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeviceDefinitionAsync(GetDeviceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSubscriptionDefinition asynchronously, invoking a callback when done
 -- @param UpdateSubscriptionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSubscriptionDefinitionAsync(UpdateSubscriptionDefinitionRequest, cb)
 	assert(UpdateSubscriptionDefinitionRequest, "You must provide a UpdateSubscriptionDefinitionRequest")
 	local headers = {
@@ -10311,19 +10354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSubscriptionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSubscriptionDefinitionSync(UpdateSubscriptionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSubscriptionDefinitionAsync(UpdateSubscriptionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSubscriptionDefinitionAsync(UpdateSubscriptionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFunctionDefinitionVersion asynchronously, invoking a callback when done
 -- @param GetFunctionDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFunctionDefinitionVersionAsync(GetFunctionDefinitionVersionRequest, cb)
 	assert(GetFunctionDefinitionVersionRequest, "You must provide a GetFunctionDefinitionVersionRequest")
 	local headers = {
@@ -10346,19 +10390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFunctionDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFunctionDefinitionVersionSync(GetFunctionDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFunctionDefinitionVersionAsync(GetFunctionDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFunctionDefinitionVersionAsync(GetFunctionDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceDefinitionVersions asynchronously, invoking a callback when done
 -- @param ListResourceDefinitionVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceDefinitionVersionsAsync(ListResourceDefinitionVersionsRequest, cb)
 	assert(ListResourceDefinitionVersionsRequest, "You must provide a ListResourceDefinitionVersionsRequest")
 	local headers = {
@@ -10381,19 +10426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceDefinitionVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceDefinitionVersionsSync(ListResourceDefinitionVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceDefinitionVersionsAsync(ListResourceDefinitionVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceDefinitionVersionsAsync(ListResourceDefinitionVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoggerDefinitionVersion asynchronously, invoking a callback when done
 -- @param GetLoggerDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoggerDefinitionVersionAsync(GetLoggerDefinitionVersionRequest, cb)
 	assert(GetLoggerDefinitionVersionRequest, "You must provide a GetLoggerDefinitionVersionRequest")
 	local headers = {
@@ -10416,19 +10462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoggerDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoggerDefinitionVersionSync(GetLoggerDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoggerDefinitionVersionAsync(GetLoggerDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoggerDefinitionVersionAsync(GetLoggerDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCoreDefinitionVersion asynchronously, invoking a callback when done
 -- @param CreateCoreDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCoreDefinitionVersionAsync(CreateCoreDefinitionVersionRequest, cb)
 	assert(CreateCoreDefinitionVersionRequest, "You must provide a CreateCoreDefinitionVersionRequest")
 	local headers = {
@@ -10451,19 +10498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCoreDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCoreDefinitionVersionSync(CreateCoreDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCoreDefinitionVersionAsync(CreateCoreDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCoreDefinitionVersionAsync(CreateCoreDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCoreDefinitionVersions asynchronously, invoking a callback when done
 -- @param ListCoreDefinitionVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCoreDefinitionVersionsAsync(ListCoreDefinitionVersionsRequest, cb)
 	assert(ListCoreDefinitionVersionsRequest, "You must provide a ListCoreDefinitionVersionsRequest")
 	local headers = {
@@ -10486,19 +10534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCoreDefinitionVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCoreDefinitionVersionsSync(ListCoreDefinitionVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCoreDefinitionVersionsAsync(ListCoreDefinitionVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCoreDefinitionVersionsAsync(ListCoreDefinitionVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGroupCertificateConfiguration asynchronously, invoking a callback when done
 -- @param UpdateGroupCertificateConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGroupCertificateConfigurationAsync(UpdateGroupCertificateConfigurationRequest, cb)
 	assert(UpdateGroupCertificateConfigurationRequest, "You must provide a UpdateGroupCertificateConfigurationRequest")
 	local headers = {
@@ -10521,19 +10570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGroupCertificateConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGroupCertificateConfigurationSync(UpdateGroupCertificateConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGroupCertificateConfigurationAsync(UpdateGroupCertificateConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGroupCertificateConfigurationAsync(UpdateGroupCertificateConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGroupCertificateAuthority asynchronously, invoking a callback when done
 -- @param CreateGroupCertificateAuthorityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGroupCertificateAuthorityAsync(CreateGroupCertificateAuthorityRequest, cb)
 	assert(CreateGroupCertificateAuthorityRequest, "You must provide a CreateGroupCertificateAuthorityRequest")
 	local headers = {
@@ -10556,19 +10606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGroupCertificateAuthorityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGroupCertificateAuthoritySync(CreateGroupCertificateAuthorityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGroupCertificateAuthorityAsync(CreateGroupCertificateAuthorityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGroupCertificateAuthorityAsync(CreateGroupCertificateAuthorityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetServiceRoleForAccount asynchronously, invoking a callback when done
 -- @param GetServiceRoleForAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetServiceRoleForAccountAsync(GetServiceRoleForAccountRequest, cb)
 	assert(GetServiceRoleForAccountRequest, "You must provide a GetServiceRoleForAccountRequest")
 	local headers = {
@@ -10591,19 +10642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetServiceRoleForAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetServiceRoleForAccountSync(GetServiceRoleForAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetServiceRoleForAccountAsync(GetServiceRoleForAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetServiceRoleForAccountAsync(GetServiceRoleForAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConnectivityInfo asynchronously, invoking a callback when done
 -- @param UpdateConnectivityInfoRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConnectivityInfoAsync(UpdateConnectivityInfoRequest, cb)
 	assert(UpdateConnectivityInfoRequest, "You must provide a UpdateConnectivityInfoRequest")
 	local headers = {
@@ -10626,19 +10678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConnectivityInfoRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConnectivityInfoSync(UpdateConnectivityInfoRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConnectivityInfoAsync(UpdateConnectivityInfoRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConnectivityInfoAsync(UpdateConnectivityInfoRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateRoleFromGroup asynchronously, invoking a callback when done
 -- @param DisassociateRoleFromGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateRoleFromGroupAsync(DisassociateRoleFromGroupRequest, cb)
 	assert(DisassociateRoleFromGroupRequest, "You must provide a DisassociateRoleFromGroupRequest")
 	local headers = {
@@ -10661,19 +10714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateRoleFromGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateRoleFromGroupSync(DisassociateRoleFromGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateRoleFromGroupAsync(DisassociateRoleFromGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateRoleFromGroupAsync(DisassociateRoleFromGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSoftwareUpdateJob asynchronously, invoking a callback when done
 -- @param CreateSoftwareUpdateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSoftwareUpdateJobAsync(CreateSoftwareUpdateJobRequest, cb)
 	assert(CreateSoftwareUpdateJobRequest, "You must provide a CreateSoftwareUpdateJobRequest")
 	local headers = {
@@ -10696,19 +10750,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSoftwareUpdateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSoftwareUpdateJobSync(CreateSoftwareUpdateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSoftwareUpdateJobAsync(CreateSoftwareUpdateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSoftwareUpdateJobAsync(CreateSoftwareUpdateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLoggerDefinition asynchronously, invoking a callback when done
 -- @param CreateLoggerDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLoggerDefinitionAsync(CreateLoggerDefinitionRequest, cb)
 	assert(CreateLoggerDefinitionRequest, "You must provide a CreateLoggerDefinitionRequest")
 	local headers = {
@@ -10731,19 +10786,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLoggerDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLoggerDefinitionSync(CreateLoggerDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLoggerDefinitionAsync(CreateLoggerDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLoggerDefinitionAsync(CreateLoggerDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFunctionDefinitions asynchronously, invoking a callback when done
 -- @param ListFunctionDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFunctionDefinitionsAsync(ListFunctionDefinitionsRequest, cb)
 	assert(ListFunctionDefinitionsRequest, "You must provide a ListFunctionDefinitionsRequest")
 	local headers = {
@@ -10766,19 +10822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFunctionDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFunctionDefinitionsSync(ListFunctionDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFunctionDefinitionsAsync(ListFunctionDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFunctionDefinitionsAsync(ListFunctionDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResourceDefinitionVersion asynchronously, invoking a callback when done
 -- @param GetResourceDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourceDefinitionVersionAsync(GetResourceDefinitionVersionRequest, cb)
 	assert(GetResourceDefinitionVersionRequest, "You must provide a GetResourceDefinitionVersionRequest")
 	local headers = {
@@ -10801,19 +10858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourceDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourceDefinitionVersionSync(GetResourceDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourceDefinitionVersionAsync(GetResourceDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourceDefinitionVersionAsync(GetResourceDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSubscriptionDefinition asynchronously, invoking a callback when done
 -- @param DeleteSubscriptionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSubscriptionDefinitionAsync(DeleteSubscriptionDefinitionRequest, cb)
 	assert(DeleteSubscriptionDefinitionRequest, "You must provide a DeleteSubscriptionDefinitionRequest")
 	local headers = {
@@ -10836,19 +10894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSubscriptionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSubscriptionDefinitionSync(DeleteSubscriptionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSubscriptionDefinitionAsync(DeleteSubscriptionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSubscriptionDefinitionAsync(DeleteSubscriptionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFunctionDefinitionVersion asynchronously, invoking a callback when done
 -- @param CreateFunctionDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFunctionDefinitionVersionAsync(CreateFunctionDefinitionVersionRequest, cb)
 	assert(CreateFunctionDefinitionVersionRequest, "You must provide a CreateFunctionDefinitionVersionRequest")
 	local headers = {
@@ -10871,19 +10930,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFunctionDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFunctionDefinitionVersionSync(CreateFunctionDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFunctionDefinitionVersionAsync(CreateFunctionDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFunctionDefinitionVersionAsync(CreateFunctionDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeployments asynchronously, invoking a callback when done
 -- @param ListDeploymentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeploymentsAsync(ListDeploymentsRequest, cb)
 	assert(ListDeploymentsRequest, "You must provide a ListDeploymentsRequest")
 	local headers = {
@@ -10906,19 +10966,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeploymentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeploymentsSync(ListDeploymentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeploymentsAsync(ListDeploymentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeploymentsAsync(ListDeploymentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroupVersion asynchronously, invoking a callback when done
 -- @param GetGroupVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupVersionAsync(GetGroupVersionRequest, cb)
 	assert(GetGroupVersionRequest, "You must provide a GetGroupVersionRequest")
 	local headers = {
@@ -10941,19 +11002,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupVersionSync(GetGroupVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupVersionAsync(GetGroupVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupVersionAsync(GetGroupVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateServiceRoleFromAccount asynchronously, invoking a callback when done
 -- @param DisassociateServiceRoleFromAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateServiceRoleFromAccountAsync(DisassociateServiceRoleFromAccountRequest, cb)
 	assert(DisassociateServiceRoleFromAccountRequest, "You must provide a DisassociateServiceRoleFromAccountRequest")
 	local headers = {
@@ -10976,19 +11038,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateServiceRoleFromAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateServiceRoleFromAccountSync(DisassociateServiceRoleFromAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateServiceRoleFromAccountAsync(DisassociateServiceRoleFromAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateServiceRoleFromAccountAsync(DisassociateServiceRoleFromAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCoreDefinitionVersion asynchronously, invoking a callback when done
 -- @param GetCoreDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCoreDefinitionVersionAsync(GetCoreDefinitionVersionRequest, cb)
 	assert(GetCoreDefinitionVersionRequest, "You must provide a GetCoreDefinitionVersionRequest")
 	local headers = {
@@ -11011,19 +11074,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCoreDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCoreDefinitionVersionSync(GetCoreDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCoreDefinitionVersionAsync(GetCoreDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCoreDefinitionVersionAsync(GetCoreDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeviceDefinitions asynchronously, invoking a callback when done
 -- @param ListDeviceDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeviceDefinitionsAsync(ListDeviceDefinitionsRequest, cb)
 	assert(ListDeviceDefinitionsRequest, "You must provide a ListDeviceDefinitionsRequest")
 	local headers = {
@@ -11046,19 +11110,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeviceDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeviceDefinitionsSync(ListDeviceDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeviceDefinitionsAsync(ListDeviceDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeviceDefinitionsAsync(ListDeviceDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroupCertificateConfiguration asynchronously, invoking a callback when done
 -- @param GetGroupCertificateConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupCertificateConfigurationAsync(GetGroupCertificateConfigurationRequest, cb)
 	assert(GetGroupCertificateConfigurationRequest, "You must provide a GetGroupCertificateConfigurationRequest")
 	local headers = {
@@ -11081,19 +11146,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupCertificateConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupCertificateConfigurationSync(GetGroupCertificateConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupCertificateConfigurationAsync(GetGroupCertificateConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupCertificateConfigurationAsync(GetGroupCertificateConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDeviceDefinition asynchronously, invoking a callback when done
 -- @param DeleteDeviceDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDeviceDefinitionAsync(DeleteDeviceDefinitionRequest, cb)
 	assert(DeleteDeviceDefinitionRequest, "You must provide a DeleteDeviceDefinitionRequest")
 	local headers = {
@@ -11116,19 +11182,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDeviceDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDeviceDefinitionSync(DeleteDeviceDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDeviceDefinitionAsync(DeleteDeviceDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDeviceDefinitionAsync(DeleteDeviceDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAssociatedRole asynchronously, invoking a callback when done
 -- @param GetAssociatedRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAssociatedRoleAsync(GetAssociatedRoleRequest, cb)
 	assert(GetAssociatedRoleRequest, "You must provide a GetAssociatedRoleRequest")
 	local headers = {
@@ -11151,19 +11218,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAssociatedRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAssociatedRoleSync(GetAssociatedRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAssociatedRoleAsync(GetAssociatedRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAssociatedRoleAsync(GetAssociatedRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateLoggerDefinition asynchronously, invoking a callback when done
 -- @param UpdateLoggerDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateLoggerDefinitionAsync(UpdateLoggerDefinitionRequest, cb)
 	assert(UpdateLoggerDefinitionRequest, "You must provide a UpdateLoggerDefinitionRequest")
 	local headers = {
@@ -11186,19 +11254,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateLoggerDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateLoggerDefinitionSync(UpdateLoggerDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateLoggerDefinitionAsync(UpdateLoggerDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateLoggerDefinitionAsync(UpdateLoggerDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFunctionDefinition asynchronously, invoking a callback when done
 -- @param CreateFunctionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFunctionDefinitionAsync(CreateFunctionDefinitionRequest, cb)
 	assert(CreateFunctionDefinitionRequest, "You must provide a CreateFunctionDefinitionRequest")
 	local headers = {
@@ -11221,19 +11290,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFunctionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFunctionDefinitionSync(CreateFunctionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFunctionDefinitionAsync(CreateFunctionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFunctionDefinitionAsync(CreateFunctionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoggerDefinition asynchronously, invoking a callback when done
 -- @param GetLoggerDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoggerDefinitionAsync(GetLoggerDefinitionRequest, cb)
 	assert(GetLoggerDefinitionRequest, "You must provide a GetLoggerDefinitionRequest")
 	local headers = {
@@ -11256,19 +11326,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoggerDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoggerDefinitionSync(GetLoggerDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoggerDefinitionAsync(GetLoggerDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoggerDefinitionAsync(GetLoggerDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFunctionDefinition asynchronously, invoking a callback when done
 -- @param UpdateFunctionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFunctionDefinitionAsync(UpdateFunctionDefinitionRequest, cb)
 	assert(UpdateFunctionDefinitionRequest, "You must provide a UpdateFunctionDefinitionRequest")
 	local headers = {
@@ -11291,19 +11362,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFunctionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFunctionDefinitionSync(UpdateFunctionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFunctionDefinitionAsync(UpdateFunctionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFunctionDefinitionAsync(UpdateFunctionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLoggerDefinitions asynchronously, invoking a callback when done
 -- @param ListLoggerDefinitionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLoggerDefinitionsAsync(ListLoggerDefinitionsRequest, cb)
 	assert(ListLoggerDefinitionsRequest, "You must provide a ListLoggerDefinitionsRequest")
 	local headers = {
@@ -11326,19 +11398,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLoggerDefinitionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLoggerDefinitionsSync(ListLoggerDefinitionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLoggerDefinitionsAsync(ListLoggerDefinitionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLoggerDefinitionsAsync(ListLoggerDefinitionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSubscriptionDefinition asynchronously, invoking a callback when done
 -- @param CreateSubscriptionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSubscriptionDefinitionAsync(CreateSubscriptionDefinitionRequest, cb)
 	assert(CreateSubscriptionDefinitionRequest, "You must provide a CreateSubscriptionDefinitionRequest")
 	local headers = {
@@ -11361,19 +11434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSubscriptionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSubscriptionDefinitionSync(CreateSubscriptionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSubscriptionDefinitionAsync(CreateSubscriptionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSubscriptionDefinitionAsync(CreateSubscriptionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConnectivityInfo asynchronously, invoking a callback when done
 -- @param GetConnectivityInfoRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConnectivityInfoAsync(GetConnectivityInfoRequest, cb)
 	assert(GetConnectivityInfoRequest, "You must provide a GetConnectivityInfoRequest")
 	local headers = {
@@ -11396,19 +11470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConnectivityInfoRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConnectivityInfoSync(GetConnectivityInfoRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConnectivityInfoAsync(GetConnectivityInfoRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConnectivityInfoAsync(GetConnectivityInfoRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroups asynchronously, invoking a callback when done
 -- @param ListGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupsAsync(ListGroupsRequest, cb)
 	assert(ListGroupsRequest, "You must provide a ListGroupsRequest")
 	local headers = {
@@ -11431,19 +11506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupsSync(ListGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupsAsync(ListGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupsAsync(ListGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLoggerDefinition asynchronously, invoking a callback when done
 -- @param DeleteLoggerDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLoggerDefinitionAsync(DeleteLoggerDefinitionRequest, cb)
 	assert(DeleteLoggerDefinitionRequest, "You must provide a DeleteLoggerDefinitionRequest")
 	local headers = {
@@ -11466,19 +11542,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLoggerDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLoggerDefinitionSync(DeleteLoggerDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLoggerDefinitionAsync(DeleteLoggerDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLoggerDefinitionAsync(DeleteLoggerDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFunctionDefinition asynchronously, invoking a callback when done
 -- @param DeleteFunctionDefinitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFunctionDefinitionAsync(DeleteFunctionDefinitionRequest, cb)
 	assert(DeleteFunctionDefinitionRequest, "You must provide a DeleteFunctionDefinitionRequest")
 	local headers = {
@@ -11501,19 +11578,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFunctionDefinitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFunctionDefinitionSync(DeleteFunctionDefinitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFunctionDefinitionAsync(DeleteFunctionDefinitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFunctionDefinitionAsync(DeleteFunctionDefinitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSubscriptionDefinitionVersion asynchronously, invoking a callback when done
 -- @param CreateSubscriptionDefinitionVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSubscriptionDefinitionVersionAsync(CreateSubscriptionDefinitionVersionRequest, cb)
 	assert(CreateSubscriptionDefinitionVersionRequest, "You must provide a CreateSubscriptionDefinitionVersionRequest")
 	local headers = {
@@ -11536,12 +11614,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSubscriptionDefinitionVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSubscriptionDefinitionVersionSync(CreateSubscriptionDefinitionVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSubscriptionDefinitionVersionAsync(CreateSubscriptionDefinitionVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSubscriptionDefinitionVersionAsync(CreateSubscriptionDefinitionVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/guardduty.lua
+++ b/aws-sdk/guardduty.lua
@@ -6066,7 +6066,7 @@ end
 --
 --- Call GetFindings asynchronously, invoking a callback when done
 -- @param GetFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFindingsAsync(GetFindingsRequest, cb)
 	assert(GetFindingsRequest, "You must provide a GetFindingsRequest")
 	local headers = {
@@ -6089,19 +6089,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFindingsSync(GetFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFindingsAsync(GetFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFindingsAsync(GetFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIPSets asynchronously, invoking a callback when done
 -- @param ListIPSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIPSetsAsync(ListIPSetsRequest, cb)
 	assert(ListIPSetsRequest, "You must provide a ListIPSetsRequest")
 	local headers = {
@@ -6124,19 +6125,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIPSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIPSetsSync(ListIPSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIPSetsAsync(ListIPSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIPSetsAsync(ListIPSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDetector asynchronously, invoking a callback when done
 -- @param UpdateDetectorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDetectorAsync(UpdateDetectorRequest, cb)
 	assert(UpdateDetectorRequest, "You must provide a UpdateDetectorRequest")
 	local headers = {
@@ -6159,19 +6161,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDetectorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDetectorSync(UpdateDetectorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDetectorAsync(UpdateDetectorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDetectorAsync(UpdateDetectorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetThreatIntelSet asynchronously, invoking a callback when done
 -- @param GetThreatIntelSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetThreatIntelSetAsync(GetThreatIntelSetRequest, cb)
 	assert(GetThreatIntelSetRequest, "You must provide a GetThreatIntelSetRequest")
 	local headers = {
@@ -6194,19 +6197,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetThreatIntelSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetThreatIntelSetSync(GetThreatIntelSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetThreatIntelSetAsync(GetThreatIntelSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetThreatIntelSetAsync(GetThreatIntelSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateThreatIntelSet asynchronously, invoking a callback when done
 -- @param UpdateThreatIntelSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateThreatIntelSetAsync(UpdateThreatIntelSetRequest, cb)
 	assert(UpdateThreatIntelSetRequest, "You must provide a UpdateThreatIntelSetRequest")
 	local headers = {
@@ -6229,19 +6233,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateThreatIntelSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateThreatIntelSetSync(UpdateThreatIntelSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateThreatIntelSetAsync(UpdateThreatIntelSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateThreatIntelSetAsync(UpdateThreatIntelSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDetectors asynchronously, invoking a callback when done
 -- @param ListDetectorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDetectorsAsync(ListDetectorsRequest, cb)
 	assert(ListDetectorsRequest, "You must provide a ListDetectorsRequest")
 	local headers = {
@@ -6264,19 +6269,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDetectorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDetectorsSync(ListDetectorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDetectorsAsync(ListDetectorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDetectorsAsync(ListDetectorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInvitations asynchronously, invoking a callback when done
 -- @param ListInvitationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInvitationsAsync(ListInvitationsRequest, cb)
 	assert(ListInvitationsRequest, "You must provide a ListInvitationsRequest")
 	local headers = {
@@ -6299,19 +6305,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInvitationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInvitationsSync(ListInvitationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInvitationsAsync(ListInvitationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInvitationsAsync(ListInvitationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInvitationsCount asynchronously, invoking a callback when done
 -- @param GetInvitationsCountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInvitationsCountAsync(GetInvitationsCountRequest, cb)
 	assert(GetInvitationsCountRequest, "You must provide a GetInvitationsCountRequest")
 	local headers = {
@@ -6334,19 +6341,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInvitationsCountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInvitationsCountSync(GetInvitationsCountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInvitationsCountAsync(GetInvitationsCountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInvitationsCountAsync(GetInvitationsCountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateMembers asynchronously, invoking a callback when done
 -- @param DisassociateMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateMembersAsync(DisassociateMembersRequest, cb)
 	assert(DisassociateMembersRequest, "You must provide a DisassociateMembersRequest")
 	local headers = {
@@ -6369,19 +6377,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateMembersSync(DisassociateMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateMembersAsync(DisassociateMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateMembersAsync(DisassociateMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFindingsFeedback asynchronously, invoking a callback when done
 -- @param UpdateFindingsFeedbackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFindingsFeedbackAsync(UpdateFindingsFeedbackRequest, cb)
 	assert(UpdateFindingsFeedbackRequest, "You must provide a UpdateFindingsFeedbackRequest")
 	local headers = {
@@ -6404,19 +6413,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFindingsFeedbackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFindingsFeedbackSync(UpdateFindingsFeedbackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFindingsFeedbackAsync(UpdateFindingsFeedbackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFindingsFeedbackAsync(UpdateFindingsFeedbackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFilters asynchronously, invoking a callback when done
 -- @param ListFiltersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFiltersAsync(ListFiltersRequest, cb)
 	assert(ListFiltersRequest, "You must provide a ListFiltersRequest")
 	local headers = {
@@ -6439,19 +6449,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFiltersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFiltersSync(ListFiltersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFiltersAsync(ListFiltersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFiltersAsync(ListFiltersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMasterAccount asynchronously, invoking a callback when done
 -- @param GetMasterAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMasterAccountAsync(GetMasterAccountRequest, cb)
 	assert(GetMasterAccountRequest, "You must provide a GetMasterAccountRequest")
 	local headers = {
@@ -6474,19 +6485,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMasterAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMasterAccountSync(GetMasterAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMasterAccountAsync(GetMasterAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMasterAccountAsync(GetMasterAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ArchiveFindings asynchronously, invoking a callback when done
 -- @param ArchiveFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ArchiveFindingsAsync(ArchiveFindingsRequest, cb)
 	assert(ArchiveFindingsRequest, "You must provide a ArchiveFindingsRequest")
 	local headers = {
@@ -6509,19 +6521,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ArchiveFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ArchiveFindingsSync(ArchiveFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ArchiveFindingsAsync(ArchiveFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ArchiveFindingsAsync(ArchiveFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIPSet asynchronously, invoking a callback when done
 -- @param GetIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIPSetAsync(GetIPSetRequest, cb)
 	assert(GetIPSetRequest, "You must provide a GetIPSetRequest")
 	local headers = {
@@ -6544,19 +6557,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIPSetSync(GetIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIPSetAsync(GetIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIPSetAsync(GetIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateFromMasterAccount asynchronously, invoking a callback when done
 -- @param DisassociateFromMasterAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateFromMasterAccountAsync(DisassociateFromMasterAccountRequest, cb)
 	assert(DisassociateFromMasterAccountRequest, "You must provide a DisassociateFromMasterAccountRequest")
 	local headers = {
@@ -6579,19 +6593,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateFromMasterAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateFromMasterAccountSync(DisassociateFromMasterAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateFromMasterAccountAsync(DisassociateFromMasterAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateFromMasterAccountAsync(DisassociateFromMasterAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMembers asynchronously, invoking a callback when done
 -- @param GetMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMembersAsync(GetMembersRequest, cb)
 	assert(GetMembersRequest, "You must provide a GetMembersRequest")
 	local headers = {
@@ -6614,19 +6629,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMembersSync(GetMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMembersAsync(GetMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMembersAsync(GetMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFindings asynchronously, invoking a callback when done
 -- @param ListFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFindingsAsync(ListFindingsRequest, cb)
 	assert(ListFindingsRequest, "You must provide a ListFindingsRequest")
 	local headers = {
@@ -6649,19 +6665,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFindingsSync(ListFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFindingsAsync(ListFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFindingsAsync(ListFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartMonitoringMembers asynchronously, invoking a callback when done
 -- @param StartMonitoringMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartMonitoringMembersAsync(StartMonitoringMembersRequest, cb)
 	assert(StartMonitoringMembersRequest, "You must provide a StartMonitoringMembersRequest")
 	local headers = {
@@ -6684,19 +6701,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartMonitoringMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartMonitoringMembersSync(StartMonitoringMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartMonitoringMembersAsync(StartMonitoringMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartMonitoringMembersAsync(StartMonitoringMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFilter asynchronously, invoking a callback when done
 -- @param CreateFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFilterAsync(CreateFilterRequest, cb)
 	assert(CreateFilterRequest, "You must provide a CreateFilterRequest")
 	local headers = {
@@ -6719,19 +6737,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFilterSync(CreateFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFilterAsync(CreateFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFilterAsync(CreateFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDetector asynchronously, invoking a callback when done
 -- @param CreateDetectorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDetectorAsync(CreateDetectorRequest, cb)
 	assert(CreateDetectorRequest, "You must provide a CreateDetectorRequest")
 	local headers = {
@@ -6754,19 +6773,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDetectorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDetectorSync(CreateDetectorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDetectorAsync(CreateDetectorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDetectorAsync(CreateDetectorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMembers asynchronously, invoking a callback when done
 -- @param ListMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMembersAsync(ListMembersRequest, cb)
 	assert(ListMembersRequest, "You must provide a ListMembersRequest")
 	local headers = {
@@ -6789,19 +6809,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMembersSync(ListMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMembersAsync(ListMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMembersAsync(ListMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMembers asynchronously, invoking a callback when done
 -- @param DeleteMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMembersAsync(DeleteMembersRequest, cb)
 	assert(DeleteMembersRequest, "You must provide a DeleteMembersRequest")
 	local headers = {
@@ -6824,19 +6845,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMembersSync(DeleteMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMembersAsync(DeleteMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMembersAsync(DeleteMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThreatIntelSets asynchronously, invoking a callback when done
 -- @param ListThreatIntelSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThreatIntelSetsAsync(ListThreatIntelSetsRequest, cb)
 	assert(ListThreatIntelSetsRequest, "You must provide a ListThreatIntelSetsRequest")
 	local headers = {
@@ -6859,19 +6881,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThreatIntelSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThreatIntelSetsSync(ListThreatIntelSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThreatIntelSetsAsync(ListThreatIntelSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThreatIntelSetsAsync(ListThreatIntelSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIPSet asynchronously, invoking a callback when done
 -- @param CreateIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIPSetAsync(CreateIPSetRequest, cb)
 	assert(CreateIPSetRequest, "You must provide a CreateIPSetRequest")
 	local headers = {
@@ -6894,19 +6917,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIPSetSync(CreateIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIPSetAsync(CreateIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIPSetAsync(CreateIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnarchiveFindings asynchronously, invoking a callback when done
 -- @param UnarchiveFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnarchiveFindingsAsync(UnarchiveFindingsRequest, cb)
 	assert(UnarchiveFindingsRequest, "You must provide a UnarchiveFindingsRequest")
 	local headers = {
@@ -6929,19 +6953,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnarchiveFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnarchiveFindingsSync(UnarchiveFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnarchiveFindingsAsync(UnarchiveFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnarchiveFindingsAsync(UnarchiveFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFilter asynchronously, invoking a callback when done
 -- @param UpdateFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFilterAsync(UpdateFilterRequest, cb)
 	assert(UpdateFilterRequest, "You must provide a UpdateFilterRequest")
 	local headers = {
@@ -6964,19 +6989,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFilterSync(UpdateFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFilterAsync(UpdateFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFilterAsync(UpdateFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeclineInvitations asynchronously, invoking a callback when done
 -- @param DeclineInvitationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeclineInvitationsAsync(DeclineInvitationsRequest, cb)
 	assert(DeclineInvitationsRequest, "You must provide a DeclineInvitationsRequest")
 	local headers = {
@@ -6999,19 +7025,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeclineInvitationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeclineInvitationsSync(DeclineInvitationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeclineInvitationsAsync(DeclineInvitationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeclineInvitationsAsync(DeclineInvitationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptInvitation asynchronously, invoking a callback when done
 -- @param AcceptInvitationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptInvitationAsync(AcceptInvitationRequest, cb)
 	assert(AcceptInvitationRequest, "You must provide a AcceptInvitationRequest")
 	local headers = {
@@ -7034,19 +7061,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptInvitationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptInvitationSync(AcceptInvitationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptInvitationAsync(AcceptInvitationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptInvitationAsync(AcceptInvitationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMembers asynchronously, invoking a callback when done
 -- @param CreateMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMembersAsync(CreateMembersRequest, cb)
 	assert(CreateMembersRequest, "You must provide a CreateMembersRequest")
 	local headers = {
@@ -7069,19 +7097,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMembersSync(CreateMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMembersAsync(CreateMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMembersAsync(CreateMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDetector asynchronously, invoking a callback when done
 -- @param GetDetectorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDetectorAsync(GetDetectorRequest, cb)
 	assert(GetDetectorRequest, "You must provide a GetDetectorRequest")
 	local headers = {
@@ -7104,19 +7133,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDetectorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDetectorSync(GetDetectorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDetectorAsync(GetDetectorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDetectorAsync(GetDetectorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSampleFindings asynchronously, invoking a callback when done
 -- @param CreateSampleFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSampleFindingsAsync(CreateSampleFindingsRequest, cb)
 	assert(CreateSampleFindingsRequest, "You must provide a CreateSampleFindingsRequest")
 	local headers = {
@@ -7139,19 +7169,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSampleFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSampleFindingsSync(CreateSampleFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSampleFindingsAsync(CreateSampleFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSampleFindingsAsync(CreateSampleFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFilter asynchronously, invoking a callback when done
 -- @param GetFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFilterAsync(GetFilterRequest, cb)
 	assert(GetFilterRequest, "You must provide a GetFilterRequest")
 	local headers = {
@@ -7174,19 +7205,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFilterSync(GetFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFilterAsync(GetFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFilterAsync(GetFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDetector asynchronously, invoking a callback when done
 -- @param DeleteDetectorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDetectorAsync(DeleteDetectorRequest, cb)
 	assert(DeleteDetectorRequest, "You must provide a DeleteDetectorRequest")
 	local headers = {
@@ -7209,19 +7241,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDetectorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDetectorSync(DeleteDetectorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDetectorAsync(DeleteDetectorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDetectorAsync(DeleteDetectorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFindingsStatistics asynchronously, invoking a callback when done
 -- @param GetFindingsStatisticsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFindingsStatisticsAsync(GetFindingsStatisticsRequest, cb)
 	assert(GetFindingsStatisticsRequest, "You must provide a GetFindingsStatisticsRequest")
 	local headers = {
@@ -7244,19 +7277,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFindingsStatisticsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFindingsStatisticsSync(GetFindingsStatisticsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFindingsStatisticsAsync(GetFindingsStatisticsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFindingsStatisticsAsync(GetFindingsStatisticsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InviteMembers asynchronously, invoking a callback when done
 -- @param InviteMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InviteMembersAsync(InviteMembersRequest, cb)
 	assert(InviteMembersRequest, "You must provide a InviteMembersRequest")
 	local headers = {
@@ -7279,19 +7313,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InviteMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InviteMembersSync(InviteMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InviteMembersAsync(InviteMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InviteMembersAsync(InviteMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInvitations asynchronously, invoking a callback when done
 -- @param DeleteInvitationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInvitationsAsync(DeleteInvitationsRequest, cb)
 	assert(DeleteInvitationsRequest, "You must provide a DeleteInvitationsRequest")
 	local headers = {
@@ -7314,19 +7349,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInvitationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInvitationsSync(DeleteInvitationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInvitationsAsync(DeleteInvitationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInvitationsAsync(DeleteInvitationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateThreatIntelSet asynchronously, invoking a callback when done
 -- @param CreateThreatIntelSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateThreatIntelSetAsync(CreateThreatIntelSetRequest, cb)
 	assert(CreateThreatIntelSetRequest, "You must provide a CreateThreatIntelSetRequest")
 	local headers = {
@@ -7349,19 +7385,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateThreatIntelSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateThreatIntelSetSync(CreateThreatIntelSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateThreatIntelSetAsync(CreateThreatIntelSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateThreatIntelSetAsync(CreateThreatIntelSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIPSet asynchronously, invoking a callback when done
 -- @param UpdateIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIPSetAsync(UpdateIPSetRequest, cb)
 	assert(UpdateIPSetRequest, "You must provide a UpdateIPSetRequest")
 	local headers = {
@@ -7384,19 +7421,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIPSetSync(UpdateIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIPSetAsync(UpdateIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIPSetAsync(UpdateIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopMonitoringMembers asynchronously, invoking a callback when done
 -- @param StopMonitoringMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopMonitoringMembersAsync(StopMonitoringMembersRequest, cb)
 	assert(StopMonitoringMembersRequest, "You must provide a StopMonitoringMembersRequest")
 	local headers = {
@@ -7419,19 +7457,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopMonitoringMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopMonitoringMembersSync(StopMonitoringMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopMonitoringMembersAsync(StopMonitoringMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopMonitoringMembersAsync(StopMonitoringMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFilter asynchronously, invoking a callback when done
 -- @param DeleteFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFilterAsync(DeleteFilterRequest, cb)
 	assert(DeleteFilterRequest, "You must provide a DeleteFilterRequest")
 	local headers = {
@@ -7454,19 +7493,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFilterSync(DeleteFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFilterAsync(DeleteFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFilterAsync(DeleteFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIPSet asynchronously, invoking a callback when done
 -- @param DeleteIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIPSetAsync(DeleteIPSetRequest, cb)
 	assert(DeleteIPSetRequest, "You must provide a DeleteIPSetRequest")
 	local headers = {
@@ -7489,19 +7529,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIPSetSync(DeleteIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIPSetAsync(DeleteIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIPSetAsync(DeleteIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteThreatIntelSet asynchronously, invoking a callback when done
 -- @param DeleteThreatIntelSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteThreatIntelSetAsync(DeleteThreatIntelSetRequest, cb)
 	assert(DeleteThreatIntelSetRequest, "You must provide a DeleteThreatIntelSetRequest")
 	local headers = {
@@ -7524,12 +7565,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteThreatIntelSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteThreatIntelSetSync(DeleteThreatIntelSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteThreatIntelSetAsync(DeleteThreatIntelSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteThreatIntelSetAsync(DeleteThreatIntelSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/health.lua
+++ b/aws-sdk/health.lua
@@ -1896,7 +1896,7 @@ end
 --
 --- Call DescribeAffectedEntities asynchronously, invoking a callback when done
 -- @param DescribeAffectedEntitiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAffectedEntitiesAsync(DescribeAffectedEntitiesRequest, cb)
 	assert(DescribeAffectedEntitiesRequest, "You must provide a DescribeAffectedEntitiesRequest")
 	local headers = {
@@ -1919,19 +1919,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAffectedEntitiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAffectedEntitiesSync(DescribeAffectedEntitiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAffectedEntitiesAsync(DescribeAffectedEntitiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAffectedEntitiesAsync(DescribeAffectedEntitiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventDetails asynchronously, invoking a callback when done
 -- @param DescribeEventDetailsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventDetailsAsync(DescribeEventDetailsRequest, cb)
 	assert(DescribeEventDetailsRequest, "You must provide a DescribeEventDetailsRequest")
 	local headers = {
@@ -1954,19 +1955,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventDetailsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventDetailsSync(DescribeEventDetailsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventDetailsAsync(DescribeEventDetailsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventDetailsAsync(DescribeEventDetailsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventTypes asynchronously, invoking a callback when done
 -- @param DescribeEventTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventTypesAsync(DescribeEventTypesRequest, cb)
 	assert(DescribeEventTypesRequest, "You must provide a DescribeEventTypesRequest")
 	local headers = {
@@ -1989,19 +1991,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventTypesSync(DescribeEventTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventTypesAsync(DescribeEventTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventTypesAsync(DescribeEventTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsRequest, cb)
 	assert(DescribeEventsRequest, "You must provide a DescribeEventsRequest")
 	local headers = {
@@ -2024,19 +2027,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEntityAggregates asynchronously, invoking a callback when done
 -- @param DescribeEntityAggregatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEntityAggregatesAsync(DescribeEntityAggregatesRequest, cb)
 	assert(DescribeEntityAggregatesRequest, "You must provide a DescribeEntityAggregatesRequest")
 	local headers = {
@@ -2059,19 +2063,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEntityAggregatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEntityAggregatesSync(DescribeEntityAggregatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEntityAggregatesAsync(DescribeEntityAggregatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEntityAggregatesAsync(DescribeEntityAggregatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventAggregates asynchronously, invoking a callback when done
 -- @param DescribeEventAggregatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventAggregatesAsync(DescribeEventAggregatesRequest, cb)
 	assert(DescribeEventAggregatesRequest, "You must provide a DescribeEventAggregatesRequest")
 	local headers = {
@@ -2094,12 +2099,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventAggregatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventAggregatesSync(DescribeEventAggregatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventAggregatesAsync(DescribeEventAggregatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventAggregatesAsync(DescribeEventAggregatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/iam.lua
+++ b/aws-sdk/iam.lua
@@ -13192,7 +13192,7 @@ end
 --
 --- Call GetUserPolicy asynchronously, invoking a callback when done
 -- @param GetUserPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserPolicyAsync(GetUserPolicyRequest, cb)
 	assert(GetUserPolicyRequest, "You must provide a GetUserPolicyRequest")
 	local headers = {
@@ -13215,19 +13215,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserPolicySync(GetUserPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserPolicyAsync(GetUserPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserPolicyAsync(GetUserPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateServiceLinkedRole asynchronously, invoking a callback when done
 -- @param CreateServiceLinkedRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateServiceLinkedRoleAsync(CreateServiceLinkedRoleRequest, cb)
 	assert(CreateServiceLinkedRoleRequest, "You must provide a CreateServiceLinkedRoleRequest")
 	local headers = {
@@ -13250,19 +13251,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateServiceLinkedRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateServiceLinkedRoleSync(CreateServiceLinkedRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateServiceLinkedRoleAsync(CreateServiceLinkedRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateServiceLinkedRoleAsync(CreateServiceLinkedRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInstanceProfile asynchronously, invoking a callback when done
 -- @param DeleteInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInstanceProfileAsync(DeleteInstanceProfileRequest, cb)
 	assert(DeleteInstanceProfileRequest, "You must provide a DeleteInstanceProfileRequest")
 	local headers = {
@@ -13285,18 +13287,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInstanceProfileSync(DeleteInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInstanceProfileAsync(DeleteInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInstanceProfileAsync(DeleteInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountSummary asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountSummaryAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -13315,19 +13318,20 @@ end
 --- Call GetAccountSummary synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountSummarySync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountSummaryAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountSummaryAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRolePermissionsBoundary asynchronously, invoking a callback when done
 -- @param DeleteRolePermissionsBoundaryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRolePermissionsBoundaryAsync(DeleteRolePermissionsBoundaryRequest, cb)
 	assert(DeleteRolePermissionsBoundaryRequest, "You must provide a DeleteRolePermissionsBoundaryRequest")
 	local headers = {
@@ -13350,19 +13354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRolePermissionsBoundaryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRolePermissionsBoundarySync(DeleteRolePermissionsBoundaryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRolePermissionsBoundaryAsync(DeleteRolePermissionsBoundaryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRolePermissionsBoundaryAsync(DeleteRolePermissionsBoundaryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAttachedGroupPolicies asynchronously, invoking a callback when done
 -- @param ListAttachedGroupPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAttachedGroupPoliciesAsync(ListAttachedGroupPoliciesRequest, cb)
 	assert(ListAttachedGroupPoliciesRequest, "You must provide a ListAttachedGroupPoliciesRequest")
 	local headers = {
@@ -13385,19 +13390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAttachedGroupPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAttachedGroupPoliciesSync(ListAttachedGroupPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAttachedGroupPoliciesAsync(ListAttachedGroupPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAttachedGroupPoliciesAsync(ListAttachedGroupPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUser asynchronously, invoking a callback when done
 -- @param UpdateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserAsync(UpdateUserRequest, cb)
 	assert(UpdateUserRequest, "You must provide a UpdateUserRequest")
 	local headers = {
@@ -13420,19 +13426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserSync(UpdateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserAsync(UpdateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserAsync(UpdateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAccountAliases asynchronously, invoking a callback when done
 -- @param ListAccountAliasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAccountAliasesAsync(ListAccountAliasesRequest, cb)
 	assert(ListAccountAliasesRequest, "You must provide a ListAccountAliasesRequest")
 	local headers = {
@@ -13455,19 +13462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAccountAliasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAccountAliasesSync(ListAccountAliasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAccountAliasesAsync(ListAccountAliasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAccountAliasesAsync(ListAccountAliasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUser asynchronously, invoking a callback when done
 -- @param GetUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserAsync(GetUserRequest, cb)
 	assert(GetUserRequest, "You must provide a GetUserRequest")
 	local headers = {
@@ -13490,19 +13498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserSync(GetUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserAsync(GetUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserAsync(GetUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInstanceProfilesForRole asynchronously, invoking a callback when done
 -- @param ListInstanceProfilesForRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInstanceProfilesForRoleAsync(ListInstanceProfilesForRoleRequest, cb)
 	assert(ListInstanceProfilesForRoleRequest, "You must provide a ListInstanceProfilesForRoleRequest")
 	local headers = {
@@ -13525,19 +13534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInstanceProfilesForRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInstanceProfilesForRoleSync(ListInstanceProfilesForRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInstanceProfilesForRoleAsync(ListInstanceProfilesForRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInstanceProfilesForRoleAsync(ListInstanceProfilesForRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadSSHPublicKey asynchronously, invoking a callback when done
 -- @param UploadSSHPublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadSSHPublicKeyAsync(UploadSSHPublicKeyRequest, cb)
 	assert(UploadSSHPublicKeyRequest, "You must provide a UploadSSHPublicKeyRequest")
 	local headers = {
@@ -13560,19 +13570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadSSHPublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadSSHPublicKeySync(UploadSSHPublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadSSHPublicKeyAsync(UploadSSHPublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadSSHPublicKeyAsync(UploadSSHPublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetServiceLinkedRoleDeletionStatus asynchronously, invoking a callback when done
 -- @param GetServiceLinkedRoleDeletionStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetServiceLinkedRoleDeletionStatusAsync(GetServiceLinkedRoleDeletionStatusRequest, cb)
 	assert(GetServiceLinkedRoleDeletionStatusRequest, "You must provide a GetServiceLinkedRoleDeletionStatusRequest")
 	local headers = {
@@ -13595,19 +13606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetServiceLinkedRoleDeletionStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetServiceLinkedRoleDeletionStatusSync(GetServiceLinkedRoleDeletionStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetServiceLinkedRoleDeletionStatusAsync(GetServiceLinkedRoleDeletionStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetServiceLinkedRoleDeletionStatusAsync(GetServiceLinkedRoleDeletionStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroupPolicies asynchronously, invoking a callback when done
 -- @param ListGroupPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupPoliciesAsync(ListGroupPoliciesRequest, cb)
 	assert(ListGroupPoliciesRequest, "You must provide a ListGroupPoliciesRequest")
 	local headers = {
@@ -13630,19 +13642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupPoliciesSync(ListGroupPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupPoliciesAsync(ListGroupPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupPoliciesAsync(ListGroupPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAccessKey asynchronously, invoking a callback when done
 -- @param CreateAccessKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAccessKeyAsync(CreateAccessKeyRequest, cb)
 	assert(CreateAccessKeyRequest, "You must provide a CreateAccessKeyRequest")
 	local headers = {
@@ -13665,19 +13678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAccessKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAccessKeySync(CreateAccessKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAccessKeyAsync(CreateAccessKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAccessKeyAsync(CreateAccessKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateLoginProfile asynchronously, invoking a callback when done
 -- @param UpdateLoginProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateLoginProfileAsync(UpdateLoginProfileRequest, cb)
 	assert(UpdateLoginProfileRequest, "You must provide a UpdateLoginProfileRequest")
 	local headers = {
@@ -13700,19 +13714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateLoginProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateLoginProfileSync(UpdateLoginProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateLoginProfileAsync(UpdateLoginProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateLoginProfileAsync(UpdateLoginProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroups asynchronously, invoking a callback when done
 -- @param ListGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupsAsync(ListGroupsRequest, cb)
 	assert(ListGroupsRequest, "You must provide a ListGroupsRequest")
 	local headers = {
@@ -13735,19 +13750,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupsSync(ListGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupsAsync(ListGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupsAsync(ListGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRoleDescription asynchronously, invoking a callback when done
 -- @param UpdateRoleDescriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRoleDescriptionAsync(UpdateRoleDescriptionRequest, cb)
 	assert(UpdateRoleDescriptionRequest, "You must provide a UpdateRoleDescriptionRequest")
 	local headers = {
@@ -13770,19 +13786,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRoleDescriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRoleDescriptionSync(UpdateRoleDescriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRoleDescriptionAsync(UpdateRoleDescriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRoleDescriptionAsync(UpdateRoleDescriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSAMLProvider asynchronously, invoking a callback when done
 -- @param UpdateSAMLProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSAMLProviderAsync(UpdateSAMLProviderRequest, cb)
 	assert(UpdateSAMLProviderRequest, "You must provide a UpdateSAMLProviderRequest")
 	local headers = {
@@ -13805,19 +13822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSAMLProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSAMLProviderSync(UpdateSAMLProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSAMLProviderAsync(UpdateSAMLProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSAMLProviderAsync(UpdateSAMLProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetServiceSpecificCredential asynchronously, invoking a callback when done
 -- @param ResetServiceSpecificCredentialRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetServiceSpecificCredentialAsync(ResetServiceSpecificCredentialRequest, cb)
 	assert(ResetServiceSpecificCredentialRequest, "You must provide a ResetServiceSpecificCredentialRequest")
 	local headers = {
@@ -13840,19 +13858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetServiceSpecificCredentialRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetServiceSpecificCredentialSync(ResetServiceSpecificCredentialRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetServiceSpecificCredentialAsync(ResetServiceSpecificCredentialRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetServiceSpecificCredentialAsync(ResetServiceSpecificCredentialRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSSHPublicKey asynchronously, invoking a callback when done
 -- @param DeleteSSHPublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSSHPublicKeyAsync(DeleteSSHPublicKeyRequest, cb)
 	assert(DeleteSSHPublicKeyRequest, "You must provide a DeleteSSHPublicKeyRequest")
 	local headers = {
@@ -13875,19 +13894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSSHPublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSSHPublicKeySync(DeleteSSHPublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSSHPublicKeyAsync(DeleteSSHPublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSSHPublicKeyAsync(DeleteSSHPublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRole asynchronously, invoking a callback when done
 -- @param UpdateRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRoleAsync(UpdateRoleRequest, cb)
 	assert(UpdateRoleRequest, "You must provide a UpdateRoleRequest")
 	local headers = {
@@ -13910,19 +13930,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRoleSync(UpdateRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRoleAsync(UpdateRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRoleAsync(UpdateRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveUserFromGroup asynchronously, invoking a callback when done
 -- @param RemoveUserFromGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveUserFromGroupAsync(RemoveUserFromGroupRequest, cb)
 	assert(RemoveUserFromGroupRequest, "You must provide a RemoveUserFromGroupRequest")
 	local headers = {
@@ -13945,19 +13966,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveUserFromGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveUserFromGroupSync(RemoveUserFromGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveUserFromGroupAsync(RemoveUserFromGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveUserFromGroupAsync(RemoveUserFromGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSAMLProviders asynchronously, invoking a callback when done
 -- @param ListSAMLProvidersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSAMLProvidersAsync(ListSAMLProvidersRequest, cb)
 	assert(ListSAMLProvidersRequest, "You must provide a ListSAMLProvidersRequest")
 	local headers = {
@@ -13980,19 +14002,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSAMLProvidersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSAMLProvidersSync(ListSAMLProvidersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSAMLProvidersAsync(ListSAMLProvidersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSAMLProvidersAsync(ListSAMLProvidersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRolePolicy asynchronously, invoking a callback when done
 -- @param DeleteRolePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRolePolicyAsync(DeleteRolePolicyRequest, cb)
 	assert(DeleteRolePolicyRequest, "You must provide a DeleteRolePolicyRequest")
 	local headers = {
@@ -14015,19 +14038,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRolePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRolePolicySync(DeleteRolePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRolePolicyAsync(DeleteRolePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRolePolicyAsync(DeleteRolePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadServerCertificate asynchronously, invoking a callback when done
 -- @param UploadServerCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadServerCertificateAsync(UploadServerCertificateRequest, cb)
 	assert(UploadServerCertificateRequest, "You must provide a UploadServerCertificateRequest")
 	local headers = {
@@ -14050,19 +14074,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadServerCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadServerCertificateSync(UploadServerCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadServerCertificateAsync(UploadServerCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadServerCertificateAsync(UploadServerCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetContextKeysForPrincipalPolicy asynchronously, invoking a callback when done
 -- @param GetContextKeysForPrincipalPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetContextKeysForPrincipalPolicyAsync(GetContextKeysForPrincipalPolicyRequest, cb)
 	assert(GetContextKeysForPrincipalPolicyRequest, "You must provide a GetContextKeysForPrincipalPolicyRequest")
 	local headers = {
@@ -14085,19 +14110,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetContextKeysForPrincipalPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetContextKeysForPrincipalPolicySync(GetContextKeysForPrincipalPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetContextKeysForPrincipalPolicyAsync(GetContextKeysForPrincipalPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetContextKeysForPrincipalPolicyAsync(GetContextKeysForPrincipalPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAccessKey asynchronously, invoking a callback when done
 -- @param UpdateAccessKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAccessKeyAsync(UpdateAccessKeyRequest, cb)
 	assert(UpdateAccessKeyRequest, "You must provide a UpdateAccessKeyRequest")
 	local headers = {
@@ -14120,19 +14146,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAccessKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAccessKeySync(UpdateAccessKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAccessKeyAsync(UpdateAccessKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAccessKeyAsync(UpdateAccessKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRoles asynchronously, invoking a callback when done
 -- @param ListRolesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRolesAsync(ListRolesRequest, cb)
 	assert(ListRolesRequest, "You must provide a ListRolesRequest")
 	local headers = {
@@ -14155,19 +14182,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRolesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRolesSync(ListRolesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRolesAsync(ListRolesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRolesAsync(ListRolesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAccessKey asynchronously, invoking a callback when done
 -- @param DeleteAccessKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAccessKeyAsync(DeleteAccessKeyRequest, cb)
 	assert(DeleteAccessKeyRequest, "You must provide a DeleteAccessKeyRequest")
 	local headers = {
@@ -14190,19 +14218,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAccessKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAccessKeySync(DeleteAccessKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAccessKeyAsync(DeleteAccessKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAccessKeyAsync(DeleteAccessKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddRoleToInstanceProfile asynchronously, invoking a callback when done
 -- @param AddRoleToInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddRoleToInstanceProfileAsync(AddRoleToInstanceProfileRequest, cb)
 	assert(AddRoleToInstanceProfileRequest, "You must provide a AddRoleToInstanceProfileRequest")
 	local headers = {
@@ -14225,19 +14254,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddRoleToInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddRoleToInstanceProfileSync(AddRoleToInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddRoleToInstanceProfileAsync(AddRoleToInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddRoleToInstanceProfileAsync(AddRoleToInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetContextKeysForCustomPolicy asynchronously, invoking a callback when done
 -- @param GetContextKeysForCustomPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetContextKeysForCustomPolicyAsync(GetContextKeysForCustomPolicyRequest, cb)
 	assert(GetContextKeysForCustomPolicyRequest, "You must provide a GetContextKeysForCustomPolicyRequest")
 	local headers = {
@@ -14260,19 +14290,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetContextKeysForCustomPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetContextKeysForCustomPolicySync(GetContextKeysForCustomPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetContextKeysForCustomPolicyAsync(GetContextKeysForCustomPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetContextKeysForCustomPolicyAsync(GetContextKeysForCustomPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroupPolicy asynchronously, invoking a callback when done
 -- @param GetGroupPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupPolicyAsync(GetGroupPolicyRequest, cb)
 	assert(GetGroupPolicyRequest, "You must provide a GetGroupPolicyRequest")
 	local headers = {
@@ -14295,19 +14326,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupPolicySync(GetGroupPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupPolicyAsync(GetGroupPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupPolicyAsync(GetGroupPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteServiceLinkedRole asynchronously, invoking a callback when done
 -- @param DeleteServiceLinkedRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServiceLinkedRoleAsync(DeleteServiceLinkedRoleRequest, cb)
 	assert(DeleteServiceLinkedRoleRequest, "You must provide a DeleteServiceLinkedRoleRequest")
 	local headers = {
@@ -14330,19 +14362,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServiceLinkedRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServiceLinkedRoleSync(DeleteServiceLinkedRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServiceLinkedRoleAsync(DeleteServiceLinkedRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServiceLinkedRoleAsync(DeleteServiceLinkedRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateServiceSpecificCredential asynchronously, invoking a callback when done
 -- @param CreateServiceSpecificCredentialRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateServiceSpecificCredentialAsync(CreateServiceSpecificCredentialRequest, cb)
 	assert(CreateServiceSpecificCredentialRequest, "You must provide a CreateServiceSpecificCredentialRequest")
 	local headers = {
@@ -14365,19 +14398,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateServiceSpecificCredentialRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateServiceSpecificCredentialSync(CreateServiceSpecificCredentialRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateServiceSpecificCredentialAsync(CreateServiceSpecificCredentialRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateServiceSpecificCredentialAsync(CreateServiceSpecificCredentialRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLoginProfile asynchronously, invoking a callback when done
 -- @param CreateLoginProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLoginProfileAsync(CreateLoginProfileRequest, cb)
 	assert(CreateLoginProfileRequest, "You must provide a CreateLoginProfileRequest")
 	local headers = {
@@ -14400,19 +14434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLoginProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLoginProfileSync(CreateLoginProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLoginProfileAsync(CreateLoginProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLoginProfileAsync(CreateLoginProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SimulateCustomPolicy asynchronously, invoking a callback when done
 -- @param SimulateCustomPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SimulateCustomPolicyAsync(SimulateCustomPolicyRequest, cb)
 	assert(SimulateCustomPolicyRequest, "You must provide a SimulateCustomPolicyRequest")
 	local headers = {
@@ -14435,19 +14470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SimulateCustomPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SimulateCustomPolicySync(SimulateCustomPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SimulateCustomPolicyAsync(SimulateCustomPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SimulateCustomPolicyAsync(SimulateCustomPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeactivateMFADevice asynchronously, invoking a callback when done
 -- @param DeactivateMFADeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeactivateMFADeviceAsync(DeactivateMFADeviceRequest, cb)
 	assert(DeactivateMFADeviceRequest, "You must provide a DeactivateMFADeviceRequest")
 	local headers = {
@@ -14470,19 +14506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeactivateMFADeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeactivateMFADeviceSync(DeactivateMFADeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeactivateMFADeviceAsync(DeactivateMFADeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeactivateMFADeviceAsync(DeactivateMFADeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachRolePolicy asynchronously, invoking a callback when done
 -- @param DetachRolePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachRolePolicyAsync(DetachRolePolicyRequest, cb)
 	assert(DetachRolePolicyRequest, "You must provide a DetachRolePolicyRequest")
 	local headers = {
@@ -14505,19 +14542,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachRolePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachRolePolicySync(DetachRolePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachRolePolicyAsync(DetachRolePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachRolePolicyAsync(DetachRolePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPolicy asynchronously, invoking a callback when done
 -- @param GetPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPolicyAsync(GetPolicyRequest, cb)
 	assert(GetPolicyRequest, "You must provide a GetPolicyRequest")
 	local headers = {
@@ -14540,19 +14578,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPolicySync(GetPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPolicyAsync(GetPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPolicyAsync(GetPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSAMLProvider asynchronously, invoking a callback when done
 -- @param CreateSAMLProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSAMLProviderAsync(CreateSAMLProviderRequest, cb)
 	assert(CreateSAMLProviderRequest, "You must provide a CreateSAMLProviderRequest")
 	local headers = {
@@ -14575,19 +14614,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSAMLProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSAMLProviderSync(CreateSAMLProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSAMLProviderAsync(CreateSAMLProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSAMLProviderAsync(CreateSAMLProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOpenIDConnectProviders asynchronously, invoking a callback when done
 -- @param ListOpenIDConnectProvidersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOpenIDConnectProvidersAsync(ListOpenIDConnectProvidersRequest, cb)
 	assert(ListOpenIDConnectProvidersRequest, "You must provide a ListOpenIDConnectProvidersRequest")
 	local headers = {
@@ -14610,19 +14650,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOpenIDConnectProvidersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOpenIDConnectProvidersSync(ListOpenIDConnectProvidersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOpenIDConnectProvidersAsync(ListOpenIDConnectProvidersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOpenIDConnectProvidersAsync(ListOpenIDConnectProvidersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAccountAlias asynchronously, invoking a callback when done
 -- @param DeleteAccountAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAccountAliasAsync(DeleteAccountAliasRequest, cb)
 	assert(DeleteAccountAliasRequest, "You must provide a DeleteAccountAliasRequest")
 	local headers = {
@@ -14645,19 +14686,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAccountAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAccountAliasSync(DeleteAccountAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAccountAliasAsync(DeleteAccountAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAccountAliasAsync(DeleteAccountAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSigningCertificates asynchronously, invoking a callback when done
 -- @param ListSigningCertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSigningCertificatesAsync(ListSigningCertificatesRequest, cb)
 	assert(ListSigningCertificatesRequest, "You must provide a ListSigningCertificatesRequest")
 	local headers = {
@@ -14680,19 +14722,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSigningCertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSigningCertificatesSync(ListSigningCertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSigningCertificatesAsync(ListSigningCertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSigningCertificatesAsync(ListSigningCertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRole asynchronously, invoking a callback when done
 -- @param DeleteRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRoleAsync(DeleteRoleRequest, cb)
 	assert(DeleteRoleRequest, "You must provide a DeleteRoleRequest")
 	local headers = {
@@ -14715,19 +14758,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRoleSync(DeleteRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRoleAsync(DeleteRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRoleAsync(DeleteRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGroup asynchronously, invoking a callback when done
 -- @param UpdateGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGroupAsync(UpdateGroupRequest, cb)
 	assert(UpdateGroupRequest, "You must provide a UpdateGroupRequest")
 	local headers = {
@@ -14750,19 +14794,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGroupSync(UpdateGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGroupAsync(UpdateGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGroupAsync(UpdateGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroup asynchronously, invoking a callback when done
 -- @param GetGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupAsync(GetGroupRequest, cb)
 	assert(GetGroupRequest, "You must provide a GetGroupRequest")
 	local headers = {
@@ -14785,19 +14830,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupSync(GetGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupAsync(GetGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupAsync(GetGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRolePolicy asynchronously, invoking a callback when done
 -- @param GetRolePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRolePolicyAsync(GetRolePolicyRequest, cb)
 	assert(GetRolePolicyRequest, "You must provide a GetRolePolicyRequest")
 	local headers = {
@@ -14820,19 +14866,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRolePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRolePolicySync(GetRolePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRolePolicyAsync(GetRolePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRolePolicyAsync(GetRolePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUser asynchronously, invoking a callback when done
 -- @param CreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserAsync(CreateUserRequest, cb)
 	assert(CreateUserRequest, "You must provide a CreateUserRequest")
 	local headers = {
@@ -14855,19 +14902,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserSync(CreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserAsync(CreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserAsync(CreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddUserToGroup asynchronously, invoking a callback when done
 -- @param AddUserToGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddUserToGroupAsync(AddUserToGroupRequest, cb)
 	assert(AddUserToGroupRequest, "You must provide a AddUserToGroupRequest")
 	local headers = {
@@ -14890,19 +14938,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddUserToGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddUserToGroupSync(AddUserToGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddUserToGroupAsync(AddUserToGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddUserToGroupAsync(AddUserToGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveRoleFromInstanceProfile asynchronously, invoking a callback when done
 -- @param RemoveRoleFromInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveRoleFromInstanceProfileAsync(RemoveRoleFromInstanceProfileRequest, cb)
 	assert(RemoveRoleFromInstanceProfileRequest, "You must provide a RemoveRoleFromInstanceProfileRequest")
 	local headers = {
@@ -14925,19 +14974,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveRoleFromInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveRoleFromInstanceProfileSync(RemoveRoleFromInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveRoleFromInstanceProfileAsync(RemoveRoleFromInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveRoleFromInstanceProfileAsync(RemoveRoleFromInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInstanceProfiles asynchronously, invoking a callback when done
 -- @param ListInstanceProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInstanceProfilesAsync(ListInstanceProfilesRequest, cb)
 	assert(ListInstanceProfilesRequest, "You must provide a ListInstanceProfilesRequest")
 	local headers = {
@@ -14960,19 +15010,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInstanceProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInstanceProfilesSync(ListInstanceProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInstanceProfilesAsync(ListInstanceProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInstanceProfilesAsync(ListInstanceProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateServiceSpecificCredential asynchronously, invoking a callback when done
 -- @param UpdateServiceSpecificCredentialRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServiceSpecificCredentialAsync(UpdateServiceSpecificCredentialRequest, cb)
 	assert(UpdateServiceSpecificCredentialRequest, "You must provide a UpdateServiceSpecificCredentialRequest")
 	local headers = {
@@ -14995,19 +15046,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServiceSpecificCredentialRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServiceSpecificCredentialSync(UpdateServiceSpecificCredentialRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServiceSpecificCredentialAsync(UpdateServiceSpecificCredentialRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServiceSpecificCredentialAsync(UpdateServiceSpecificCredentialRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAttachedUserPolicies asynchronously, invoking a callback when done
 -- @param ListAttachedUserPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAttachedUserPoliciesAsync(ListAttachedUserPoliciesRequest, cb)
 	assert(ListAttachedUserPoliciesRequest, "You must provide a ListAttachedUserPoliciesRequest")
 	local headers = {
@@ -15030,19 +15082,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAttachedUserPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAttachedUserPoliciesSync(ListAttachedUserPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAttachedUserPoliciesAsync(ListAttachedUserPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAttachedUserPoliciesAsync(ListAttachedUserPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePolicyVersion asynchronously, invoking a callback when done
 -- @param CreatePolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePolicyVersionAsync(CreatePolicyVersionRequest, cb)
 	assert(CreatePolicyVersionRequest, "You must provide a CreatePolicyVersionRequest")
 	local headers = {
@@ -15065,19 +15118,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePolicyVersionSync(CreatePolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePolicyVersionAsync(CreatePolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePolicyVersionAsync(CreatePolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListServiceSpecificCredentials asynchronously, invoking a callback when done
 -- @param ListServiceSpecificCredentialsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListServiceSpecificCredentialsAsync(ListServiceSpecificCredentialsRequest, cb)
 	assert(ListServiceSpecificCredentialsRequest, "You must provide a ListServiceSpecificCredentialsRequest")
 	local headers = {
@@ -15100,19 +15154,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListServiceSpecificCredentialsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListServiceSpecificCredentialsSync(ListServiceSpecificCredentialsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListServiceSpecificCredentialsAsync(ListServiceSpecificCredentialsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListServiceSpecificCredentialsAsync(ListServiceSpecificCredentialsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachUserPolicy asynchronously, invoking a callback when done
 -- @param AttachUserPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachUserPolicyAsync(AttachUserPolicyRequest, cb)
 	assert(AttachUserPolicyRequest, "You must provide a AttachUserPolicyRequest")
 	local headers = {
@@ -15135,19 +15190,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachUserPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachUserPolicySync(AttachUserPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachUserPolicyAsync(AttachUserPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachUserPolicyAsync(AttachUserPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVirtualMFADevices asynchronously, invoking a callback when done
 -- @param ListVirtualMFADevicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVirtualMFADevicesAsync(ListVirtualMFADevicesRequest, cb)
 	assert(ListVirtualMFADevicesRequest, "You must provide a ListVirtualMFADevicesRequest")
 	local headers = {
@@ -15170,19 +15226,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVirtualMFADevicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVirtualMFADevicesSync(ListVirtualMFADevicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVirtualMFADevicesAsync(ListVirtualMFADevicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVirtualMFADevicesAsync(ListVirtualMFADevicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAssumeRolePolicy asynchronously, invoking a callback when done
 -- @param UpdateAssumeRolePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAssumeRolePolicyAsync(UpdateAssumeRolePolicyRequest, cb)
 	assert(UpdateAssumeRolePolicyRequest, "You must provide a UpdateAssumeRolePolicyRequest")
 	local headers = {
@@ -15205,19 +15262,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAssumeRolePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAssumeRolePolicySync(UpdateAssumeRolePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAssumeRolePolicyAsync(UpdateAssumeRolePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAssumeRolePolicyAsync(UpdateAssumeRolePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListServerCertificates asynchronously, invoking a callback when done
 -- @param ListServerCertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListServerCertificatesAsync(ListServerCertificatesRequest, cb)
 	assert(ListServerCertificatesRequest, "You must provide a ListServerCertificatesRequest")
 	local headers = {
@@ -15240,19 +15298,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListServerCertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListServerCertificatesSync(ListServerCertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListServerCertificatesAsync(ListServerCertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListServerCertificatesAsync(ListServerCertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGroup asynchronously, invoking a callback when done
 -- @param DeleteGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGroupAsync(DeleteGroupRequest, cb)
 	assert(DeleteGroupRequest, "You must provide a DeleteGroupRequest")
 	local headers = {
@@ -15275,19 +15334,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGroupSync(DeleteGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateOpenIDConnectProviderThumbprint asynchronously, invoking a callback when done
 -- @param UpdateOpenIDConnectProviderThumbprintRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateOpenIDConnectProviderThumbprintAsync(UpdateOpenIDConnectProviderThumbprintRequest, cb)
 	assert(UpdateOpenIDConnectProviderThumbprintRequest, "You must provide a UpdateOpenIDConnectProviderThumbprintRequest")
 	local headers = {
@@ -15310,19 +15370,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateOpenIDConnectProviderThumbprintRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateOpenIDConnectProviderThumbprintSync(UpdateOpenIDConnectProviderThumbprintRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateOpenIDConnectProviderThumbprintAsync(UpdateOpenIDConnectProviderThumbprintRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateOpenIDConnectProviderThumbprintAsync(UpdateOpenIDConnectProviderThumbprintRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGroup asynchronously, invoking a callback when done
 -- @param CreateGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGroupAsync(CreateGroupRequest, cb)
 	assert(CreateGroupRequest, "You must provide a CreateGroupRequest")
 	local headers = {
@@ -15345,19 +15406,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGroupSync(CreateGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGroupAsync(CreateGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGroupAsync(CreateGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePolicy asynchronously, invoking a callback when done
 -- @param DeletePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePolicyAsync(DeletePolicyRequest, cb)
 	assert(DeletePolicyRequest, "You must provide a DeletePolicyRequest")
 	local headers = {
@@ -15380,19 +15442,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePolicySync(DeletePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserPolicy asynchronously, invoking a callback when done
 -- @param DeleteUserPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserPolicyAsync(DeleteUserPolicyRequest, cb)
 	assert(DeleteUserPolicyRequest, "You must provide a DeleteUserPolicyRequest")
 	local headers = {
@@ -15415,19 +15478,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserPolicySync(DeleteUserPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserPolicyAsync(DeleteUserPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserPolicyAsync(DeleteUserPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateServerCertificate asynchronously, invoking a callback when done
 -- @param UpdateServerCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServerCertificateAsync(UpdateServerCertificateRequest, cb)
 	assert(UpdateServerCertificateRequest, "You must provide a UpdateServerCertificateRequest")
 	local headers = {
@@ -15450,19 +15514,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServerCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServerCertificateSync(UpdateServerCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServerCertificateAsync(UpdateServerCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServerCertificateAsync(UpdateServerCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddClientIDToOpenIDConnectProvider asynchronously, invoking a callback when done
 -- @param AddClientIDToOpenIDConnectProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddClientIDToOpenIDConnectProviderAsync(AddClientIDToOpenIDConnectProviderRequest, cb)
 	assert(AddClientIDToOpenIDConnectProviderRequest, "You must provide a AddClientIDToOpenIDConnectProviderRequest")
 	local headers = {
@@ -15485,19 +15550,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddClientIDToOpenIDConnectProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddClientIDToOpenIDConnectProviderSync(AddClientIDToOpenIDConnectProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddClientIDToOpenIDConnectProviderAsync(AddClientIDToOpenIDConnectProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddClientIDToOpenIDConnectProviderAsync(AddClientIDToOpenIDConnectProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVirtualMFADevice asynchronously, invoking a callback when done
 -- @param DeleteVirtualMFADeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVirtualMFADeviceAsync(DeleteVirtualMFADeviceRequest, cb)
 	assert(DeleteVirtualMFADeviceRequest, "You must provide a DeleteVirtualMFADeviceRequest")
 	local headers = {
@@ -15520,19 +15586,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVirtualMFADeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVirtualMFADeviceSync(DeleteVirtualMFADeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVirtualMFADeviceAsync(DeleteVirtualMFADeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVirtualMFADeviceAsync(DeleteVirtualMFADeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRolePermissionsBoundary asynchronously, invoking a callback when done
 -- @param PutRolePermissionsBoundaryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRolePermissionsBoundaryAsync(PutRolePermissionsBoundaryRequest, cb)
 	assert(PutRolePermissionsBoundaryRequest, "You must provide a PutRolePermissionsBoundaryRequest")
 	local headers = {
@@ -15555,19 +15622,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRolePermissionsBoundaryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRolePermissionsBoundarySync(PutRolePermissionsBoundaryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRolePermissionsBoundaryAsync(PutRolePermissionsBoundaryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRolePermissionsBoundaryAsync(PutRolePermissionsBoundaryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SimulatePrincipalPolicy asynchronously, invoking a callback when done
 -- @param SimulatePrincipalPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SimulatePrincipalPolicyAsync(SimulatePrincipalPolicyRequest, cb)
 	assert(SimulatePrincipalPolicyRequest, "You must provide a SimulatePrincipalPolicyRequest")
 	local headers = {
@@ -15590,19 +15658,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SimulatePrincipalPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SimulatePrincipalPolicySync(SimulatePrincipalPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SimulatePrincipalPolicyAsync(SimulatePrincipalPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SimulatePrincipalPolicyAsync(SimulatePrincipalPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAccessKeys asynchronously, invoking a callback when done
 -- @param ListAccessKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAccessKeysAsync(ListAccessKeysRequest, cb)
 	assert(ListAccessKeysRequest, "You must provide a ListAccessKeysRequest")
 	local headers = {
@@ -15625,19 +15694,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAccessKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAccessKeysSync(ListAccessKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAccessKeysAsync(ListAccessKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAccessKeysAsync(ListAccessKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSSHPublicKey asynchronously, invoking a callback when done
 -- @param GetSSHPublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSSHPublicKeyAsync(GetSSHPublicKeyRequest, cb)
 	assert(GetSSHPublicKeyRequest, "You must provide a GetSSHPublicKeyRequest")
 	local headers = {
@@ -15660,19 +15730,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSSHPublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSSHPublicKeySync(GetSSHPublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSSHPublicKeyAsync(GetSSHPublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSSHPublicKeyAsync(GetSSHPublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSSHPublicKeys asynchronously, invoking a callback when done
 -- @param ListSSHPublicKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSSHPublicKeysAsync(ListSSHPublicKeysRequest, cb)
 	assert(ListSSHPublicKeysRequest, "You must provide a ListSSHPublicKeysRequest")
 	local headers = {
@@ -15695,19 +15766,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSSHPublicKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSSHPublicKeysSync(ListSSHPublicKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSSHPublicKeysAsync(ListSSHPublicKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSSHPublicKeysAsync(ListSSHPublicKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSigningCertificate asynchronously, invoking a callback when done
 -- @param DeleteSigningCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSigningCertificateAsync(DeleteSigningCertificateRequest, cb)
 	assert(DeleteSigningCertificateRequest, "You must provide a DeleteSigningCertificateRequest")
 	local headers = {
@@ -15730,19 +15802,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSigningCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSigningCertificateSync(DeleteSigningCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSigningCertificateAsync(DeleteSigningCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSigningCertificateAsync(DeleteSigningCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPolicyVersion asynchronously, invoking a callback when done
 -- @param GetPolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPolicyVersionAsync(GetPolicyVersionRequest, cb)
 	assert(GetPolicyVersionRequest, "You must provide a GetPolicyVersionRequest")
 	local headers = {
@@ -15765,19 +15838,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPolicyVersionSync(GetPolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPolicyVersionAsync(GetPolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPolicyVersionAsync(GetPolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRolePolicy asynchronously, invoking a callback when done
 -- @param PutRolePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRolePolicyAsync(PutRolePolicyRequest, cb)
 	assert(PutRolePolicyRequest, "You must provide a PutRolePolicyRequest")
 	local headers = {
@@ -15800,19 +15874,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRolePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRolePolicySync(PutRolePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRolePolicyAsync(PutRolePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRolePolicyAsync(PutRolePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetDefaultPolicyVersion asynchronously, invoking a callback when done
 -- @param SetDefaultPolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetDefaultPolicyVersionAsync(SetDefaultPolicyVersionRequest, cb)
 	assert(SetDefaultPolicyVersionRequest, "You must provide a SetDefaultPolicyVersionRequest")
 	local headers = {
@@ -15835,19 +15910,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetDefaultPolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetDefaultPolicyVersionSync(SetDefaultPolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetDefaultPolicyVersionAsync(SetDefaultPolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetDefaultPolicyVersionAsync(SetDefaultPolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccessKeyLastUsed asynchronously, invoking a callback when done
 -- @param GetAccessKeyLastUsedRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccessKeyLastUsedAsync(GetAccessKeyLastUsedRequest, cb)
 	assert(GetAccessKeyLastUsedRequest, "You must provide a GetAccessKeyLastUsedRequest")
 	local headers = {
@@ -15870,18 +15946,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccessKeyLastUsedRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccessKeyLastUsedSync(GetAccessKeyLastUsedRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccessKeyLastUsedAsync(GetAccessKeyLastUsedRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccessKeyLastUsedAsync(GetAccessKeyLastUsedRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAccountPasswordPolicy asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAccountPasswordPolicyAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -15900,19 +15977,20 @@ end
 --- Call DeleteAccountPasswordPolicy synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAccountPasswordPolicySync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAccountPasswordPolicyAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAccountPasswordPolicyAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMFADevices asynchronously, invoking a callback when done
 -- @param ListMFADevicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMFADevicesAsync(ListMFADevicesRequest, cb)
 	assert(ListMFADevicesRequest, "You must provide a ListMFADevicesRequest")
 	local headers = {
@@ -15935,19 +16013,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMFADevicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMFADevicesSync(ListMFADevicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMFADevicesAsync(ListMFADevicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMFADevicesAsync(ListMFADevicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSigningCertificate asynchronously, invoking a callback when done
 -- @param UpdateSigningCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSigningCertificateAsync(UpdateSigningCertificateRequest, cb)
 	assert(UpdateSigningCertificateRequest, "You must provide a UpdateSigningCertificateRequest")
 	local headers = {
@@ -15970,19 +16049,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSigningCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSigningCertificateSync(UpdateSigningCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSigningCertificateAsync(UpdateSigningCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSigningCertificateAsync(UpdateSigningCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachGroupPolicy asynchronously, invoking a callback when done
 -- @param DetachGroupPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachGroupPolicyAsync(DetachGroupPolicyRequest, cb)
 	assert(DetachGroupPolicyRequest, "You must provide a DetachGroupPolicyRequest")
 	local headers = {
@@ -16005,19 +16085,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachGroupPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachGroupPolicySync(DetachGroupPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachGroupPolicyAsync(DetachGroupPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachGroupPolicyAsync(DetachGroupPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSSHPublicKey asynchronously, invoking a callback when done
 -- @param UpdateSSHPublicKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSSHPublicKeyAsync(UpdateSSHPublicKeyRequest, cb)
 	assert(UpdateSSHPublicKeyRequest, "You must provide a UpdateSSHPublicKeyRequest")
 	local headers = {
@@ -16040,19 +16121,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSSHPublicKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSSHPublicKeySync(UpdateSSHPublicKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSSHPublicKeyAsync(UpdateSSHPublicKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSSHPublicKeyAsync(UpdateSSHPublicKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceProfile asynchronously, invoking a callback when done
 -- @param GetInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceProfileAsync(GetInstanceProfileRequest, cb)
 	assert(GetInstanceProfileRequest, "You must provide a GetInstanceProfileRequest")
 	local headers = {
@@ -16075,19 +16157,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceProfileSync(GetInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceProfileAsync(GetInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceProfileAsync(GetInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -16110,19 +16193,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOpenIDConnectProvider asynchronously, invoking a callback when done
 -- @param GetOpenIDConnectProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOpenIDConnectProviderAsync(GetOpenIDConnectProviderRequest, cb)
 	assert(GetOpenIDConnectProviderRequest, "You must provide a GetOpenIDConnectProviderRequest")
 	local headers = {
@@ -16145,19 +16229,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOpenIDConnectProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOpenIDConnectProviderSync(GetOpenIDConnectProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOpenIDConnectProviderAsync(GetOpenIDConnectProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOpenIDConnectProviderAsync(GetOpenIDConnectProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUsers asynchronously, invoking a callback when done
 -- @param ListUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUsersAsync(ListUsersRequest, cb)
 	assert(ListUsersRequest, "You must provide a ListUsersRequest")
 	local headers = {
@@ -16180,19 +16265,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUsersSync(ListUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUsersAsync(ListUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUsersAsync(ListUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLoginProfile asynchronously, invoking a callback when done
 -- @param DeleteLoginProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLoginProfileAsync(DeleteLoginProfileRequest, cb)
 	assert(DeleteLoginProfileRequest, "You must provide a DeleteLoginProfileRequest")
 	local headers = {
@@ -16215,19 +16301,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLoginProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLoginProfileSync(DeleteLoginProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLoginProfileAsync(DeleteLoginProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLoginProfileAsync(DeleteLoginProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPolicyVersions asynchronously, invoking a callback when done
 -- @param ListPolicyVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPolicyVersionsAsync(ListPolicyVersionsRequest, cb)
 	assert(ListPolicyVersionsRequest, "You must provide a ListPolicyVersionsRequest")
 	local headers = {
@@ -16250,19 +16337,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPolicyVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPolicyVersionsSync(ListPolicyVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPolicyVersionsAsync(ListPolicyVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPolicyVersionsAsync(ListPolicyVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachGroupPolicy asynchronously, invoking a callback when done
 -- @param AttachGroupPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachGroupPolicyAsync(AttachGroupPolicyRequest, cb)
 	assert(AttachGroupPolicyRequest, "You must provide a AttachGroupPolicyRequest")
 	local headers = {
@@ -16285,19 +16373,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachGroupPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachGroupPolicySync(AttachGroupPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachGroupPolicyAsync(AttachGroupPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachGroupPolicyAsync(AttachGroupPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteServiceSpecificCredential asynchronously, invoking a callback when done
 -- @param DeleteServiceSpecificCredentialRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServiceSpecificCredentialAsync(DeleteServiceSpecificCredentialRequest, cb)
 	assert(DeleteServiceSpecificCredentialRequest, "You must provide a DeleteServiceSpecificCredentialRequest")
 	local headers = {
@@ -16320,19 +16409,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServiceSpecificCredentialRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServiceSpecificCredentialSync(DeleteServiceSpecificCredentialRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServiceSpecificCredentialAsync(DeleteServiceSpecificCredentialRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServiceSpecificCredentialAsync(DeleteServiceSpecificCredentialRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePolicy asynchronously, invoking a callback when done
 -- @param CreatePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePolicyAsync(CreatePolicyRequest, cb)
 	assert(CreatePolicyRequest, "You must provide a CreatePolicyRequest")
 	local headers = {
@@ -16355,19 +16445,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePolicySync(CreatePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePolicyAsync(CreatePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePolicyAsync(CreatePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateOpenIDConnectProvider asynchronously, invoking a callback when done
 -- @param CreateOpenIDConnectProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateOpenIDConnectProviderAsync(CreateOpenIDConnectProviderRequest, cb)
 	assert(CreateOpenIDConnectProviderRequest, "You must provide a CreateOpenIDConnectProviderRequest")
 	local headers = {
@@ -16390,19 +16481,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateOpenIDConnectProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateOpenIDConnectProviderSync(CreateOpenIDConnectProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateOpenIDConnectProviderAsync(CreateOpenIDConnectProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateOpenIDConnectProviderAsync(CreateOpenIDConnectProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachUserPolicy asynchronously, invoking a callback when done
 -- @param DetachUserPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachUserPolicyAsync(DetachUserPolicyRequest, cb)
 	assert(DetachUserPolicyRequest, "You must provide a DetachUserPolicyRequest")
 	local headers = {
@@ -16425,19 +16517,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachUserPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachUserPolicySync(DetachUserPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachUserPolicyAsync(DetachUserPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachUserPolicyAsync(DetachUserPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroupsForUser asynchronously, invoking a callback when done
 -- @param ListGroupsForUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupsForUserAsync(ListGroupsForUserRequest, cb)
 	assert(ListGroupsForUserRequest, "You must provide a ListGroupsForUserRequest")
 	local headers = {
@@ -16460,18 +16553,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupsForUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupsForUserSync(ListGroupsForUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupsForUserAsync(ListGroupsForUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupsForUserAsync(ListGroupsForUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCredentialReport asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCredentialReportAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -16490,19 +16584,20 @@ end
 --- Call GetCredentialReport synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCredentialReportSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCredentialReportAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCredentialReportAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAccountAlias asynchronously, invoking a callback when done
 -- @param CreateAccountAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAccountAliasAsync(CreateAccountAliasRequest, cb)
 	assert(CreateAccountAliasRequest, "You must provide a CreateAccountAliasRequest")
 	local headers = {
@@ -16525,19 +16620,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAccountAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAccountAliasSync(CreateAccountAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAccountAliasAsync(CreateAccountAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAccountAliasAsync(CreateAccountAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountAuthorizationDetails asynchronously, invoking a callback when done
 -- @param GetAccountAuthorizationDetailsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountAuthorizationDetailsAsync(GetAccountAuthorizationDetailsRequest, cb)
 	assert(GetAccountAuthorizationDetailsRequest, "You must provide a GetAccountAuthorizationDetailsRequest")
 	local headers = {
@@ -16560,19 +16656,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountAuthorizationDetailsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountAuthorizationDetailsSync(GetAccountAuthorizationDetailsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountAuthorizationDetailsAsync(GetAccountAuthorizationDetailsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountAuthorizationDetailsAsync(GetAccountAuthorizationDetailsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSAMLProvider asynchronously, invoking a callback when done
 -- @param GetSAMLProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSAMLProviderAsync(GetSAMLProviderRequest, cb)
 	assert(GetSAMLProviderRequest, "You must provide a GetSAMLProviderRequest")
 	local headers = {
@@ -16595,19 +16692,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSAMLProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSAMLProviderSync(GetSAMLProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSAMLProviderAsync(GetSAMLProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSAMLProviderAsync(GetSAMLProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRole asynchronously, invoking a callback when done
 -- @param CreateRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRoleAsync(CreateRoleRequest, cb)
 	assert(CreateRoleRequest, "You must provide a CreateRoleRequest")
 	local headers = {
@@ -16630,19 +16728,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRoleSync(CreateRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRoleAsync(CreateRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRoleAsync(CreateRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAttachedRolePolicies asynchronously, invoking a callback when done
 -- @param ListAttachedRolePoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAttachedRolePoliciesAsync(ListAttachedRolePoliciesRequest, cb)
 	assert(ListAttachedRolePoliciesRequest, "You must provide a ListAttachedRolePoliciesRequest")
 	local headers = {
@@ -16665,19 +16764,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAttachedRolePoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAttachedRolePoliciesSync(ListAttachedRolePoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAttachedRolePoliciesAsync(ListAttachedRolePoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAttachedRolePoliciesAsync(ListAttachedRolePoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableMFADevice asynchronously, invoking a callback when done
 -- @param EnableMFADeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableMFADeviceAsync(EnableMFADeviceRequest, cb)
 	assert(EnableMFADeviceRequest, "You must provide a EnableMFADeviceRequest")
 	local headers = {
@@ -16700,19 +16800,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableMFADeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableMFADeviceSync(EnableMFADeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableMFADeviceAsync(EnableMFADeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableMFADeviceAsync(EnableMFADeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSAMLProvider asynchronously, invoking a callback when done
 -- @param DeleteSAMLProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSAMLProviderAsync(DeleteSAMLProviderRequest, cb)
 	assert(DeleteSAMLProviderRequest, "You must provide a DeleteSAMLProviderRequest")
 	local headers = {
@@ -16735,19 +16836,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSAMLProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSAMLProviderSync(DeleteSAMLProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSAMLProviderAsync(DeleteSAMLProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSAMLProviderAsync(DeleteSAMLProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUserPolicies asynchronously, invoking a callback when done
 -- @param ListUserPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUserPoliciesAsync(ListUserPoliciesRequest, cb)
 	assert(ListUserPoliciesRequest, "You must provide a ListUserPoliciesRequest")
 	local headers = {
@@ -16770,19 +16872,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUserPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUserPoliciesSync(ListUserPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUserPoliciesAsync(ListUserPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUserPoliciesAsync(ListUserPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRolePolicies asynchronously, invoking a callback when done
 -- @param ListRolePoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRolePoliciesAsync(ListRolePoliciesRequest, cb)
 	assert(ListRolePoliciesRequest, "You must provide a ListRolePoliciesRequest")
 	local headers = {
@@ -16805,19 +16908,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRolePoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRolePoliciesSync(ListRolePoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRolePoliciesAsync(ListRolePoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRolePoliciesAsync(ListRolePoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutGroupPolicy asynchronously, invoking a callback when done
 -- @param PutGroupPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutGroupPolicyAsync(PutGroupPolicyRequest, cb)
 	assert(PutGroupPolicyRequest, "You must provide a PutGroupPolicyRequest")
 	local headers = {
@@ -16840,19 +16944,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutGroupPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutGroupPolicySync(PutGroupPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutGroupPolicyAsync(PutGroupPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutGroupPolicyAsync(PutGroupPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadSigningCertificate asynchronously, invoking a callback when done
 -- @param UploadSigningCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadSigningCertificateAsync(UploadSigningCertificateRequest, cb)
 	assert(UploadSigningCertificateRequest, "You must provide a UploadSigningCertificateRequest")
 	local headers = {
@@ -16875,19 +16980,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadSigningCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadSigningCertificateSync(UploadSigningCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadSigningCertificateAsync(UploadSigningCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadSigningCertificateAsync(UploadSigningCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserPermissionsBoundary asynchronously, invoking a callback when done
 -- @param DeleteUserPermissionsBoundaryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserPermissionsBoundaryAsync(DeleteUserPermissionsBoundaryRequest, cb)
 	assert(DeleteUserPermissionsBoundaryRequest, "You must provide a DeleteUserPermissionsBoundaryRequest")
 	local headers = {
@@ -16910,18 +17016,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserPermissionsBoundaryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserPermissionsBoundarySync(DeleteUserPermissionsBoundaryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserPermissionsBoundaryAsync(DeleteUserPermissionsBoundaryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserPermissionsBoundaryAsync(DeleteUserPermissionsBoundaryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GenerateCredentialReport asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GenerateCredentialReportAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -16940,19 +17047,20 @@ end
 --- Call GenerateCredentialReport synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GenerateCredentialReportSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GenerateCredentialReportAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GenerateCredentialReportAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ChangePassword asynchronously, invoking a callback when done
 -- @param ChangePasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ChangePasswordAsync(ChangePasswordRequest, cb)
 	assert(ChangePasswordRequest, "You must provide a ChangePasswordRequest")
 	local headers = {
@@ -16975,19 +17083,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ChangePasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ChangePasswordSync(ChangePasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ChangePasswordAsync(ChangePasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ChangePasswordAsync(ChangePasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListEntitiesForPolicy asynchronously, invoking a callback when done
 -- @param ListEntitiesForPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEntitiesForPolicyAsync(ListEntitiesForPolicyRequest, cb)
 	assert(ListEntitiesForPolicyRequest, "You must provide a ListEntitiesForPolicyRequest")
 	local headers = {
@@ -17010,19 +17119,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEntitiesForPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEntitiesForPolicySync(ListEntitiesForPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEntitiesForPolicyAsync(ListEntitiesForPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEntitiesForPolicyAsync(ListEntitiesForPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutUserPermissionsBoundary asynchronously, invoking a callback when done
 -- @param PutUserPermissionsBoundaryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutUserPermissionsBoundaryAsync(PutUserPermissionsBoundaryRequest, cb)
 	assert(PutUserPermissionsBoundaryRequest, "You must provide a PutUserPermissionsBoundaryRequest")
 	local headers = {
@@ -17045,19 +17155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutUserPermissionsBoundaryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutUserPermissionsBoundarySync(PutUserPermissionsBoundaryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutUserPermissionsBoundaryAsync(PutUserPermissionsBoundaryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutUserPermissionsBoundaryAsync(PutUserPermissionsBoundaryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoginProfile asynchronously, invoking a callback when done
 -- @param GetLoginProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoginProfileAsync(GetLoginProfileRequest, cb)
 	assert(GetLoginProfileRequest, "You must provide a GetLoginProfileRequest")
 	local headers = {
@@ -17080,19 +17191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoginProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoginProfileSync(GetLoginProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoginProfileAsync(GetLoginProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoginProfileAsync(GetLoginProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVirtualMFADevice asynchronously, invoking a callback when done
 -- @param CreateVirtualMFADeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVirtualMFADeviceAsync(CreateVirtualMFADeviceRequest, cb)
 	assert(CreateVirtualMFADeviceRequest, "You must provide a CreateVirtualMFADeviceRequest")
 	local headers = {
@@ -17115,19 +17227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVirtualMFADeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVirtualMFADeviceSync(CreateVirtualMFADeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVirtualMFADeviceAsync(CreateVirtualMFADeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVirtualMFADeviceAsync(CreateVirtualMFADeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetServerCertificate asynchronously, invoking a callback when done
 -- @param GetServerCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetServerCertificateAsync(GetServerCertificateRequest, cb)
 	assert(GetServerCertificateRequest, "You must provide a GetServerCertificateRequest")
 	local headers = {
@@ -17150,19 +17263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetServerCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetServerCertificateSync(GetServerCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetServerCertificateAsync(GetServerCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetServerCertificateAsync(GetServerCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachRolePolicy asynchronously, invoking a callback when done
 -- @param AttachRolePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachRolePolicyAsync(AttachRolePolicyRequest, cb)
 	assert(AttachRolePolicyRequest, "You must provide a AttachRolePolicyRequest")
 	local headers = {
@@ -17185,19 +17299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachRolePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachRolePolicySync(AttachRolePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachRolePolicyAsync(AttachRolePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachRolePolicyAsync(AttachRolePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveClientIDFromOpenIDConnectProvider asynchronously, invoking a callback when done
 -- @param RemoveClientIDFromOpenIDConnectProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveClientIDFromOpenIDConnectProviderAsync(RemoveClientIDFromOpenIDConnectProviderRequest, cb)
 	assert(RemoveClientIDFromOpenIDConnectProviderRequest, "You must provide a RemoveClientIDFromOpenIDConnectProviderRequest")
 	local headers = {
@@ -17220,19 +17335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveClientIDFromOpenIDConnectProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveClientIDFromOpenIDConnectProviderSync(RemoveClientIDFromOpenIDConnectProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveClientIDFromOpenIDConnectProviderAsync(RemoveClientIDFromOpenIDConnectProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveClientIDFromOpenIDConnectProviderAsync(RemoveClientIDFromOpenIDConnectProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAccountPasswordPolicy asynchronously, invoking a callback when done
 -- @param UpdateAccountPasswordPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAccountPasswordPolicyAsync(UpdateAccountPasswordPolicyRequest, cb)
 	assert(UpdateAccountPasswordPolicyRequest, "You must provide a UpdateAccountPasswordPolicyRequest")
 	local headers = {
@@ -17255,19 +17371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAccountPasswordPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAccountPasswordPolicySync(UpdateAccountPasswordPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAccountPasswordPolicyAsync(UpdateAccountPasswordPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAccountPasswordPolicyAsync(UpdateAccountPasswordPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRole asynchronously, invoking a callback when done
 -- @param GetRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRoleAsync(GetRoleRequest, cb)
 	assert(GetRoleRequest, "You must provide a GetRoleRequest")
 	local headers = {
@@ -17290,19 +17407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRoleSync(GetRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRoleAsync(GetRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRoleAsync(GetRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePolicyVersion asynchronously, invoking a callback when done
 -- @param DeletePolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePolicyVersionAsync(DeletePolicyVersionRequest, cb)
 	assert(DeletePolicyVersionRequest, "You must provide a DeletePolicyVersionRequest")
 	local headers = {
@@ -17325,19 +17443,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePolicyVersionSync(DeletePolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePolicyVersionAsync(DeletePolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePolicyVersionAsync(DeletePolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPolicies asynchronously, invoking a callback when done
 -- @param ListPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPoliciesAsync(ListPoliciesRequest, cb)
 	assert(ListPoliciesRequest, "You must provide a ListPoliciesRequest")
 	local headers = {
@@ -17360,19 +17479,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPoliciesSync(ListPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutUserPolicy asynchronously, invoking a callback when done
 -- @param PutUserPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutUserPolicyAsync(PutUserPolicyRequest, cb)
 	assert(PutUserPolicyRequest, "You must provide a PutUserPolicyRequest")
 	local headers = {
@@ -17395,19 +17515,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutUserPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutUserPolicySync(PutUserPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutUserPolicyAsync(PutUserPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutUserPolicyAsync(PutUserPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResyncMFADevice asynchronously, invoking a callback when done
 -- @param ResyncMFADeviceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResyncMFADeviceAsync(ResyncMFADeviceRequest, cb)
 	assert(ResyncMFADeviceRequest, "You must provide a ResyncMFADeviceRequest")
 	local headers = {
@@ -17430,19 +17551,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResyncMFADeviceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResyncMFADeviceSync(ResyncMFADeviceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResyncMFADeviceAsync(ResyncMFADeviceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResyncMFADeviceAsync(ResyncMFADeviceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteServerCertificate asynchronously, invoking a callback when done
 -- @param DeleteServerCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServerCertificateAsync(DeleteServerCertificateRequest, cb)
 	assert(DeleteServerCertificateRequest, "You must provide a DeleteServerCertificateRequest")
 	local headers = {
@@ -17465,18 +17587,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServerCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServerCertificateSync(DeleteServerCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServerCertificateAsync(DeleteServerCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServerCertificateAsync(DeleteServerCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountPasswordPolicy asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountPasswordPolicyAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -17495,19 +17618,20 @@ end
 --- Call GetAccountPasswordPolicy synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountPasswordPolicySync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountPasswordPolicyAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountPasswordPolicyAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInstanceProfile asynchronously, invoking a callback when done
 -- @param CreateInstanceProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInstanceProfileAsync(CreateInstanceProfileRequest, cb)
 	assert(CreateInstanceProfileRequest, "You must provide a CreateInstanceProfileRequest")
 	local headers = {
@@ -17530,19 +17654,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInstanceProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInstanceProfileSync(CreateInstanceProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInstanceProfileAsync(CreateInstanceProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInstanceProfileAsync(CreateInstanceProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteOpenIDConnectProvider asynchronously, invoking a callback when done
 -- @param DeleteOpenIDConnectProviderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteOpenIDConnectProviderAsync(DeleteOpenIDConnectProviderRequest, cb)
 	assert(DeleteOpenIDConnectProviderRequest, "You must provide a DeleteOpenIDConnectProviderRequest")
 	local headers = {
@@ -17565,19 +17690,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteOpenIDConnectProviderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteOpenIDConnectProviderSync(DeleteOpenIDConnectProviderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteOpenIDConnectProviderAsync(DeleteOpenIDConnectProviderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteOpenIDConnectProviderAsync(DeleteOpenIDConnectProviderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGroupPolicy asynchronously, invoking a callback when done
 -- @param DeleteGroupPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGroupPolicyAsync(DeleteGroupPolicyRequest, cb)
 	assert(DeleteGroupPolicyRequest, "You must provide a DeleteGroupPolicyRequest")
 	local headers = {
@@ -17600,12 +17726,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGroupPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGroupPolicySync(DeleteGroupPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGroupPolicyAsync(DeleteGroupPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGroupPolicyAsync(DeleteGroupPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/importexport.lua
+++ b/aws-sdk/importexport.lua
@@ -1966,7 +1966,7 @@ end
 --
 --- Call ListJobs asynchronously, invoking a callback when done
 -- @param ListJobsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsAsync(ListJobsInput, cb)
 	assert(ListJobsInput, "You must provide a ListJobsInput")
 	local headers = {
@@ -1989,19 +1989,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsSync(ListJobsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsAsync(ListJobsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsAsync(ListJobsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateJob asynchronously, invoking a callback when done
 -- @param UpdateJobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateJobAsync(UpdateJobInput, cb)
 	assert(UpdateJobInput, "You must provide a UpdateJobInput")
 	local headers = {
@@ -2024,19 +2025,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateJobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateJobSync(UpdateJobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateJobAsync(UpdateJobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateJobAsync(UpdateJobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJob asynchronously, invoking a callback when done
 -- @param CreateJobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobAsync(CreateJobInput, cb)
 	assert(CreateJobInput, "You must provide a CreateJobInput")
 	local headers = {
@@ -2059,19 +2061,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobSync(CreateJobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobAsync(CreateJobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobAsync(CreateJobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStatus asynchronously, invoking a callback when done
 -- @param GetStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStatusAsync(GetStatusInput, cb)
 	assert(GetStatusInput, "You must provide a GetStatusInput")
 	local headers = {
@@ -2094,19 +2097,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStatusSync(GetStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStatusAsync(GetStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStatusAsync(GetStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelJob asynchronously, invoking a callback when done
 -- @param CancelJobInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelJobAsync(CancelJobInput, cb)
 	assert(CancelJobInput, "You must provide a CancelJobInput")
 	local headers = {
@@ -2129,19 +2133,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelJobInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelJobSync(CancelJobInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelJobAsync(CancelJobInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelJobAsync(CancelJobInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetShippingLabel asynchronously, invoking a callback when done
 -- @param GetShippingLabelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetShippingLabelAsync(GetShippingLabelInput, cb)
 	assert(GetShippingLabelInput, "You must provide a GetShippingLabelInput")
 	local headers = {
@@ -2164,12 +2169,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetShippingLabelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetShippingLabelSync(GetShippingLabelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetShippingLabelAsync(GetShippingLabelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetShippingLabelAsync(GetShippingLabelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/inspector.lua
+++ b/aws-sdk/inspector.lua
@@ -5871,7 +5871,7 @@ end
 --
 --- Call DeleteAssessmentTarget asynchronously, invoking a callback when done
 -- @param DeleteAssessmentTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAssessmentTargetAsync(DeleteAssessmentTargetRequest, cb)
 	assert(DeleteAssessmentTargetRequest, "You must provide a DeleteAssessmentTargetRequest")
 	local headers = {
@@ -5894,19 +5894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAssessmentTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAssessmentTargetSync(DeleteAssessmentTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAssessmentTargetAsync(DeleteAssessmentTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAssessmentTargetAsync(DeleteAssessmentTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAssessmentTarget asynchronously, invoking a callback when done
 -- @param UpdateAssessmentTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAssessmentTargetAsync(UpdateAssessmentTargetRequest, cb)
 	assert(UpdateAssessmentTargetRequest, "You must provide a UpdateAssessmentTargetRequest")
 	local headers = {
@@ -5929,19 +5930,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAssessmentTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAssessmentTargetSync(UpdateAssessmentTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAssessmentTargetAsync(UpdateAssessmentTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAssessmentTargetAsync(UpdateAssessmentTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveAttributesFromFindings asynchronously, invoking a callback when done
 -- @param RemoveAttributesFromFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveAttributesFromFindingsAsync(RemoveAttributesFromFindingsRequest, cb)
 	assert(RemoveAttributesFromFindingsRequest, "You must provide a RemoveAttributesFromFindingsRequest")
 	local headers = {
@@ -5964,19 +5966,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveAttributesFromFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveAttributesFromFindingsSync(RemoveAttributesFromFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveAttributesFromFindingsAsync(RemoveAttributesFromFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveAttributesFromFindingsAsync(RemoveAttributesFromFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTelemetryMetadata asynchronously, invoking a callback when done
 -- @param GetTelemetryMetadataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTelemetryMetadataAsync(GetTelemetryMetadataRequest, cb)
 	assert(GetTelemetryMetadataRequest, "You must provide a GetTelemetryMetadataRequest")
 	local headers = {
@@ -5999,19 +6002,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTelemetryMetadataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTelemetryMetadataSync(GetTelemetryMetadataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTelemetryMetadataAsync(GetTelemetryMetadataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTelemetryMetadataAsync(GetTelemetryMetadataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAssessmentRuns asynchronously, invoking a callback when done
 -- @param DescribeAssessmentRunsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAssessmentRunsAsync(DescribeAssessmentRunsRequest, cb)
 	assert(DescribeAssessmentRunsRequest, "You must provide a DescribeAssessmentRunsRequest")
 	local headers = {
@@ -6034,19 +6038,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAssessmentRunsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAssessmentRunsSync(DescribeAssessmentRunsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAssessmentRunsAsync(DescribeAssessmentRunsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAssessmentRunsAsync(DescribeAssessmentRunsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartAssessmentRun asynchronously, invoking a callback when done
 -- @param StartAssessmentRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartAssessmentRunAsync(StartAssessmentRunRequest, cb)
 	assert(StartAssessmentRunRequest, "You must provide a StartAssessmentRunRequest")
 	local headers = {
@@ -6069,18 +6074,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartAssessmentRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartAssessmentRunSync(StartAssessmentRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartAssessmentRunAsync(StartAssessmentRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartAssessmentRunAsync(StartAssessmentRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCrossAccountAccessRole asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCrossAccountAccessRoleAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -6099,19 +6105,20 @@ end
 --- Call DescribeCrossAccountAccessRole synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCrossAccountAccessRoleSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCrossAccountAccessRoleAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCrossAccountAccessRoleAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAssessmentTargets asynchronously, invoking a callback when done
 -- @param DescribeAssessmentTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAssessmentTargetsAsync(DescribeAssessmentTargetsRequest, cb)
 	assert(DescribeAssessmentTargetsRequest, "You must provide a DescribeAssessmentTargetsRequest")
 	local headers = {
@@ -6134,19 +6141,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAssessmentTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAssessmentTargetsSync(DescribeAssessmentTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAssessmentTargetsAsync(DescribeAssessmentTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAssessmentTargetsAsync(DescribeAssessmentTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRulesPackages asynchronously, invoking a callback when done
 -- @param ListRulesPackagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRulesPackagesAsync(ListRulesPackagesRequest, cb)
 	assert(ListRulesPackagesRequest, "You must provide a ListRulesPackagesRequest")
 	local headers = {
@@ -6169,19 +6177,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRulesPackagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRulesPackagesSync(ListRulesPackagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRulesPackagesAsync(ListRulesPackagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRulesPackagesAsync(ListRulesPackagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopAssessmentRun asynchronously, invoking a callback when done
 -- @param StopAssessmentRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopAssessmentRunAsync(StopAssessmentRunRequest, cb)
 	assert(StopAssessmentRunRequest, "You must provide a StopAssessmentRunRequest")
 	local headers = {
@@ -6204,19 +6213,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopAssessmentRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopAssessmentRunSync(StopAssessmentRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopAssessmentRunAsync(StopAssessmentRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopAssessmentRunAsync(StopAssessmentRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssessmentTemplates asynchronously, invoking a callback when done
 -- @param ListAssessmentTemplatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssessmentTemplatesAsync(ListAssessmentTemplatesRequest, cb)
 	assert(ListAssessmentTemplatesRequest, "You must provide a ListAssessmentTemplatesRequest")
 	local headers = {
@@ -6239,19 +6249,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssessmentTemplatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssessmentTemplatesSync(ListAssessmentTemplatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssessmentTemplatesAsync(ListAssessmentTemplatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssessmentTemplatesAsync(ListAssessmentTemplatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFindings asynchronously, invoking a callback when done
 -- @param DescribeFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFindingsAsync(DescribeFindingsRequest, cb)
 	assert(DescribeFindingsRequest, "You must provide a DescribeFindingsRequest")
 	local headers = {
@@ -6274,19 +6285,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFindingsSync(DescribeFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFindingsAsync(DescribeFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFindingsAsync(DescribeFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAssessmentTemplate asynchronously, invoking a callback when done
 -- @param DeleteAssessmentTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAssessmentTemplateAsync(DeleteAssessmentTemplateRequest, cb)
 	assert(DeleteAssessmentTemplateRequest, "You must provide a DeleteAssessmentTemplateRequest")
 	local headers = {
@@ -6309,19 +6321,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAssessmentTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAssessmentTemplateSync(DeleteAssessmentTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAssessmentTemplateAsync(DeleteAssessmentTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAssessmentTemplateAsync(DeleteAssessmentTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeResourceGroups asynchronously, invoking a callback when done
 -- @param DescribeResourceGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeResourceGroupsAsync(DescribeResourceGroupsRequest, cb)
 	assert(DescribeResourceGroupsRequest, "You must provide a DescribeResourceGroupsRequest")
 	local headers = {
@@ -6344,19 +6357,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeResourceGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeResourceGroupsSync(DescribeResourceGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeResourceGroupsAsync(DescribeResourceGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeResourceGroupsAsync(DescribeResourceGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFindings asynchronously, invoking a callback when done
 -- @param ListFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFindingsAsync(ListFindingsRequest, cb)
 	assert(ListFindingsRequest, "You must provide a ListFindingsRequest")
 	local headers = {
@@ -6379,19 +6393,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFindingsSync(ListFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFindingsAsync(ListFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFindingsAsync(ListFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListEventSubscriptions asynchronously, invoking a callback when done
 -- @param ListEventSubscriptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEventSubscriptionsAsync(ListEventSubscriptionsRequest, cb)
 	assert(ListEventSubscriptionsRequest, "You must provide a ListEventSubscriptionsRequest")
 	local headers = {
@@ -6414,19 +6429,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEventSubscriptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEventSubscriptionsSync(ListEventSubscriptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEventSubscriptionsAsync(ListEventSubscriptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEventSubscriptionsAsync(ListEventSubscriptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssessmentTargets asynchronously, invoking a callback when done
 -- @param ListAssessmentTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssessmentTargetsAsync(ListAssessmentTargetsRequest, cb)
 	assert(ListAssessmentTargetsRequest, "You must provide a ListAssessmentTargetsRequest")
 	local headers = {
@@ -6449,19 +6465,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssessmentTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssessmentTargetsSync(ListAssessmentTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssessmentTargetsAsync(ListAssessmentTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssessmentTargetsAsync(ListAssessmentTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeExclusions asynchronously, invoking a callback when done
 -- @param DescribeExclusionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeExclusionsAsync(DescribeExclusionsRequest, cb)
 	assert(DescribeExclusionsRequest, "You must provide a DescribeExclusionsRequest")
 	local headers = {
@@ -6484,19 +6501,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeExclusionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeExclusionsSync(DescribeExclusionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeExclusionsAsync(DescribeExclusionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeExclusionsAsync(DescribeExclusionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListExclusions asynchronously, invoking a callback when done
 -- @param ListExclusionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListExclusionsAsync(ListExclusionsRequest, cb)
 	assert(ListExclusionsRequest, "You must provide a ListExclusionsRequest")
 	local headers = {
@@ -6519,19 +6537,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListExclusionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListExclusionsSync(ListExclusionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListExclusionsAsync(ListExclusionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListExclusionsAsync(ListExclusionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetExclusionsPreview asynchronously, invoking a callback when done
 -- @param GetExclusionsPreviewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetExclusionsPreviewAsync(GetExclusionsPreviewRequest, cb)
 	assert(GetExclusionsPreviewRequest, "You must provide a GetExclusionsPreviewRequest")
 	local headers = {
@@ -6554,19 +6573,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetExclusionsPreviewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetExclusionsPreviewSync(GetExclusionsPreviewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetExclusionsPreviewAsync(GetExclusionsPreviewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetExclusionsPreviewAsync(GetExclusionsPreviewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetTagsForResource asynchronously, invoking a callback when done
 -- @param SetTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetTagsForResourceAsync(SetTagsForResourceRequest, cb)
 	assert(SetTagsForResourceRequest, "You must provide a SetTagsForResourceRequest")
 	local headers = {
@@ -6589,19 +6609,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetTagsForResourceSync(SetTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetTagsForResourceAsync(SetTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetTagsForResourceAsync(SetTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAssessmentRun asynchronously, invoking a callback when done
 -- @param DeleteAssessmentRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAssessmentRunAsync(DeleteAssessmentRunRequest, cb)
 	assert(DeleteAssessmentRunRequest, "You must provide a DeleteAssessmentRunRequest")
 	local headers = {
@@ -6624,19 +6645,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAssessmentRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAssessmentRunSync(DeleteAssessmentRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAssessmentRunAsync(DeleteAssessmentRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAssessmentRunAsync(DeleteAssessmentRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAssessmentTarget asynchronously, invoking a callback when done
 -- @param CreateAssessmentTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAssessmentTargetAsync(CreateAssessmentTargetRequest, cb)
 	assert(CreateAssessmentTargetRequest, "You must provide a CreateAssessmentTargetRequest")
 	local headers = {
@@ -6659,19 +6681,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAssessmentTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAssessmentTargetSync(CreateAssessmentTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAssessmentTargetAsync(CreateAssessmentTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAssessmentTargetAsync(CreateAssessmentTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnsubscribeFromEvent asynchronously, invoking a callback when done
 -- @param UnsubscribeFromEventRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnsubscribeFromEventAsync(UnsubscribeFromEventRequest, cb)
 	assert(UnsubscribeFromEventRequest, "You must provide a UnsubscribeFromEventRequest")
 	local headers = {
@@ -6694,19 +6717,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnsubscribeFromEventRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnsubscribeFromEventSync(UnsubscribeFromEventRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnsubscribeFromEventAsync(UnsubscribeFromEventRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnsubscribeFromEventAsync(UnsubscribeFromEventRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssessmentRuns asynchronously, invoking a callback when done
 -- @param ListAssessmentRunsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssessmentRunsAsync(ListAssessmentRunsRequest, cb)
 	assert(ListAssessmentRunsRequest, "You must provide a ListAssessmentRunsRequest")
 	local headers = {
@@ -6729,19 +6753,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssessmentRunsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssessmentRunsSync(ListAssessmentRunsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssessmentRunsAsync(ListAssessmentRunsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssessmentRunsAsync(ListAssessmentRunsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateExclusionsPreview asynchronously, invoking a callback when done
 -- @param CreateExclusionsPreviewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateExclusionsPreviewAsync(CreateExclusionsPreviewRequest, cb)
 	assert(CreateExclusionsPreviewRequest, "You must provide a CreateExclusionsPreviewRequest")
 	local headers = {
@@ -6764,19 +6789,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateExclusionsPreviewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateExclusionsPreviewSync(CreateExclusionsPreviewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateExclusionsPreviewAsync(CreateExclusionsPreviewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateExclusionsPreviewAsync(CreateExclusionsPreviewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterCrossAccountAccessRole asynchronously, invoking a callback when done
 -- @param RegisterCrossAccountAccessRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterCrossAccountAccessRoleAsync(RegisterCrossAccountAccessRoleRequest, cb)
 	assert(RegisterCrossAccountAccessRoleRequest, "You must provide a RegisterCrossAccountAccessRoleRequest")
 	local headers = {
@@ -6799,19 +6825,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterCrossAccountAccessRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterCrossAccountAccessRoleSync(RegisterCrossAccountAccessRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterCrossAccountAccessRoleAsync(RegisterCrossAccountAccessRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterCrossAccountAccessRoleAsync(RegisterCrossAccountAccessRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddAttributesToFindings asynchronously, invoking a callback when done
 -- @param AddAttributesToFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddAttributesToFindingsAsync(AddAttributesToFindingsRequest, cb)
 	assert(AddAttributesToFindingsRequest, "You must provide a AddAttributesToFindingsRequest")
 	local headers = {
@@ -6834,19 +6861,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddAttributesToFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddAttributesToFindingsSync(AddAttributesToFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddAttributesToFindingsAsync(AddAttributesToFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddAttributesToFindingsAsync(AddAttributesToFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResourceGroup asynchronously, invoking a callback when done
 -- @param CreateResourceGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResourceGroupAsync(CreateResourceGroupRequest, cb)
 	assert(CreateResourceGroupRequest, "You must provide a CreateResourceGroupRequest")
 	local headers = {
@@ -6869,19 +6897,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResourceGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResourceGroupSync(CreateResourceGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResourceGroupAsync(CreateResourceGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResourceGroupAsync(CreateResourceGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAssessmentTemplates asynchronously, invoking a callback when done
 -- @param DescribeAssessmentTemplatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAssessmentTemplatesAsync(DescribeAssessmentTemplatesRequest, cb)
 	assert(DescribeAssessmentTemplatesRequest, "You must provide a DescribeAssessmentTemplatesRequest")
 	local headers = {
@@ -6904,19 +6933,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAssessmentTemplatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAssessmentTemplatesSync(DescribeAssessmentTemplatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAssessmentTemplatesAsync(DescribeAssessmentTemplatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAssessmentTemplatesAsync(DescribeAssessmentTemplatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PreviewAgents asynchronously, invoking a callback when done
 -- @param PreviewAgentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PreviewAgentsAsync(PreviewAgentsRequest, cb)
 	assert(PreviewAgentsRequest, "You must provide a PreviewAgentsRequest")
 	local headers = {
@@ -6939,19 +6969,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PreviewAgentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PreviewAgentsSync(PreviewAgentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PreviewAgentsAsync(PreviewAgentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PreviewAgentsAsync(PreviewAgentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAssessmentTemplate asynchronously, invoking a callback when done
 -- @param CreateAssessmentTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAssessmentTemplateAsync(CreateAssessmentTemplateRequest, cb)
 	assert(CreateAssessmentTemplateRequest, "You must provide a CreateAssessmentTemplateRequest")
 	local headers = {
@@ -6974,19 +7005,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAssessmentTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAssessmentTemplateSync(CreateAssessmentTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAssessmentTemplateAsync(CreateAssessmentTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAssessmentTemplateAsync(CreateAssessmentTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SubscribeToEvent asynchronously, invoking a callback when done
 -- @param SubscribeToEventRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SubscribeToEventAsync(SubscribeToEventRequest, cb)
 	assert(SubscribeToEventRequest, "You must provide a SubscribeToEventRequest")
 	local headers = {
@@ -7009,19 +7041,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SubscribeToEventRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SubscribeToEventSync(SubscribeToEventRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SubscribeToEventAsync(SubscribeToEventRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SubscribeToEventAsync(SubscribeToEventRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRulesPackages asynchronously, invoking a callback when done
 -- @param DescribeRulesPackagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRulesPackagesAsync(DescribeRulesPackagesRequest, cb)
 	assert(DescribeRulesPackagesRequest, "You must provide a DescribeRulesPackagesRequest")
 	local headers = {
@@ -7044,19 +7077,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRulesPackagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRulesPackagesSync(DescribeRulesPackagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRulesPackagesAsync(DescribeRulesPackagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRulesPackagesAsync(DescribeRulesPackagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -7079,19 +7113,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssessmentRunAgents asynchronously, invoking a callback when done
 -- @param ListAssessmentRunAgentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssessmentRunAgentsAsync(ListAssessmentRunAgentsRequest, cb)
 	assert(ListAssessmentRunAgentsRequest, "You must provide a ListAssessmentRunAgentsRequest")
 	local headers = {
@@ -7114,19 +7149,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssessmentRunAgentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssessmentRunAgentsSync(ListAssessmentRunAgentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssessmentRunAgentsAsync(ListAssessmentRunAgentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssessmentRunAgentsAsync(ListAssessmentRunAgentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAssessmentReport asynchronously, invoking a callback when done
 -- @param GetAssessmentReportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAssessmentReportAsync(GetAssessmentReportRequest, cb)
 	assert(GetAssessmentReportRequest, "You must provide a GetAssessmentReportRequest")
 	local headers = {
@@ -7149,12 +7185,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAssessmentReportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAssessmentReportSync(GetAssessmentReportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAssessmentReportAsync(GetAssessmentReportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAssessmentReportAsync(GetAssessmentReportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/iot.lua
+++ b/aws-sdk/iot.lua
@@ -21007,7 +21007,7 @@ end
 --
 --- Call ReplaceTopicRule asynchronously, invoking a callback when done
 -- @param ReplaceTopicRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReplaceTopicRuleAsync(ReplaceTopicRuleRequest, cb)
 	assert(ReplaceTopicRuleRequest, "You must provide a ReplaceTopicRuleRequest")
 	local headers = {
@@ -21030,19 +21030,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReplaceTopicRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReplaceTopicRuleSync(ReplaceTopicRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReplaceTopicRuleAsync(ReplaceTopicRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReplaceTopicRuleAsync(ReplaceTopicRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListViolationEvents asynchronously, invoking a callback when done
 -- @param ListViolationEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListViolationEventsAsync(ListViolationEventsRequest, cb)
 	assert(ListViolationEventsRequest, "You must provide a ListViolationEventsRequest")
 	local headers = {
@@ -21065,19 +21066,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListViolationEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListViolationEventsSync(ListViolationEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListViolationEventsAsync(ListViolationEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListViolationEventsAsync(ListViolationEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateThingGroupsForThing asynchronously, invoking a callback when done
 -- @param UpdateThingGroupsForThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateThingGroupsForThingAsync(UpdateThingGroupsForThingRequest, cb)
 	assert(UpdateThingGroupsForThingRequest, "You must provide a UpdateThingGroupsForThingRequest")
 	local headers = {
@@ -21100,19 +21102,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateThingGroupsForThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateThingGroupsForThingSync(UpdateThingGroupsForThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateThingGroupsForThingAsync(UpdateThingGroupsForThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateThingGroupsForThingAsync(UpdateThingGroupsForThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeprecateThingType asynchronously, invoking a callback when done
 -- @param DeprecateThingTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeprecateThingTypeAsync(DeprecateThingTypeRequest, cb)
 	assert(DeprecateThingTypeRequest, "You must provide a DeprecateThingTypeRequest")
 	local headers = {
@@ -21135,19 +21138,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeprecateThingTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeprecateThingTypeSync(DeprecateThingTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeprecateThingTypeAsync(DeprecateThingTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeprecateThingTypeAsync(DeprecateThingTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartOnDemandAuditTask asynchronously, invoking a callback when done
 -- @param StartOnDemandAuditTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartOnDemandAuditTaskAsync(StartOnDemandAuditTaskRequest, cb)
 	assert(StartOnDemandAuditTaskRequest, "You must provide a StartOnDemandAuditTaskRequest")
 	local headers = {
@@ -21170,19 +21174,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartOnDemandAuditTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartOnDemandAuditTaskSync(StartOnDemandAuditTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartOnDemandAuditTaskAsync(StartOnDemandAuditTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartOnDemandAuditTaskAsync(StartOnDemandAuditTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAuthorizers asynchronously, invoking a callback when done
 -- @param ListAuthorizersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAuthorizersAsync(ListAuthorizersRequest, cb)
 	assert(ListAuthorizersRequest, "You must provide a ListAuthorizersRequest")
 	local headers = {
@@ -21205,19 +21210,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAuthorizersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAuthorizersSync(ListAuthorizersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAuthorizersAsync(ListAuthorizersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAuthorizersAsync(ListAuthorizersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAuthorizer asynchronously, invoking a callback when done
 -- @param DeleteAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAuthorizerAsync(DeleteAuthorizerRequest, cb)
 	assert(DeleteAuthorizerRequest, "You must provide a DeleteAuthorizerRequest")
 	local headers = {
@@ -21240,19 +21246,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAuthorizerSync(DeleteAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAuthorizerAsync(DeleteAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAuthorizerAsync(DeleteAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetV2LoggingLevel asynchronously, invoking a callback when done
 -- @param SetV2LoggingLevelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetV2LoggingLevelAsync(SetV2LoggingLevelRequest, cb)
 	assert(SetV2LoggingLevelRequest, "You must provide a SetV2LoggingLevelRequest")
 	local headers = {
@@ -21275,19 +21282,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetV2LoggingLevelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetV2LoggingLevelSync(SetV2LoggingLevelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetV2LoggingLevelAsync(SetV2LoggingLevelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetV2LoggingLevelAsync(SetV2LoggingLevelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectCertificateTransfer asynchronously, invoking a callback when done
 -- @param RejectCertificateTransferRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectCertificateTransferAsync(RejectCertificateTransferRequest, cb)
 	assert(RejectCertificateTransferRequest, "You must provide a RejectCertificateTransferRequest")
 	local headers = {
@@ -21310,19 +21318,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectCertificateTransferRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectCertificateTransferSync(RejectCertificateTransferRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectCertificateTransferAsync(RejectCertificateTransferRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectCertificateTransferAsync(RejectCertificateTransferRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRoleAlias asynchronously, invoking a callback when done
 -- @param DeleteRoleAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRoleAliasAsync(DeleteRoleAliasRequest, cb)
 	assert(DeleteRoleAliasRequest, "You must provide a DeleteRoleAliasRequest")
 	local headers = {
@@ -21345,19 +21354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRoleAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRoleAliasSync(DeleteRoleAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRoleAliasAsync(DeleteRoleAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRoleAliasAsync(DeleteRoleAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSecurityProfile asynchronously, invoking a callback when done
 -- @param DescribeSecurityProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSecurityProfileAsync(DescribeSecurityProfileRequest, cb)
 	assert(DescribeSecurityProfileRequest, "You must provide a DescribeSecurityProfileRequest")
 	local headers = {
@@ -21380,19 +21390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSecurityProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSecurityProfileSync(DescribeSecurityProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSecurityProfileAsync(DescribeSecurityProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSecurityProfileAsync(DescribeSecurityProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAuditTasks asynchronously, invoking a callback when done
 -- @param ListAuditTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAuditTasksAsync(ListAuditTasksRequest, cb)
 	assert(ListAuditTasksRequest, "You must provide a ListAuditTasksRequest")
 	local headers = {
@@ -21415,19 +21426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAuditTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAuditTasksSync(ListAuditTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAuditTasksAsync(ListAuditTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAuditTasksAsync(ListAuditTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetDefaultAuthorizer asynchronously, invoking a callback when done
 -- @param SetDefaultAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetDefaultAuthorizerAsync(SetDefaultAuthorizerRequest, cb)
 	assert(SetDefaultAuthorizerRequest, "You must provide a SetDefaultAuthorizerRequest")
 	local headers = {
@@ -21450,19 +21462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetDefaultAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetDefaultAuthorizerSync(SetDefaultAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetDefaultAuthorizerAsync(SetDefaultAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetDefaultAuthorizerAsync(SetDefaultAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCACertificates asynchronously, invoking a callback when done
 -- @param ListCACertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCACertificatesAsync(ListCACertificatesRequest, cb)
 	assert(ListCACertificatesRequest, "You must provide a ListCACertificatesRequest")
 	local headers = {
@@ -21485,19 +21498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCACertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCACertificatesSync(ListCACertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCACertificatesAsync(ListCACertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCACertificatesAsync(ListCACertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTopicRule asynchronously, invoking a callback when done
 -- @param GetTopicRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTopicRuleAsync(GetTopicRuleRequest, cb)
 	assert(GetTopicRuleRequest, "You must provide a GetTopicRuleRequest")
 	local headers = {
@@ -21520,19 +21534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTopicRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTopicRuleSync(GetTopicRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTopicRuleAsync(GetTopicRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTopicRuleAsync(GetTopicRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAuthorizer asynchronously, invoking a callback when done
 -- @param DescribeAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAuthorizerAsync(DescribeAuthorizerRequest, cb)
 	assert(DescribeAuthorizerRequest, "You must provide a DescribeAuthorizerRequest")
 	local headers = {
@@ -21555,19 +21570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAuthorizerSync(DescribeAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAuthorizerAsync(DescribeAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAuthorizerAsync(DescribeAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDefaultAuthorizer asynchronously, invoking a callback when done
 -- @param DescribeDefaultAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDefaultAuthorizerAsync(DescribeDefaultAuthorizerRequest, cb)
 	assert(DescribeDefaultAuthorizerRequest, "You must provide a DescribeDefaultAuthorizerRequest")
 	local headers = {
@@ -21590,19 +21606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDefaultAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDefaultAuthorizerSync(DescribeDefaultAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDefaultAuthorizerAsync(DescribeDefaultAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDefaultAuthorizerAsync(DescribeDefaultAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobDocument asynchronously, invoking a callback when done
 -- @param GetJobDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobDocumentAsync(GetJobDocumentRequest, cb)
 	assert(GetJobDocumentRequest, "You must provide a GetJobDocumentRequest")
 	local headers = {
@@ -21625,19 +21642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobDocumentSync(GetJobDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobDocumentAsync(GetJobDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobDocumentAsync(GetJobDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAuditTask asynchronously, invoking a callback when done
 -- @param DescribeAuditTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAuditTaskAsync(DescribeAuditTaskRequest, cb)
 	assert(DescribeAuditTaskRequest, "You must provide a DescribeAuditTaskRequest")
 	local headers = {
@@ -21660,19 +21678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAuditTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAuditTaskSync(DescribeAuditTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAuditTaskAsync(DescribeAuditTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAuditTaskAsync(DescribeAuditTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStream asynchronously, invoking a callback when done
 -- @param DescribeStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStreamAsync(DescribeStreamRequest, cb)
 	assert(DescribeStreamRequest, "You must provide a DescribeStreamRequest")
 	local headers = {
@@ -21695,19 +21714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStreamSync(DescribeStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStreamAsync(DescribeStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStreamAsync(DescribeStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelJob asynchronously, invoking a callback when done
 -- @param CancelJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelJobAsync(CancelJobRequest, cb)
 	assert(CancelJobRequest, "You must provide a CancelJobRequest")
 	local headers = {
@@ -21730,19 +21750,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelJobSync(CancelJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelJobAsync(CancelJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelJobAsync(CancelJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTargetsForSecurityProfile asynchronously, invoking a callback when done
 -- @param ListTargetsForSecurityProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTargetsForSecurityProfileAsync(ListTargetsForSecurityProfileRequest, cb)
 	assert(ListTargetsForSecurityProfileRequest, "You must provide a ListTargetsForSecurityProfileRequest")
 	local headers = {
@@ -21765,19 +21786,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTargetsForSecurityProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTargetsForSecurityProfileSync(ListTargetsForSecurityProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTargetsForSecurityProfileAsync(ListTargetsForSecurityProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTargetsForSecurityProfileAsync(ListTargetsForSecurityProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterCACertificate asynchronously, invoking a callback when done
 -- @param RegisterCACertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterCACertificateAsync(RegisterCACertificateRequest, cb)
 	assert(RegisterCACertificateRequest, "You must provide a RegisterCACertificateRequest")
 	local headers = {
@@ -21800,19 +21822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterCACertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterCACertificateSync(RegisterCACertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterCACertificateAsync(RegisterCACertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterCACertificateAsync(RegisterCACertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEndpoint asynchronously, invoking a callback when done
 -- @param DescribeEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEndpointAsync(DescribeEndpointRequest, cb)
 	assert(DescribeEndpointRequest, "You must provide a DescribeEndpointRequest")
 	local headers = {
@@ -21835,19 +21858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEndpointSync(DescribeEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEndpointAsync(DescribeEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEndpointAsync(DescribeEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeThingType asynchronously, invoking a callback when done
 -- @param DescribeThingTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeThingTypeAsync(DescribeThingTypeRequest, cb)
 	assert(DescribeThingTypeRequest, "You must provide a DescribeThingTypeRequest")
 	local headers = {
@@ -21870,19 +21894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeThingTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeThingTypeSync(DescribeThingTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeThingTypeAsync(DescribeThingTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeThingTypeAsync(DescribeThingTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteJob asynchronously, invoking a callback when done
 -- @param DeleteJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteJobAsync(DeleteJobRequest, cb)
 	assert(DeleteJobRequest, "You must provide a DeleteJobRequest")
 	local headers = {
@@ -21905,19 +21930,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteJobSync(DeleteJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteJobAsync(DeleteJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteJobAsync(DeleteJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThingRegistrationTaskReports asynchronously, invoking a callback when done
 -- @param ListThingRegistrationTaskReportsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingRegistrationTaskReportsAsync(ListThingRegistrationTaskReportsRequest, cb)
 	assert(ListThingRegistrationTaskReportsRequest, "You must provide a ListThingRegistrationTaskReportsRequest")
 	local headers = {
@@ -21940,19 +21966,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingRegistrationTaskReportsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingRegistrationTaskReportsSync(ListThingRegistrationTaskReportsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingRegistrationTaskReportsAsync(ListThingRegistrationTaskReportsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingRegistrationTaskReportsAsync(ListThingRegistrationTaskReportsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachSecurityProfile asynchronously, invoking a callback when done
 -- @param DetachSecurityProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachSecurityProfileAsync(DetachSecurityProfileRequest, cb)
 	assert(DetachSecurityProfileRequest, "You must provide a DetachSecurityProfileRequest")
 	local headers = {
@@ -21975,19 +22002,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachSecurityProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachSecurityProfileSync(DetachSecurityProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachSecurityProfileAsync(DetachSecurityProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachSecurityProfileAsync(DetachSecurityProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJobExecution asynchronously, invoking a callback when done
 -- @param DescribeJobExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobExecutionAsync(DescribeJobExecutionRequest, cb)
 	assert(DescribeJobExecutionRequest, "You must provide a DescribeJobExecutionRequest")
 	local headers = {
@@ -22010,19 +22038,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobExecutionSync(DescribeJobExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobExecutionAsync(DescribeJobExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobExecutionAsync(DescribeJobExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeScheduledAudit asynchronously, invoking a callback when done
 -- @param DescribeScheduledAuditRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScheduledAuditAsync(DescribeScheduledAuditRequest, cb)
 	assert(DescribeScheduledAuditRequest, "You must provide a DescribeScheduledAuditRequest")
 	local headers = {
@@ -22045,19 +22074,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScheduledAuditRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScheduledAuditSync(DescribeScheduledAuditRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScheduledAuditAsync(DescribeScheduledAuditRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScheduledAuditAsync(DescribeScheduledAuditRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTopicRule asynchronously, invoking a callback when done
 -- @param DeleteTopicRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTopicRuleAsync(DeleteTopicRuleRequest, cb)
 	assert(DeleteTopicRuleRequest, "You must provide a DeleteTopicRuleRequest")
 	local headers = {
@@ -22080,19 +22110,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTopicRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTopicRuleSync(DeleteTopicRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTopicRuleAsync(DeleteTopicRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTopicRuleAsync(DeleteTopicRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteOTAUpdate asynchronously, invoking a callback when done
 -- @param DeleteOTAUpdateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteOTAUpdateAsync(DeleteOTAUpdateRequest, cb)
 	assert(DeleteOTAUpdateRequest, "You must provide a DeleteOTAUpdateRequest")
 	local headers = {
@@ -22115,19 +22146,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteOTAUpdateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteOTAUpdateSync(DeleteOTAUpdateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteOTAUpdateAsync(DeleteOTAUpdateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteOTAUpdateAsync(DeleteOTAUpdateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateThing asynchronously, invoking a callback when done
 -- @param UpdateThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateThingAsync(UpdateThingRequest, cb)
 	assert(UpdateThingRequest, "You must provide a UpdateThingRequest")
 	local headers = {
@@ -22150,19 +22182,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateThingSync(UpdateThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateThingAsync(UpdateThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateThingAsync(UpdateThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableTopicRule asynchronously, invoking a callback when done
 -- @param EnableTopicRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableTopicRuleAsync(EnableTopicRuleRequest, cb)
 	assert(EnableTopicRuleRequest, "You must provide a EnableTopicRuleRequest")
 	local headers = {
@@ -22185,19 +22218,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableTopicRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableTopicRuleSync(EnableTopicRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableTopicRuleAsync(EnableTopicRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableTopicRuleAsync(EnableTopicRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAccountAuditConfiguration asynchronously, invoking a callback when done
 -- @param UpdateAccountAuditConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAccountAuditConfigurationAsync(UpdateAccountAuditConfigurationRequest, cb)
 	assert(UpdateAccountAuditConfigurationRequest, "You must provide a UpdateAccountAuditConfigurationRequest")
 	local headers = {
@@ -22220,19 +22254,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAccountAuditConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAccountAuditConfigurationSync(UpdateAccountAuditConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAccountAuditConfigurationAsync(UpdateAccountAuditConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAccountAuditConfigurationAsync(UpdateAccountAuditConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPolicy asynchronously, invoking a callback when done
 -- @param GetPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPolicyAsync(GetPolicyRequest, cb)
 	assert(GetPolicyRequest, "You must provide a GetPolicyRequest")
 	local headers = {
@@ -22255,19 +22290,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPolicySync(GetPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPolicyAsync(GetPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPolicyAsync(GetPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TransferCertificate asynchronously, invoking a callback when done
 -- @param TransferCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TransferCertificateAsync(TransferCertificateRequest, cb)
 	assert(TransferCertificateRequest, "You must provide a TransferCertificateRequest")
 	local headers = {
@@ -22290,19 +22326,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TransferCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TransferCertificateSync(TransferCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TransferCertificateAsync(TransferCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TransferCertificateAsync(TransferCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteThingGroup asynchronously, invoking a callback when done
 -- @param DeleteThingGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteThingGroupAsync(DeleteThingGroupRequest, cb)
 	assert(DeleteThingGroupRequest, "You must provide a DeleteThingGroupRequest")
 	local headers = {
@@ -22325,19 +22362,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteThingGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteThingGroupSync(DeleteThingGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteThingGroupAsync(DeleteThingGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteThingGroupAsync(DeleteThingGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartThingRegistrationTask asynchronously, invoking a callback when done
 -- @param StartThingRegistrationTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartThingRegistrationTaskAsync(StartThingRegistrationTaskRequest, cb)
 	assert(StartThingRegistrationTaskRequest, "You must provide a StartThingRegistrationTaskRequest")
 	local headers = {
@@ -22360,19 +22398,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartThingRegistrationTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartThingRegistrationTaskSync(StartThingRegistrationTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartThingRegistrationTaskAsync(StartThingRegistrationTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartThingRegistrationTaskAsync(StartThingRegistrationTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchIndex asynchronously, invoking a callback when done
 -- @param SearchIndexRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchIndexAsync(SearchIndexRequest, cb)
 	assert(SearchIndexRequest, "You must provide a SearchIndexRequest")
 	local headers = {
@@ -22395,19 +22434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchIndexRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchIndexSync(SearchIndexRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchIndexAsync(SearchIndexRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchIndexAsync(SearchIndexRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCertificate asynchronously, invoking a callback when done
 -- @param DeleteCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCertificateAsync(DeleteCertificateRequest, cb)
 	assert(DeleteCertificateRequest, "You must provide a DeleteCertificateRequest")
 	local headers = {
@@ -22430,19 +22470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCertificateSync(DeleteCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCertificateAsync(DeleteCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCertificateAsync(DeleteCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStreams asynchronously, invoking a callback when done
 -- @param ListStreamsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStreamsAsync(ListStreamsRequest, cb)
 	assert(ListStreamsRequest, "You must provide a ListStreamsRequest")
 	local headers = {
@@ -22465,19 +22506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStreamsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStreamsSync(ListStreamsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStreamsAsync(ListStreamsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStreamsAsync(ListStreamsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetV2LoggingOptions asynchronously, invoking a callback when done
 -- @param GetV2LoggingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetV2LoggingOptionsAsync(GetV2LoggingOptionsRequest, cb)
 	assert(GetV2LoggingOptionsRequest, "You must provide a GetV2LoggingOptionsRequest")
 	local headers = {
@@ -22500,19 +22542,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetV2LoggingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetV2LoggingOptionsSync(GetV2LoggingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetV2LoggingOptionsAsync(GetV2LoggingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetV2LoggingOptionsAsync(GetV2LoggingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteV2LoggingLevel asynchronously, invoking a callback when done
 -- @param DeleteV2LoggingLevelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteV2LoggingLevelAsync(DeleteV2LoggingLevelRequest, cb)
 	assert(DeleteV2LoggingLevelRequest, "You must provide a DeleteV2LoggingLevelRequest")
 	local headers = {
@@ -22535,19 +22578,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteV2LoggingLevelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteV2LoggingLevelSync(DeleteV2LoggingLevelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteV2LoggingLevelAsync(DeleteV2LoggingLevelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteV2LoggingLevelAsync(DeleteV2LoggingLevelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOutgoingCertificates asynchronously, invoking a callback when done
 -- @param ListOutgoingCertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOutgoingCertificatesAsync(ListOutgoingCertificatesRequest, cb)
 	assert(ListOutgoingCertificatesRequest, "You must provide a ListOutgoingCertificatesRequest")
 	local headers = {
@@ -22570,19 +22614,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOutgoingCertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOutgoingCertificatesSync(ListOutgoingCertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOutgoingCertificatesAsync(ListOutgoingCertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOutgoingCertificatesAsync(ListOutgoingCertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachThingPrincipal asynchronously, invoking a callback when done
 -- @param AttachThingPrincipalRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachThingPrincipalAsync(AttachThingPrincipalRequest, cb)
 	assert(AttachThingPrincipalRequest, "You must provide a AttachThingPrincipalRequest")
 	local headers = {
@@ -22605,19 +22650,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachThingPrincipalRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachThingPrincipalSync(AttachThingPrincipalRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachThingPrincipalAsync(AttachThingPrincipalRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachThingPrincipalAsync(AttachThingPrincipalRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptCertificateTransfer asynchronously, invoking a callback when done
 -- @param AcceptCertificateTransferRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptCertificateTransferAsync(AcceptCertificateTransferRequest, cb)
 	assert(AcceptCertificateTransferRequest, "You must provide a AcceptCertificateTransferRequest")
 	local headers = {
@@ -22640,19 +22686,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptCertificateTransferRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptCertificateTransferSync(AcceptCertificateTransferRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptCertificateTransferAsync(AcceptCertificateTransferRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptCertificateTransferAsync(AcceptCertificateTransferRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAttachedPolicies asynchronously, invoking a callback when done
 -- @param ListAttachedPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAttachedPoliciesAsync(ListAttachedPoliciesRequest, cb)
 	assert(ListAttachedPoliciesRequest, "You must provide a ListAttachedPoliciesRequest")
 	local headers = {
@@ -22675,19 +22722,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAttachedPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAttachedPoliciesSync(ListAttachedPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAttachedPoliciesAsync(ListAttachedPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAttachedPoliciesAsync(ListAttachedPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ClearDefaultAuthorizer asynchronously, invoking a callback when done
 -- @param ClearDefaultAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ClearDefaultAuthorizerAsync(ClearDefaultAuthorizerRequest, cb)
 	assert(ClearDefaultAuthorizerRequest, "You must provide a ClearDefaultAuthorizerRequest")
 	local headers = {
@@ -22710,19 +22758,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ClearDefaultAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ClearDefaultAuthorizerSync(ClearDefaultAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ClearDefaultAuthorizerAsync(ClearDefaultAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ClearDefaultAuthorizerAsync(ClearDefaultAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAuthorizer asynchronously, invoking a callback when done
 -- @param CreateAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAuthorizerAsync(CreateAuthorizerRequest, cb)
 	assert(CreateAuthorizerRequest, "You must provide a CreateAuthorizerRequest")
 	local headers = {
@@ -22745,19 +22794,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAuthorizerSync(CreateAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAuthorizerAsync(CreateAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAuthorizerAsync(CreateAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestAuthorization asynchronously, invoking a callback when done
 -- @param TestAuthorizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestAuthorizationAsync(TestAuthorizationRequest, cb)
 	assert(TestAuthorizationRequest, "You must provide a TestAuthorizationRequest")
 	local headers = {
@@ -22780,19 +22830,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestAuthorizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestAuthorizationSync(TestAuthorizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestAuthorizationAsync(TestAuthorizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestAuthorizationAsync(TestAuthorizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelAuditTask asynchronously, invoking a callback when done
 -- @param CancelAuditTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelAuditTaskAsync(CancelAuditTaskRequest, cb)
 	assert(CancelAuditTaskRequest, "You must provide a CancelAuditTaskRequest")
 	local headers = {
@@ -22815,19 +22866,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelAuditTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelAuditTaskSync(CancelAuditTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelAuditTaskAsync(CancelAuditTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelAuditTaskAsync(CancelAuditTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIndexingConfiguration asynchronously, invoking a callback when done
 -- @param GetIndexingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIndexingConfigurationAsync(GetIndexingConfigurationRequest, cb)
 	assert(GetIndexingConfigurationRequest, "You must provide a GetIndexingConfigurationRequest")
 	local headers = {
@@ -22850,19 +22902,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIndexingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIndexingConfigurationSync(GetIndexingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIndexingConfigurationAsync(GetIndexingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIndexingConfigurationAsync(GetIndexingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRegistrationCode asynchronously, invoking a callback when done
 -- @param DeleteRegistrationCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRegistrationCodeAsync(DeleteRegistrationCodeRequest, cb)
 	assert(DeleteRegistrationCodeRequest, "You must provide a DeleteRegistrationCodeRequest")
 	local headers = {
@@ -22885,19 +22938,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRegistrationCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRegistrationCodeSync(DeleteRegistrationCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRegistrationCodeAsync(DeleteRegistrationCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRegistrationCodeAsync(DeleteRegistrationCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTopicRules asynchronously, invoking a callback when done
 -- @param ListTopicRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTopicRulesAsync(ListTopicRulesRequest, cb)
 	assert(ListTopicRulesRequest, "You must provide a ListTopicRulesRequest")
 	local headers = {
@@ -22920,19 +22974,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTopicRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTopicRulesSync(ListTopicRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTopicRulesAsync(ListTopicRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTopicRulesAsync(ListTopicRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePolicyVersion asynchronously, invoking a callback when done
 -- @param CreatePolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePolicyVersionAsync(CreatePolicyVersionRequest, cb)
 	assert(CreatePolicyVersionRequest, "You must provide a CreatePolicyVersionRequest")
 	local headers = {
@@ -22955,19 +23010,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePolicyVersionSync(CreatePolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePolicyVersionAsync(CreatePolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePolicyVersionAsync(CreatePolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListActiveViolations asynchronously, invoking a callback when done
 -- @param ListActiveViolationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListActiveViolationsAsync(ListActiveViolationsRequest, cb)
 	assert(ListActiveViolationsRequest, "You must provide a ListActiveViolationsRequest")
 	local headers = {
@@ -22990,19 +23046,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListActiveViolationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListActiveViolationsSync(ListActiveViolationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListActiveViolationsAsync(ListActiveViolationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListActiveViolationsAsync(ListActiveViolationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListScheduledAudits asynchronously, invoking a callback when done
 -- @param ListScheduledAuditsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListScheduledAuditsAsync(ListScheduledAuditsRequest, cb)
 	assert(ListScheduledAuditsRequest, "You must provide a ListScheduledAuditsRequest")
 	local headers = {
@@ -23025,19 +23082,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListScheduledAuditsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListScheduledAuditsSync(ListScheduledAuditsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListScheduledAuditsAsync(ListScheduledAuditsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListScheduledAuditsAsync(ListScheduledAuditsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteScheduledAudit asynchronously, invoking a callback when done
 -- @param DeleteScheduledAuditRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteScheduledAuditAsync(DeleteScheduledAuditRequest, cb)
 	assert(DeleteScheduledAuditRequest, "You must provide a DeleteScheduledAuditRequest")
 	local headers = {
@@ -23060,19 +23118,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteScheduledAuditRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteScheduledAuditSync(DeleteScheduledAuditRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteScheduledAuditAsync(DeleteScheduledAuditRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteScheduledAuditAsync(DeleteScheduledAuditRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeThingRegistrationTask asynchronously, invoking a callback when done
 -- @param DescribeThingRegistrationTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeThingRegistrationTaskAsync(DescribeThingRegistrationTaskRequest, cb)
 	assert(DescribeThingRegistrationTaskRequest, "You must provide a DescribeThingRegistrationTaskRequest")
 	local headers = {
@@ -23095,19 +23154,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeThingRegistrationTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeThingRegistrationTaskSync(DescribeThingRegistrationTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeThingRegistrationTaskAsync(DescribeThingRegistrationTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeThingRegistrationTaskAsync(DescribeThingRegistrationTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListV2LoggingLevels asynchronously, invoking a callback when done
 -- @param ListV2LoggingLevelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListV2LoggingLevelsAsync(ListV2LoggingLevelsRequest, cb)
 	assert(ListV2LoggingLevelsRequest, "You must provide a ListV2LoggingLevelsRequest")
 	local headers = {
@@ -23130,19 +23190,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListV2LoggingLevelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListV2LoggingLevelsSync(ListV2LoggingLevelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListV2LoggingLevelsAsync(ListV2LoggingLevelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListV2LoggingLevelsAsync(ListV2LoggingLevelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIndex asynchronously, invoking a callback when done
 -- @param DescribeIndexRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIndexAsync(DescribeIndexRequest, cb)
 	assert(DescribeIndexRequest, "You must provide a DescribeIndexRequest")
 	local headers = {
@@ -23165,19 +23226,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIndexRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIndexSync(DescribeIndexRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIndexAsync(DescribeIndexRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIndexAsync(DescribeIndexRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveThingFromThingGroup asynchronously, invoking a callback when done
 -- @param RemoveThingFromThingGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveThingFromThingGroupAsync(RemoveThingFromThingGroupRequest, cb)
 	assert(RemoveThingFromThingGroupRequest, "You must provide a RemoveThingFromThingGroupRequest")
 	local headers = {
@@ -23200,19 +23262,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveThingFromThingGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveThingFromThingGroupSync(RemoveThingFromThingGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveThingFromThingGroupAsync(RemoveThingFromThingGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveThingFromThingGroupAsync(RemoveThingFromThingGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOTAUpdate asynchronously, invoking a callback when done
 -- @param GetOTAUpdateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOTAUpdateAsync(GetOTAUpdateRequest, cb)
 	assert(GetOTAUpdateRequest, "You must provide a GetOTAUpdateRequest")
 	local headers = {
@@ -23235,19 +23298,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOTAUpdateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOTAUpdateSync(GetOTAUpdateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOTAUpdateAsync(GetOTAUpdateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOTAUpdateAsync(GetOTAUpdateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCertificates asynchronously, invoking a callback when done
 -- @param ListCertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCertificatesAsync(ListCertificatesRequest, cb)
 	assert(ListCertificatesRequest, "You must provide a ListCertificatesRequest")
 	local headers = {
@@ -23270,19 +23334,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCertificatesSync(ListCertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCertificatesAsync(ListCertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCertificatesAsync(ListCertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePolicy asynchronously, invoking a callback when done
 -- @param DeletePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePolicyAsync(DeletePolicyRequest, cb)
 	assert(DeletePolicyRequest, "You must provide a DeletePolicyRequest")
 	local headers = {
@@ -23305,19 +23370,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePolicySync(DeletePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePolicyVersion asynchronously, invoking a callback when done
 -- @param DeletePolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePolicyVersionAsync(DeletePolicyVersionRequest, cb)
 	assert(DeletePolicyVersionRequest, "You must provide a DeletePolicyVersionRequest")
 	local headers = {
@@ -23340,19 +23406,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePolicyVersionSync(DeletePolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePolicyVersionAsync(DeletePolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePolicyVersionAsync(DeletePolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRoleAlias asynchronously, invoking a callback when done
 -- @param CreateRoleAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRoleAliasAsync(CreateRoleAliasRequest, cb)
 	assert(CreateRoleAliasRequest, "You must provide a CreateRoleAliasRequest")
 	local headers = {
@@ -23375,19 +23442,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRoleAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRoleAliasSync(CreateRoleAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRoleAliasAsync(CreateRoleAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRoleAliasAsync(CreateRoleAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTopicRule asynchronously, invoking a callback when done
 -- @param CreateTopicRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTopicRuleAsync(CreateTopicRuleRequest, cb)
 	assert(CreateTopicRuleRequest, "You must provide a CreateTopicRuleRequest")
 	local headers = {
@@ -23410,19 +23478,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTopicRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTopicRuleSync(CreateTopicRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTopicRuleAsync(CreateTopicRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTopicRuleAsync(CreateTopicRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRoleAlias asynchronously, invoking a callback when done
 -- @param DescribeRoleAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRoleAliasAsync(DescribeRoleAliasRequest, cb)
 	assert(DescribeRoleAliasRequest, "You must provide a DescribeRoleAliasRequest")
 	local headers = {
@@ -23445,19 +23514,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRoleAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRoleAliasSync(DescribeRoleAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRoleAliasAsync(DescribeRoleAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRoleAliasAsync(DescribeRoleAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCertificatesByCA asynchronously, invoking a callback when done
 -- @param ListCertificatesByCARequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCertificatesByCAAsync(ListCertificatesByCARequest, cb)
 	assert(ListCertificatesByCARequest, "You must provide a ListCertificatesByCARequest")
 	local headers = {
@@ -23480,19 +23550,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCertificatesByCARequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCertificatesByCASync(ListCertificatesByCARequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCertificatesByCAAsync(ListCertificatesByCARequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCertificatesByCAAsync(ListCertificatesByCARequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateThingGroup asynchronously, invoking a callback when done
 -- @param CreateThingGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateThingGroupAsync(CreateThingGroupRequest, cb)
 	assert(CreateThingGroupRequest, "You must provide a CreateThingGroupRequest")
 	local headers = {
@@ -23515,19 +23586,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateThingGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateThingGroupSync(CreateThingGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateThingGroupAsync(CreateThingGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateThingGroupAsync(CreateThingGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateOTAUpdate asynchronously, invoking a callback when done
 -- @param CreateOTAUpdateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateOTAUpdateAsync(CreateOTAUpdateRequest, cb)
 	assert(CreateOTAUpdateRequest, "You must provide a CreateOTAUpdateRequest")
 	local headers = {
@@ -23550,19 +23622,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateOTAUpdateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateOTAUpdateSync(CreateOTAUpdateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateOTAUpdateAsync(CreateOTAUpdateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateOTAUpdateAsync(CreateOTAUpdateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateTargetsWithJob asynchronously, invoking a callback when done
 -- @param AssociateTargetsWithJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateTargetsWithJobAsync(AssociateTargetsWithJobRequest, cb)
 	assert(AssociateTargetsWithJobRequest, "You must provide a AssociateTargetsWithJobRequest")
 	local headers = {
@@ -23585,19 +23658,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateTargetsWithJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateTargetsWithJobSync(AssociateTargetsWithJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateTargetsWithJobAsync(AssociateTargetsWithJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateTargetsWithJobAsync(AssociateTargetsWithJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJob asynchronously, invoking a callback when done
 -- @param DescribeJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobAsync(DescribeJobRequest, cb)
 	assert(DescribeJobRequest, "You must provide a DescribeJobRequest")
 	local headers = {
@@ -23620,19 +23694,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobSync(DescribeJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobAsync(DescribeJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobAsync(DescribeJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCACertificate asynchronously, invoking a callback when done
 -- @param DescribeCACertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCACertificateAsync(DescribeCACertificateRequest, cb)
 	assert(DescribeCACertificateRequest, "You must provide a DescribeCACertificateRequest")
 	local headers = {
@@ -23655,19 +23730,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCACertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCACertificateSync(DescribeCACertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCACertificateAsync(DescribeCACertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCACertificateAsync(DescribeCACertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPolicyVersion asynchronously, invoking a callback when done
 -- @param GetPolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPolicyVersionAsync(GetPolicyVersionRequest, cb)
 	assert(GetPolicyVersionRequest, "You must provide a GetPolicyVersionRequest")
 	local headers = {
@@ -23690,19 +23766,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPolicyVersionSync(GetPolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPolicyVersionAsync(GetPolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPolicyVersionAsync(GetPolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThingRegistrationTasks asynchronously, invoking a callback when done
 -- @param ListThingRegistrationTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingRegistrationTasksAsync(ListThingRegistrationTasksRequest, cb)
 	assert(ListThingRegistrationTasksRequest, "You must provide a ListThingRegistrationTasksRequest")
 	local headers = {
@@ -23725,19 +23802,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingRegistrationTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingRegistrationTasksSync(ListThingRegistrationTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingRegistrationTasksAsync(ListThingRegistrationTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingRegistrationTasksAsync(ListThingRegistrationTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobs asynchronously, invoking a callback when done
 -- @param ListJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsAsync(ListJobsRequest, cb)
 	assert(ListJobsRequest, "You must provide a ListJobsRequest")
 	local headers = {
@@ -23760,19 +23838,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsSync(ListJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsAsync(ListJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsAsync(ListJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThingTypes asynchronously, invoking a callback when done
 -- @param ListThingTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingTypesAsync(ListThingTypesRequest, cb)
 	assert(ListThingTypesRequest, "You must provide a ListThingTypesRequest")
 	local headers = {
@@ -23795,19 +23874,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingTypesSync(ListThingTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingTypesAsync(ListThingTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingTypesAsync(ListThingTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateKeysAndCertificate asynchronously, invoking a callback when done
 -- @param CreateKeysAndCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateKeysAndCertificateAsync(CreateKeysAndCertificateRequest, cb)
 	assert(CreateKeysAndCertificateRequest, "You must provide a CreateKeysAndCertificateRequest")
 	local headers = {
@@ -23830,19 +23910,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateKeysAndCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateKeysAndCertificateSync(CreateKeysAndCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateKeysAndCertificateAsync(CreateKeysAndCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateKeysAndCertificateAsync(CreateKeysAndCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSecurityProfile asynchronously, invoking a callback when done
 -- @param DeleteSecurityProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSecurityProfileAsync(DeleteSecurityProfileRequest, cb)
 	assert(DeleteSecurityProfileRequest, "You must provide a DeleteSecurityProfileRequest")
 	local headers = {
@@ -23865,19 +23946,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSecurityProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSecurityProfileSync(DeleteSecurityProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSecurityProfileAsync(DeleteSecurityProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSecurityProfileAsync(DeleteSecurityProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ValidateSecurityProfileBehaviors asynchronously, invoking a callback when done
 -- @param ValidateSecurityProfileBehaviorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ValidateSecurityProfileBehaviorsAsync(ValidateSecurityProfileBehaviorsRequest, cb)
 	assert(ValidateSecurityProfileBehaviorsRequest, "You must provide a ValidateSecurityProfileBehaviorsRequest")
 	local headers = {
@@ -23900,19 +23982,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ValidateSecurityProfileBehaviorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ValidateSecurityProfileBehaviorsSync(ValidateSecurityProfileBehaviorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ValidateSecurityProfileBehaviorsAsync(ValidateSecurityProfileBehaviorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ValidateSecurityProfileBehaviorsAsync(ValidateSecurityProfileBehaviorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThings asynchronously, invoking a callback when done
 -- @param ListThingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingsAsync(ListThingsRequest, cb)
 	assert(ListThingsRequest, "You must provide a ListThingsRequest")
 	local headers = {
@@ -23935,19 +24018,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingsSync(ListThingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingsAsync(ListThingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingsAsync(ListThingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateScheduledAudit asynchronously, invoking a callback when done
 -- @param CreateScheduledAuditRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateScheduledAuditAsync(CreateScheduledAuditRequest, cb)
 	assert(CreateScheduledAuditRequest, "You must provide a CreateScheduledAuditRequest")
 	local headers = {
@@ -23970,19 +24054,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateScheduledAuditRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateScheduledAuditSync(CreateScheduledAuditRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateScheduledAuditAsync(CreateScheduledAuditRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateScheduledAuditAsync(CreateScheduledAuditRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRoleAliases asynchronously, invoking a callback when done
 -- @param ListRoleAliasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRoleAliasesAsync(ListRoleAliasesRequest, cb)
 	assert(ListRoleAliasesRequest, "You must provide a ListRoleAliasesRequest")
 	local headers = {
@@ -24005,19 +24090,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRoleAliasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRoleAliasesSync(ListRoleAliasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRoleAliasesAsync(ListRoleAliasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRoleAliasesAsync(ListRoleAliasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSecurityProfile asynchronously, invoking a callback when done
 -- @param CreateSecurityProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSecurityProfileAsync(CreateSecurityProfileRequest, cb)
 	assert(CreateSecurityProfileRequest, "You must provide a CreateSecurityProfileRequest")
 	local headers = {
@@ -24040,19 +24126,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSecurityProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSecurityProfileSync(CreateSecurityProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSecurityProfileAsync(CreateSecurityProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSecurityProfileAsync(CreateSecurityProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCertificate asynchronously, invoking a callback when done
 -- @param UpdateCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCertificateAsync(UpdateCertificateRequest, cb)
 	assert(UpdateCertificateRequest, "You must provide a UpdateCertificateRequest")
 	local headers = {
@@ -24075,19 +24162,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCertificateSync(UpdateCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCertificateAsync(UpdateCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCertificateAsync(UpdateCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRegistrationCode asynchronously, invoking a callback when done
 -- @param GetRegistrationCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRegistrationCodeAsync(GetRegistrationCodeRequest, cb)
 	assert(GetRegistrationCodeRequest, "You must provide a GetRegistrationCodeRequest")
 	local headers = {
@@ -24110,19 +24198,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRegistrationCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRegistrationCodeSync(GetRegistrationCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRegistrationCodeAsync(GetRegistrationCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRegistrationCodeAsync(GetRegistrationCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetV2LoggingOptions asynchronously, invoking a callback when done
 -- @param SetV2LoggingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetV2LoggingOptionsAsync(SetV2LoggingOptionsRequest, cb)
 	assert(SetV2LoggingOptionsRequest, "You must provide a SetV2LoggingOptionsRequest")
 	local headers = {
@@ -24145,19 +24234,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetV2LoggingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetV2LoggingOptionsSync(SetV2LoggingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetV2LoggingOptionsAsync(SetV2LoggingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetV2LoggingOptionsAsync(SetV2LoggingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPrincipalThings asynchronously, invoking a callback when done
 -- @param ListPrincipalThingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPrincipalThingsAsync(ListPrincipalThingsRequest, cb)
 	assert(ListPrincipalThingsRequest, "You must provide a ListPrincipalThingsRequest")
 	local headers = {
@@ -24180,19 +24270,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPrincipalThingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPrincipalThingsSync(ListPrincipalThingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPrincipalThingsAsync(ListPrincipalThingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPrincipalThingsAsync(ListPrincipalThingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelJobExecution asynchronously, invoking a callback when done
 -- @param CancelJobExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelJobExecutionAsync(CancelJobExecutionRequest, cb)
 	assert(CancelJobExecutionRequest, "You must provide a CancelJobExecutionRequest")
 	local headers = {
@@ -24215,19 +24306,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelJobExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelJobExecutionSync(CancelJobExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelJobExecutionAsync(CancelJobExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelJobExecutionAsync(CancelJobExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAuditFindings asynchronously, invoking a callback when done
 -- @param ListAuditFindingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAuditFindingsAsync(ListAuditFindingsRequest, cb)
 	assert(ListAuditFindingsRequest, "You must provide a ListAuditFindingsRequest")
 	local headers = {
@@ -24250,19 +24342,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAuditFindingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAuditFindingsSync(ListAuditFindingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAuditFindingsAsync(ListAuditFindingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAuditFindingsAsync(ListAuditFindingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteJobExecution asynchronously, invoking a callback when done
 -- @param DeleteJobExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteJobExecutionAsync(DeleteJobExecutionRequest, cb)
 	assert(DeleteJobExecutionRequest, "You must provide a DeleteJobExecutionRequest")
 	local headers = {
@@ -24285,19 +24378,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteJobExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteJobExecutionSync(DeleteJobExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteJobExecutionAsync(DeleteJobExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteJobExecutionAsync(DeleteJobExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEffectivePolicies asynchronously, invoking a callback when done
 -- @param GetEffectivePoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEffectivePoliciesAsync(GetEffectivePoliciesRequest, cb)
 	assert(GetEffectivePoliciesRequest, "You must provide a GetEffectivePoliciesRequest")
 	local headers = {
@@ -24320,19 +24414,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEffectivePoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEffectivePoliciesSync(GetEffectivePoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEffectivePoliciesAsync(GetEffectivePoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEffectivePoliciesAsync(GetEffectivePoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCertificateFromCsr asynchronously, invoking a callback when done
 -- @param CreateCertificateFromCsrRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCertificateFromCsrAsync(CreateCertificateFromCsrRequest, cb)
 	assert(CreateCertificateFromCsrRequest, "You must provide a CreateCertificateFromCsrRequest")
 	local headers = {
@@ -24355,19 +24450,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCertificateFromCsrRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCertificateFromCsrSync(CreateCertificateFromCsrRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCertificateFromCsrAsync(CreateCertificateFromCsrRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCertificateFromCsrAsync(CreateCertificateFromCsrRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetLoggingOptions asynchronously, invoking a callback when done
 -- @param SetLoggingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetLoggingOptionsAsync(SetLoggingOptionsRequest, cb)
 	assert(SetLoggingOptionsRequest, "You must provide a SetLoggingOptionsRequest")
 	local headers = {
@@ -24390,19 +24486,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetLoggingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetLoggingOptionsSync(SetLoggingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetLoggingOptionsAsync(SetLoggingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetLoggingOptionsAsync(SetLoggingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStream asynchronously, invoking a callback when done
 -- @param DeleteStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStreamAsync(DeleteStreamRequest, cb)
 	assert(DeleteStreamRequest, "You must provide a DeleteStreamRequest")
 	local headers = {
@@ -24425,19 +24522,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStreamSync(DeleteStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStreamAsync(DeleteStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStreamAsync(DeleteStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableTopicRule asynchronously, invoking a callback when done
 -- @param DisableTopicRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableTopicRuleAsync(DisableTopicRuleRequest, cb)
 	assert(DisableTopicRuleRequest, "You must provide a DisableTopicRuleRequest")
 	local headers = {
@@ -24460,19 +24558,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableTopicRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableTopicRuleSync(DisableTopicRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableTopicRuleAsync(DisableTopicRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableTopicRuleAsync(DisableTopicRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestInvokeAuthorizer asynchronously, invoking a callback when done
 -- @param TestInvokeAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestInvokeAuthorizerAsync(TestInvokeAuthorizerRequest, cb)
 	assert(TestInvokeAuthorizerRequest, "You must provide a TestInvokeAuthorizerRequest")
 	local headers = {
@@ -24495,19 +24594,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestInvokeAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestInvokeAuthorizerSync(TestInvokeAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestInvokeAuthorizerAsync(TestInvokeAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestInvokeAuthorizerAsync(TestInvokeAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIndexingConfiguration asynchronously, invoking a callback when done
 -- @param UpdateIndexingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIndexingConfigurationAsync(UpdateIndexingConfigurationRequest, cb)
 	assert(UpdateIndexingConfigurationRequest, "You must provide a UpdateIndexingConfigurationRequest")
 	local headers = {
@@ -24530,19 +24630,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateIndexingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIndexingConfigurationSync(UpdateIndexingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIndexingConfigurationAsync(UpdateIndexingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIndexingConfigurationAsync(UpdateIndexingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePolicy asynchronously, invoking a callback when done
 -- @param CreatePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePolicyAsync(CreatePolicyRequest, cb)
 	assert(CreatePolicyRequest, "You must provide a CreatePolicyRequest")
 	local headers = {
@@ -24565,19 +24666,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePolicySync(CreatePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePolicyAsync(CreatePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePolicyAsync(CreatePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachSecurityProfile asynchronously, invoking a callback when done
 -- @param AttachSecurityProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachSecurityProfileAsync(AttachSecurityProfileRequest, cb)
 	assert(AttachSecurityProfileRequest, "You must provide a AttachSecurityProfileRequest")
 	local headers = {
@@ -24600,19 +24702,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachSecurityProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachSecurityProfileSync(AttachSecurityProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachSecurityProfileAsync(AttachSecurityProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachSecurityProfileAsync(AttachSecurityProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobExecutionsForThing asynchronously, invoking a callback when done
 -- @param ListJobExecutionsForThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobExecutionsForThingAsync(ListJobExecutionsForThingRequest, cb)
 	assert(ListJobExecutionsForThingRequest, "You must provide a ListJobExecutionsForThingRequest")
 	local headers = {
@@ -24635,19 +24738,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobExecutionsForThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobExecutionsForThingSync(ListJobExecutionsForThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobExecutionsForThingAsync(ListJobExecutionsForThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobExecutionsForThingAsync(ListJobExecutionsForThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterCertificate asynchronously, invoking a callback when done
 -- @param RegisterCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterCertificateAsync(RegisterCertificateRequest, cb)
 	assert(RegisterCertificateRequest, "You must provide a RegisterCertificateRequest")
 	local headers = {
@@ -24670,19 +24774,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterCertificateSync(RegisterCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterCertificateAsync(RegisterCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterCertificateAsync(RegisterCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOTAUpdates asynchronously, invoking a callback when done
 -- @param ListOTAUpdatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOTAUpdatesAsync(ListOTAUpdatesRequest, cb)
 	assert(ListOTAUpdatesRequest, "You must provide a ListOTAUpdatesRequest")
 	local headers = {
@@ -24705,19 +24810,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOTAUpdatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOTAUpdatesSync(ListOTAUpdatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOTAUpdatesAsync(ListOTAUpdatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOTAUpdatesAsync(ListOTAUpdatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteThingType asynchronously, invoking a callback when done
 -- @param DeleteThingTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteThingTypeAsync(DeleteThingTypeRequest, cb)
 	assert(DeleteThingTypeRequest, "You must provide a DeleteThingTypeRequest")
 	local headers = {
@@ -24740,19 +24846,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteThingTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteThingTypeSync(DeleteThingTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteThingTypeAsync(DeleteThingTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteThingTypeAsync(DeleteThingTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeThingGroup asynchronously, invoking a callback when done
 -- @param DescribeThingGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeThingGroupAsync(DescribeThingGroupRequest, cb)
 	assert(DescribeThingGroupRequest, "You must provide a DescribeThingGroupRequest")
 	local headers = {
@@ -24775,19 +24882,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeThingGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeThingGroupSync(DescribeThingGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeThingGroupAsync(DescribeThingGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeThingGroupAsync(DescribeThingGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopThingRegistrationTask asynchronously, invoking a callback when done
 -- @param StopThingRegistrationTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopThingRegistrationTaskAsync(StopThingRegistrationTaskRequest, cb)
 	assert(StopThingRegistrationTaskRequest, "You must provide a StopThingRegistrationTaskRequest")
 	local headers = {
@@ -24810,19 +24918,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopThingRegistrationTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopThingRegistrationTaskSync(StopThingRegistrationTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopThingRegistrationTaskAsync(StopThingRegistrationTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopThingRegistrationTaskAsync(StopThingRegistrationTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddThingToThingGroup asynchronously, invoking a callback when done
 -- @param AddThingToThingGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddThingToThingGroupAsync(AddThingToThingGroupRequest, cb)
 	assert(AddThingToThingGroupRequest, "You must provide a AddThingToThingGroupRequest")
 	local headers = {
@@ -24845,19 +24954,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddThingToThingGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddThingToThingGroupSync(AddThingToThingGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddThingToThingGroupAsync(AddThingToThingGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddThingToThingGroupAsync(AddThingToThingGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetDefaultPolicyVersion asynchronously, invoking a callback when done
 -- @param SetDefaultPolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetDefaultPolicyVersionAsync(SetDefaultPolicyVersionRequest, cb)
 	assert(SetDefaultPolicyVersionRequest, "You must provide a SetDefaultPolicyVersionRequest")
 	local headers = {
@@ -24880,19 +24990,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetDefaultPolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetDefaultPolicyVersionSync(SetDefaultPolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetDefaultPolicyVersionAsync(SetDefaultPolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetDefaultPolicyVersionAsync(SetDefaultPolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPolicyVersions asynchronously, invoking a callback when done
 -- @param ListPolicyVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPolicyVersionsAsync(ListPolicyVersionsRequest, cb)
 	assert(ListPolicyVersionsRequest, "You must provide a ListPolicyVersionsRequest")
 	local headers = {
@@ -24915,19 +25026,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPolicyVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPolicyVersionsSync(ListPolicyVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPolicyVersionsAsync(ListPolicyVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPolicyVersionsAsync(ListPolicyVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountAuditConfiguration asynchronously, invoking a callback when done
 -- @param DescribeAccountAuditConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountAuditConfigurationAsync(DescribeAccountAuditConfigurationRequest, cb)
 	assert(DescribeAccountAuditConfigurationRequest, "You must provide a DescribeAccountAuditConfigurationRequest")
 	local headers = {
@@ -24950,19 +25062,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountAuditConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountAuditConfigurationSync(DescribeAccountAuditConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountAuditConfigurationAsync(DescribeAccountAuditConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountAuditConfigurationAsync(DescribeAccountAuditConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoggingOptions asynchronously, invoking a callback when done
 -- @param GetLoggingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoggingOptionsAsync(GetLoggingOptionsRequest, cb)
 	assert(GetLoggingOptionsRequest, "You must provide a GetLoggingOptionsRequest")
 	local headers = {
@@ -24985,19 +25098,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoggingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoggingOptionsSync(GetLoggingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoggingOptionsAsync(GetLoggingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoggingOptionsAsync(GetLoggingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachPolicy asynchronously, invoking a callback when done
 -- @param DetachPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachPolicyAsync(DetachPolicyRequest, cb)
 	assert(DetachPolicyRequest, "You must provide a DetachPolicyRequest")
 	local headers = {
@@ -25020,19 +25134,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachPolicySync(DetachPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachPolicyAsync(DetachPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachPolicyAsync(DetachPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThingGroups asynchronously, invoking a callback when done
 -- @param ListThingGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingGroupsAsync(ListThingGroupsRequest, cb)
 	assert(ListThingGroupsRequest, "You must provide a ListThingGroupsRequest")
 	local headers = {
@@ -25055,19 +25170,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingGroupsSync(ListThingGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingGroupsAsync(ListThingGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingGroupsAsync(ListThingGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterThing asynchronously, invoking a callback when done
 -- @param RegisterThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterThingAsync(RegisterThingRequest, cb)
 	assert(RegisterThingRequest, "You must provide a RegisterThingRequest")
 	local headers = {
@@ -25090,19 +25206,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterThingSync(RegisterThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterThingAsync(RegisterThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterThingAsync(RegisterThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRoleAlias asynchronously, invoking a callback when done
 -- @param UpdateRoleAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRoleAliasAsync(UpdateRoleAliasRequest, cb)
 	assert(UpdateRoleAliasRequest, "You must provide a UpdateRoleAliasRequest")
 	local headers = {
@@ -25125,19 +25242,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRoleAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRoleAliasSync(UpdateRoleAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRoleAliasAsync(UpdateRoleAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRoleAliasAsync(UpdateRoleAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCACertificate asynchronously, invoking a callback when done
 -- @param DeleteCACertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCACertificateAsync(DeleteCACertificateRequest, cb)
 	assert(DeleteCACertificateRequest, "You must provide a DeleteCACertificateRequest")
 	local headers = {
@@ -25160,19 +25278,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCACertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCACertificateSync(DeleteCACertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCACertificateAsync(DeleteCACertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCACertificateAsync(DeleteCACertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSecurityProfile asynchronously, invoking a callback when done
 -- @param UpdateSecurityProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSecurityProfileAsync(UpdateSecurityProfileRequest, cb)
 	assert(UpdateSecurityProfileRequest, "You must provide a UpdateSecurityProfileRequest")
 	local headers = {
@@ -25195,19 +25314,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSecurityProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSecurityProfileSync(UpdateSecurityProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSecurityProfileAsync(UpdateSecurityProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSecurityProfileAsync(UpdateSecurityProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateThingType asynchronously, invoking a callback when done
 -- @param CreateThingTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateThingTypeAsync(CreateThingTypeRequest, cb)
 	assert(CreateThingTypeRequest, "You must provide a CreateThingTypeRequest")
 	local headers = {
@@ -25230,19 +25350,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateThingTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateThingTypeSync(CreateThingTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateThingTypeAsync(CreateThingTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateThingTypeAsync(CreateThingTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAccountAuditConfiguration asynchronously, invoking a callback when done
 -- @param DeleteAccountAuditConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAccountAuditConfigurationAsync(DeleteAccountAuditConfigurationRequest, cb)
 	assert(DeleteAccountAuditConfigurationRequest, "You must provide a DeleteAccountAuditConfigurationRequest")
 	local headers = {
@@ -25265,19 +25386,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAccountAuditConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAccountAuditConfigurationSync(DeleteAccountAuditConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAccountAuditConfigurationAsync(DeleteAccountAuditConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAccountAuditConfigurationAsync(DeleteAccountAuditConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStream asynchronously, invoking a callback when done
 -- @param UpdateStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStreamAsync(UpdateStreamRequest, cb)
 	assert(UpdateStreamRequest, "You must provide a UpdateStreamRequest")
 	local headers = {
@@ -25300,19 +25422,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStreamSync(UpdateStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStreamAsync(UpdateStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStreamAsync(UpdateStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJob asynchronously, invoking a callback when done
 -- @param CreateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobAsync(CreateJobRequest, cb)
 	assert(CreateJobRequest, "You must provide a CreateJobRequest")
 	local headers = {
@@ -25335,19 +25458,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobSync(CreateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobAsync(CreateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobAsync(CreateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteThing asynchronously, invoking a callback when done
 -- @param DeleteThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteThingAsync(DeleteThingRequest, cb)
 	assert(DeleteThingRequest, "You must provide a DeleteThingRequest")
 	local headers = {
@@ -25370,19 +25494,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteThingSync(DeleteThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteThingAsync(DeleteThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteThingAsync(DeleteThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachPolicy asynchronously, invoking a callback when done
 -- @param AttachPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachPolicyAsync(AttachPolicyRequest, cb)
 	assert(AttachPolicyRequest, "You must provide a AttachPolicyRequest")
 	local headers = {
@@ -25405,19 +25530,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachPolicySync(AttachPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachPolicyAsync(AttachPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachPolicyAsync(AttachPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSecurityProfilesForTarget asynchronously, invoking a callback when done
 -- @param ListSecurityProfilesForTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSecurityProfilesForTargetAsync(ListSecurityProfilesForTargetRequest, cb)
 	assert(ListSecurityProfilesForTargetRequest, "You must provide a ListSecurityProfilesForTargetRequest")
 	local headers = {
@@ -25440,19 +25566,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSecurityProfilesForTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSecurityProfilesForTargetSync(ListSecurityProfilesForTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSecurityProfilesForTargetAsync(ListSecurityProfilesForTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSecurityProfilesForTargetAsync(ListSecurityProfilesForTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobExecutionsForJob asynchronously, invoking a callback when done
 -- @param ListJobExecutionsForJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobExecutionsForJobAsync(ListJobExecutionsForJobRequest, cb)
 	assert(ListJobExecutionsForJobRequest, "You must provide a ListJobExecutionsForJobRequest")
 	local headers = {
@@ -25475,19 +25602,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobExecutionsForJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobExecutionsForJobSync(ListJobExecutionsForJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobExecutionsForJobAsync(ListJobExecutionsForJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobExecutionsForJobAsync(ListJobExecutionsForJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIndices asynchronously, invoking a callback when done
 -- @param ListIndicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIndicesAsync(ListIndicesRequest, cb)
 	assert(ListIndicesRequest, "You must provide a ListIndicesRequest")
 	local headers = {
@@ -25510,19 +25638,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIndicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIndicesSync(ListIndicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIndicesAsync(ListIndicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIndicesAsync(ListIndicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCACertificate asynchronously, invoking a callback when done
 -- @param UpdateCACertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCACertificateAsync(UpdateCACertificateRequest, cb)
 	assert(UpdateCACertificateRequest, "You must provide a UpdateCACertificateRequest")
 	local headers = {
@@ -25545,19 +25674,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCACertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCACertificateSync(UpdateCACertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCACertificateAsync(UpdateCACertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCACertificateAsync(UpdateCACertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAuthorizer asynchronously, invoking a callback when done
 -- @param UpdateAuthorizerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAuthorizerAsync(UpdateAuthorizerRequest, cb)
 	assert(UpdateAuthorizerRequest, "You must provide a UpdateAuthorizerRequest")
 	local headers = {
@@ -25580,19 +25710,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAuthorizerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAuthorizerSync(UpdateAuthorizerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAuthorizerAsync(UpdateAuthorizerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAuthorizerAsync(UpdateAuthorizerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStream asynchronously, invoking a callback when done
 -- @param CreateStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStreamAsync(CreateStreamRequest, cb)
 	assert(CreateStreamRequest, "You must provide a CreateStreamRequest")
 	local headers = {
@@ -25615,19 +25746,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStreamSync(CreateStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStreamAsync(CreateStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStreamAsync(CreateStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEventConfigurations asynchronously, invoking a callback when done
 -- @param UpdateEventConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEventConfigurationsAsync(UpdateEventConfigurationsRequest, cb)
 	assert(UpdateEventConfigurationsRequest, "You must provide a UpdateEventConfigurationsRequest")
 	local headers = {
@@ -25650,19 +25782,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEventConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEventConfigurationsSync(UpdateEventConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEventConfigurationsAsync(UpdateEventConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEventConfigurationsAsync(UpdateEventConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelCertificateTransfer asynchronously, invoking a callback when done
 -- @param CancelCertificateTransferRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelCertificateTransferAsync(CancelCertificateTransferRequest, cb)
 	assert(CancelCertificateTransferRequest, "You must provide a CancelCertificateTransferRequest")
 	local headers = {
@@ -25685,19 +25818,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelCertificateTransferRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelCertificateTransferSync(CancelCertificateTransferRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelCertificateTransferAsync(CancelCertificateTransferRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelCertificateTransferAsync(CancelCertificateTransferRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThingsInThingGroup asynchronously, invoking a callback when done
 -- @param ListThingsInThingGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingsInThingGroupAsync(ListThingsInThingGroupRequest, cb)
 	assert(ListThingsInThingGroupRequest, "You must provide a ListThingsInThingGroupRequest")
 	local headers = {
@@ -25720,19 +25854,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingsInThingGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingsInThingGroupSync(ListThingsInThingGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingsInThingGroupAsync(ListThingsInThingGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingsInThingGroupAsync(ListThingsInThingGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCertificate asynchronously, invoking a callback when done
 -- @param DescribeCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCertificateAsync(DescribeCertificateRequest, cb)
 	assert(DescribeCertificateRequest, "You must provide a DescribeCertificateRequest")
 	local headers = {
@@ -25755,19 +25890,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCertificateSync(DescribeCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCertificateAsync(DescribeCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCertificateAsync(DescribeCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventConfigurations asynchronously, invoking a callback when done
 -- @param DescribeEventConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventConfigurationsAsync(DescribeEventConfigurationsRequest, cb)
 	assert(DescribeEventConfigurationsRequest, "You must provide a DescribeEventConfigurationsRequest")
 	local headers = {
@@ -25790,19 +25926,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventConfigurationsSync(DescribeEventConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventConfigurationsAsync(DescribeEventConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventConfigurationsAsync(DescribeEventConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSecurityProfiles asynchronously, invoking a callback when done
 -- @param ListSecurityProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSecurityProfilesAsync(ListSecurityProfilesRequest, cb)
 	assert(ListSecurityProfilesRequest, "You must provide a ListSecurityProfilesRequest")
 	local headers = {
@@ -25825,19 +25962,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSecurityProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSecurityProfilesSync(ListSecurityProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSecurityProfilesAsync(ListSecurityProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSecurityProfilesAsync(ListSecurityProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachThingPrincipal asynchronously, invoking a callback when done
 -- @param DetachThingPrincipalRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachThingPrincipalAsync(DetachThingPrincipalRequest, cb)
 	assert(DetachThingPrincipalRequest, "You must provide a DetachThingPrincipalRequest")
 	local headers = {
@@ -25860,19 +25998,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachThingPrincipalRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachThingPrincipalSync(DetachThingPrincipalRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachThingPrincipalAsync(DetachThingPrincipalRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachThingPrincipalAsync(DetachThingPrincipalRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTargetsForPolicy asynchronously, invoking a callback when done
 -- @param ListTargetsForPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTargetsForPolicyAsync(ListTargetsForPolicyRequest, cb)
 	assert(ListTargetsForPolicyRequest, "You must provide a ListTargetsForPolicyRequest")
 	local headers = {
@@ -25895,19 +26034,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTargetsForPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTargetsForPolicySync(ListTargetsForPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTargetsForPolicyAsync(ListTargetsForPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTargetsForPolicyAsync(ListTargetsForPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPolicies asynchronously, invoking a callback when done
 -- @param ListPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPoliciesAsync(ListPoliciesRequest, cb)
 	assert(ListPoliciesRequest, "You must provide a ListPoliciesRequest")
 	local headers = {
@@ -25930,19 +26070,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPoliciesSync(ListPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateThing asynchronously, invoking a callback when done
 -- @param CreateThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateThingAsync(CreateThingRequest, cb)
 	assert(CreateThingRequest, "You must provide a CreateThingRequest")
 	local headers = {
@@ -25965,19 +26106,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateThingSync(CreateThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateThingAsync(CreateThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateThingAsync(CreateThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThingGroupsForThing asynchronously, invoking a callback when done
 -- @param ListThingGroupsForThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingGroupsForThingAsync(ListThingGroupsForThingRequest, cb)
 	assert(ListThingGroupsForThingRequest, "You must provide a ListThingGroupsForThingRequest")
 	local headers = {
@@ -26000,19 +26142,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingGroupsForThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingGroupsForThingSync(ListThingGroupsForThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingGroupsForThingAsync(ListThingGroupsForThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingGroupsForThingAsync(ListThingGroupsForThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateScheduledAudit asynchronously, invoking a callback when done
 -- @param UpdateScheduledAuditRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateScheduledAuditAsync(UpdateScheduledAuditRequest, cb)
 	assert(UpdateScheduledAuditRequest, "You must provide a UpdateScheduledAuditRequest")
 	local headers = {
@@ -26035,19 +26178,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateScheduledAuditRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateScheduledAuditSync(UpdateScheduledAuditRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateScheduledAuditAsync(UpdateScheduledAuditRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateScheduledAuditAsync(UpdateScheduledAuditRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListThingPrincipals asynchronously, invoking a callback when done
 -- @param ListThingPrincipalsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListThingPrincipalsAsync(ListThingPrincipalsRequest, cb)
 	assert(ListThingPrincipalsRequest, "You must provide a ListThingPrincipalsRequest")
 	local headers = {
@@ -26070,19 +26214,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListThingPrincipalsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListThingPrincipalsSync(ListThingPrincipalsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListThingPrincipalsAsync(ListThingPrincipalsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListThingPrincipalsAsync(ListThingPrincipalsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateThingGroup asynchronously, invoking a callback when done
 -- @param UpdateThingGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateThingGroupAsync(UpdateThingGroupRequest, cb)
 	assert(UpdateThingGroupRequest, "You must provide a UpdateThingGroupRequest")
 	local headers = {
@@ -26105,19 +26250,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateThingGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateThingGroupSync(UpdateThingGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateThingGroupAsync(UpdateThingGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateThingGroupAsync(UpdateThingGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeThing asynchronously, invoking a callback when done
 -- @param DescribeThingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeThingAsync(DescribeThingRequest, cb)
 	assert(DescribeThingRequest, "You must provide a DescribeThingRequest")
 	local headers = {
@@ -26140,12 +26286,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeThingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeThingSync(DescribeThingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeThingAsync(DescribeThingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeThingAsync(DescribeThingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/iotanalytics.lua
+++ b/aws-sdk/iotanalytics.lua
@@ -5481,7 +5481,7 @@ end
 --
 --- Call DeleteChannel asynchronously, invoking a callback when done
 -- @param DeleteChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteChannelAsync(DeleteChannelRequest, cb)
 	assert(DeleteChannelRequest, "You must provide a DeleteChannelRequest")
 	local headers = {
@@ -5504,19 +5504,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteChannelSync(DeleteChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteChannelAsync(DeleteChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteChannelAsync(DeleteChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateChannel asynchronously, invoking a callback when done
 -- @param UpdateChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateChannelAsync(UpdateChannelRequest, cb)
 	assert(UpdateChannelRequest, "You must provide a UpdateChannelRequest")
 	local headers = {
@@ -5539,19 +5540,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateChannelSync(UpdateChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateChannelAsync(UpdateChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateChannelAsync(UpdateChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelPipelineReprocessing asynchronously, invoking a callback when done
 -- @param CancelPipelineReprocessingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelPipelineReprocessingAsync(CancelPipelineReprocessingRequest, cb)
 	assert(CancelPipelineReprocessingRequest, "You must provide a CancelPipelineReprocessingRequest")
 	local headers = {
@@ -5574,19 +5576,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelPipelineReprocessingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelPipelineReprocessingSync(CancelPipelineReprocessingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelPipelineReprocessingAsync(CancelPipelineReprocessingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelPipelineReprocessingAsync(CancelPipelineReprocessingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchPutMessage asynchronously, invoking a callback when done
 -- @param BatchPutMessageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchPutMessageAsync(BatchPutMessageRequest, cb)
 	assert(BatchPutMessageRequest, "You must provide a BatchPutMessageRequest")
 	local headers = {
@@ -5609,19 +5612,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchPutMessageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchPutMessageSync(BatchPutMessageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchPutMessageAsync(BatchPutMessageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchPutMessageAsync(BatchPutMessageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateChannel asynchronously, invoking a callback when done
 -- @param CreateChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateChannelAsync(CreateChannelRequest, cb)
 	assert(CreateChannelRequest, "You must provide a CreateChannelRequest")
 	local headers = {
@@ -5644,19 +5648,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateChannelSync(CreateChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateChannelAsync(CreateChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateChannelAsync(CreateChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDataset asynchronously, invoking a callback when done
 -- @param DeleteDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDatasetAsync(DeleteDatasetRequest, cb)
 	assert(DeleteDatasetRequest, "You must provide a DeleteDatasetRequest")
 	local headers = {
@@ -5679,19 +5684,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDatasetSync(DeleteDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDatasetAsync(DeleteDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDatasetAsync(DeleteDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLoggingOptions asynchronously, invoking a callback when done
 -- @param DescribeLoggingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLoggingOptionsAsync(DescribeLoggingOptionsRequest, cb)
 	assert(DescribeLoggingOptionsRequest, "You must provide a DescribeLoggingOptionsRequest")
 	local headers = {
@@ -5714,19 +5720,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLoggingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLoggingOptionsSync(DescribeLoggingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLoggingOptionsAsync(DescribeLoggingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLoggingOptionsAsync(DescribeLoggingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RunPipelineActivity asynchronously, invoking a callback when done
 -- @param RunPipelineActivityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RunPipelineActivityAsync(RunPipelineActivityRequest, cb)
 	assert(RunPipelineActivityRequest, "You must provide a RunPipelineActivityRequest")
 	local headers = {
@@ -5749,19 +5756,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RunPipelineActivityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RunPipelineActivitySync(RunPipelineActivityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RunPipelineActivityAsync(RunPipelineActivityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RunPipelineActivityAsync(RunPipelineActivityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDatasets asynchronously, invoking a callback when done
 -- @param ListDatasetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDatasetsAsync(ListDatasetsRequest, cb)
 	assert(ListDatasetsRequest, "You must provide a ListDatasetsRequest")
 	local headers = {
@@ -5784,19 +5792,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDatasetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDatasetsSync(ListDatasetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDatasetsAsync(ListDatasetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDatasetsAsync(ListDatasetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDatastore asynchronously, invoking a callback when done
 -- @param CreateDatastoreRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDatastoreAsync(CreateDatastoreRequest, cb)
 	assert(CreateDatastoreRequest, "You must provide a CreateDatastoreRequest")
 	local headers = {
@@ -5819,19 +5828,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDatastoreRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDatastoreSync(CreateDatastoreRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDatastoreAsync(CreateDatastoreRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDatastoreAsync(CreateDatastoreRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDatasetContent asynchronously, invoking a callback when done
 -- @param GetDatasetContentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDatasetContentAsync(GetDatasetContentRequest, cb)
 	assert(GetDatasetContentRequest, "You must provide a GetDatasetContentRequest")
 	local headers = {
@@ -5854,19 +5864,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDatasetContentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDatasetContentSync(GetDatasetContentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDatasetContentAsync(GetDatasetContentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDatasetContentAsync(GetDatasetContentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartPipelineReprocessing asynchronously, invoking a callback when done
 -- @param StartPipelineReprocessingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartPipelineReprocessingAsync(StartPipelineReprocessingRequest, cb)
 	assert(StartPipelineReprocessingRequest, "You must provide a StartPipelineReprocessingRequest")
 	local headers = {
@@ -5889,19 +5900,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartPipelineReprocessingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartPipelineReprocessingSync(StartPipelineReprocessingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartPipelineReprocessingAsync(StartPipelineReprocessingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartPipelineReprocessingAsync(StartPipelineReprocessingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SampleChannelData asynchronously, invoking a callback when done
 -- @param SampleChannelDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SampleChannelDataAsync(SampleChannelDataRequest, cb)
 	assert(SampleChannelDataRequest, "You must provide a SampleChannelDataRequest")
 	local headers = {
@@ -5924,19 +5936,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SampleChannelDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SampleChannelDataSync(SampleChannelDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SampleChannelDataAsync(SampleChannelDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SampleChannelDataAsync(SampleChannelDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePipeline asynchronously, invoking a callback when done
 -- @param DeletePipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePipelineAsync(DeletePipelineRequest, cb)
 	assert(DeletePipelineRequest, "You must provide a DeletePipelineRequest")
 	local headers = {
@@ -5959,19 +5972,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePipelineSync(DeletePipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePipelineAsync(DeletePipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePipelineAsync(DeletePipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDataset asynchronously, invoking a callback when done
 -- @param DescribeDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDatasetAsync(DescribeDatasetRequest, cb)
 	assert(DescribeDatasetRequest, "You must provide a DescribeDatasetRequest")
 	local headers = {
@@ -5994,19 +6008,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDatasetSync(DescribeDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDatasetAsync(DescribeDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDatasetAsync(DescribeDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDatastore asynchronously, invoking a callback when done
 -- @param DeleteDatastoreRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDatastoreAsync(DeleteDatastoreRequest, cb)
 	assert(DeleteDatastoreRequest, "You must provide a DeleteDatastoreRequest")
 	local headers = {
@@ -6029,19 +6044,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDatastoreRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDatastoreSync(DeleteDatastoreRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDatastoreAsync(DeleteDatastoreRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDatastoreAsync(DeleteDatastoreRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDatastores asynchronously, invoking a callback when done
 -- @param ListDatastoresRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDatastoresAsync(ListDatastoresRequest, cb)
 	assert(ListDatastoresRequest, "You must provide a ListDatastoresRequest")
 	local headers = {
@@ -6064,19 +6080,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDatastoresRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDatastoresSync(ListDatastoresRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDatastoresAsync(ListDatastoresRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDatastoresAsync(ListDatastoresRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDataset asynchronously, invoking a callback when done
 -- @param CreateDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDatasetAsync(CreateDatasetRequest, cb)
 	assert(CreateDatasetRequest, "You must provide a CreateDatasetRequest")
 	local headers = {
@@ -6099,19 +6116,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDatasetSync(CreateDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDatasetAsync(CreateDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDatasetAsync(CreateDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -6134,19 +6152,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeChannel asynchronously, invoking a callback when done
 -- @param DescribeChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeChannelAsync(DescribeChannelRequest, cb)
 	assert(DescribeChannelRequest, "You must provide a DescribeChannelRequest")
 	local headers = {
@@ -6169,19 +6188,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeChannelSync(DescribeChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeChannelAsync(DescribeChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeChannelAsync(DescribeChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDatastore asynchronously, invoking a callback when done
 -- @param UpdateDatastoreRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDatastoreAsync(UpdateDatastoreRequest, cb)
 	assert(UpdateDatastoreRequest, "You must provide a UpdateDatastoreRequest")
 	local headers = {
@@ -6204,19 +6224,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDatastoreRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDatastoreSync(UpdateDatastoreRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDatastoreAsync(UpdateDatastoreRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDatastoreAsync(UpdateDatastoreRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDatasetContents asynchronously, invoking a callback when done
 -- @param ListDatasetContentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDatasetContentsAsync(ListDatasetContentsRequest, cb)
 	assert(ListDatasetContentsRequest, "You must provide a ListDatasetContentsRequest")
 	local headers = {
@@ -6239,19 +6260,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDatasetContentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDatasetContentsSync(ListDatasetContentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDatasetContentsAsync(ListDatasetContentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDatasetContentsAsync(ListDatasetContentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPipelines asynchronously, invoking a callback when done
 -- @param ListPipelinesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPipelinesAsync(ListPipelinesRequest, cb)
 	assert(ListPipelinesRequest, "You must provide a ListPipelinesRequest")
 	local headers = {
@@ -6274,19 +6296,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPipelinesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPipelinesSync(ListPipelinesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPipelinesAsync(ListPipelinesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPipelinesAsync(ListPipelinesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePipeline asynchronously, invoking a callback when done
 -- @param DescribePipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePipelineAsync(DescribePipelineRequest, cb)
 	assert(DescribePipelineRequest, "You must provide a DescribePipelineRequest")
 	local headers = {
@@ -6309,19 +6332,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePipelineSync(DescribePipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePipelineAsync(DescribePipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePipelineAsync(DescribePipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutLoggingOptions asynchronously, invoking a callback when done
 -- @param PutLoggingOptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutLoggingOptionsAsync(PutLoggingOptionsRequest, cb)
 	assert(PutLoggingOptionsRequest, "You must provide a PutLoggingOptionsRequest")
 	local headers = {
@@ -6344,19 +6368,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutLoggingOptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutLoggingOptionsSync(PutLoggingOptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutLoggingOptionsAsync(PutLoggingOptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutLoggingOptionsAsync(PutLoggingOptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDatastore asynchronously, invoking a callback when done
 -- @param DescribeDatastoreRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDatastoreAsync(DescribeDatastoreRequest, cb)
 	assert(DescribeDatastoreRequest, "You must provide a DescribeDatastoreRequest")
 	local headers = {
@@ -6379,19 +6404,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDatastoreRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDatastoreSync(DescribeDatastoreRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDatastoreAsync(DescribeDatastoreRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDatastoreAsync(DescribeDatastoreRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePipeline asynchronously, invoking a callback when done
 -- @param CreatePipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePipelineAsync(CreatePipelineRequest, cb)
 	assert(CreatePipelineRequest, "You must provide a CreatePipelineRequest")
 	local headers = {
@@ -6414,19 +6440,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePipelineSync(CreatePipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePipelineAsync(CreatePipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePipelineAsync(CreatePipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -6449,19 +6476,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListChannels asynchronously, invoking a callback when done
 -- @param ListChannelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListChannelsAsync(ListChannelsRequest, cb)
 	assert(ListChannelsRequest, "You must provide a ListChannelsRequest")
 	local headers = {
@@ -6484,19 +6512,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListChannelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListChannelsSync(ListChannelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListChannelsAsync(ListChannelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListChannelsAsync(ListChannelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDataset asynchronously, invoking a callback when done
 -- @param UpdateDatasetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDatasetAsync(UpdateDatasetRequest, cb)
 	assert(UpdateDatasetRequest, "You must provide a UpdateDatasetRequest")
 	local headers = {
@@ -6519,19 +6548,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDatasetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDatasetSync(UpdateDatasetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDatasetAsync(UpdateDatasetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDatasetAsync(UpdateDatasetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePipeline asynchronously, invoking a callback when done
 -- @param UpdatePipelineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePipelineAsync(UpdatePipelineRequest, cb)
 	assert(UpdatePipelineRequest, "You must provide a UpdatePipelineRequest")
 	local headers = {
@@ -6554,19 +6584,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePipelineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePipelineSync(UpdatePipelineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePipelineAsync(UpdatePipelineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePipelineAsync(UpdatePipelineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDatasetContent asynchronously, invoking a callback when done
 -- @param DeleteDatasetContentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDatasetContentAsync(DeleteDatasetContentRequest, cb)
 	assert(DeleteDatasetContentRequest, "You must provide a DeleteDatasetContentRequest")
 	local headers = {
@@ -6589,19 +6620,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDatasetContentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDatasetContentSync(DeleteDatasetContentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDatasetContentAsync(DeleteDatasetContentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDatasetContentAsync(DeleteDatasetContentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -6624,19 +6656,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDatasetContent asynchronously, invoking a callback when done
 -- @param CreateDatasetContentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDatasetContentAsync(CreateDatasetContentRequest, cb)
 	assert(CreateDatasetContentRequest, "You must provide a CreateDatasetContentRequest")
 	local headers = {
@@ -6659,12 +6692,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDatasetContentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDatasetContentSync(CreateDatasetContentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDatasetContentAsync(CreateDatasetContentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDatasetContentAsync(CreateDatasetContentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/kinesis.lua
+++ b/aws-sdk/kinesis.lua
@@ -3887,7 +3887,7 @@ end
 --
 --- Call IncreaseStreamRetentionPeriod asynchronously, invoking a callback when done
 -- @param IncreaseStreamRetentionPeriodInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.IncreaseStreamRetentionPeriodAsync(IncreaseStreamRetentionPeriodInput, cb)
 	assert(IncreaseStreamRetentionPeriodInput, "You must provide a IncreaseStreamRetentionPeriodInput")
 	local headers = {
@@ -3910,19 +3910,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IncreaseStreamRetentionPeriodInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.IncreaseStreamRetentionPeriodSync(IncreaseStreamRetentionPeriodInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.IncreaseStreamRetentionPeriodAsync(IncreaseStreamRetentionPeriodInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.IncreaseStreamRetentionPeriodAsync(IncreaseStreamRetentionPeriodInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetShardIterator asynchronously, invoking a callback when done
 -- @param GetShardIteratorInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetShardIteratorAsync(GetShardIteratorInput, cb)
 	assert(GetShardIteratorInput, "You must provide a GetShardIteratorInput")
 	local headers = {
@@ -3945,19 +3946,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetShardIteratorInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetShardIteratorSync(GetShardIteratorInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetShardIteratorAsync(GetShardIteratorInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetShardIteratorAsync(GetShardIteratorInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToStream asynchronously, invoking a callback when done
 -- @param AddTagsToStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToStreamAsync(AddTagsToStreamInput, cb)
 	assert(AddTagsToStreamInput, "You must provide a AddTagsToStreamInput")
 	local headers = {
@@ -3980,19 +3982,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToStreamSync(AddTagsToStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToStreamAsync(AddTagsToStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToStreamAsync(AddTagsToStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableEnhancedMonitoring asynchronously, invoking a callback when done
 -- @param DisableEnhancedMonitoringInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableEnhancedMonitoringAsync(DisableEnhancedMonitoringInput, cb)
 	assert(DisableEnhancedMonitoringInput, "You must provide a DisableEnhancedMonitoringInput")
 	local headers = {
@@ -4015,19 +4018,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableEnhancedMonitoringInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableEnhancedMonitoringSync(DisableEnhancedMonitoringInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableEnhancedMonitoringAsync(DisableEnhancedMonitoringInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableEnhancedMonitoringAsync(DisableEnhancedMonitoringInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DecreaseStreamRetentionPeriod asynchronously, invoking a callback when done
 -- @param DecreaseStreamRetentionPeriodInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DecreaseStreamRetentionPeriodAsync(DecreaseStreamRetentionPeriodInput, cb)
 	assert(DecreaseStreamRetentionPeriodInput, "You must provide a DecreaseStreamRetentionPeriodInput")
 	local headers = {
@@ -4050,19 +4054,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DecreaseStreamRetentionPeriodInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DecreaseStreamRetentionPeriodSync(DecreaseStreamRetentionPeriodInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DecreaseStreamRetentionPeriodAsync(DecreaseStreamRetentionPeriodInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DecreaseStreamRetentionPeriodAsync(DecreaseStreamRetentionPeriodInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLimits asynchronously, invoking a callback when done
 -- @param DescribeLimitsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLimitsAsync(DescribeLimitsInput, cb)
 	assert(DescribeLimitsInput, "You must provide a DescribeLimitsInput")
 	local headers = {
@@ -4085,19 +4090,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLimitsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLimitsSync(DescribeLimitsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLimitsAsync(DescribeLimitsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLimitsAsync(DescribeLimitsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListShards asynchronously, invoking a callback when done
 -- @param ListShardsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListShardsAsync(ListShardsInput, cb)
 	assert(ListShardsInput, "You must provide a ListShardsInput")
 	local headers = {
@@ -4120,19 +4126,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListShardsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListShardsSync(ListShardsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListShardsAsync(ListShardsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListShardsAsync(ListShardsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStreams asynchronously, invoking a callback when done
 -- @param ListStreamsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStreamsAsync(ListStreamsInput, cb)
 	assert(ListStreamsInput, "You must provide a ListStreamsInput")
 	local headers = {
@@ -4155,19 +4162,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStreamsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStreamsSync(ListStreamsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStreamsAsync(ListStreamsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStreamsAsync(ListStreamsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterStreamConsumer asynchronously, invoking a callback when done
 -- @param DeregisterStreamConsumerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterStreamConsumerAsync(DeregisterStreamConsumerInput, cb)
 	assert(DeregisterStreamConsumerInput, "You must provide a DeregisterStreamConsumerInput")
 	local headers = {
@@ -4190,19 +4198,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterStreamConsumerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterStreamConsumerSync(DeregisterStreamConsumerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterStreamConsumerAsync(DeregisterStreamConsumerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterStreamConsumerAsync(DeregisterStreamConsumerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStreamConsumers asynchronously, invoking a callback when done
 -- @param ListStreamConsumersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStreamConsumersAsync(ListStreamConsumersInput, cb)
 	assert(ListStreamConsumersInput, "You must provide a ListStreamConsumersInput")
 	local headers = {
@@ -4225,19 +4234,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStreamConsumersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStreamConsumersSync(ListStreamConsumersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStreamConsumersAsync(ListStreamConsumersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStreamConsumersAsync(ListStreamConsumersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateShardCount asynchronously, invoking a callback when done
 -- @param UpdateShardCountInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateShardCountAsync(UpdateShardCountInput, cb)
 	assert(UpdateShardCountInput, "You must provide a UpdateShardCountInput")
 	local headers = {
@@ -4260,19 +4270,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateShardCountInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateShardCountSync(UpdateShardCountInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateShardCountAsync(UpdateShardCountInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateShardCountAsync(UpdateShardCountInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStreamSummary asynchronously, invoking a callback when done
 -- @param DescribeStreamSummaryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStreamSummaryAsync(DescribeStreamSummaryInput, cb)
 	assert(DescribeStreamSummaryInput, "You must provide a DescribeStreamSummaryInput")
 	local headers = {
@@ -4295,19 +4306,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStreamSummaryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStreamSummarySync(DescribeStreamSummaryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStreamSummaryAsync(DescribeStreamSummaryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStreamSummaryAsync(DescribeStreamSummaryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartStreamEncryption asynchronously, invoking a callback when done
 -- @param StartStreamEncryptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartStreamEncryptionAsync(StartStreamEncryptionInput, cb)
 	assert(StartStreamEncryptionInput, "You must provide a StartStreamEncryptionInput")
 	local headers = {
@@ -4330,19 +4342,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartStreamEncryptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartStreamEncryptionSync(StartStreamEncryptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartStreamEncryptionAsync(StartStreamEncryptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartStreamEncryptionAsync(StartStreamEncryptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStreamConsumer asynchronously, invoking a callback when done
 -- @param DescribeStreamConsumerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStreamConsumerAsync(DescribeStreamConsumerInput, cb)
 	assert(DescribeStreamConsumerInput, "You must provide a DescribeStreamConsumerInput")
 	local headers = {
@@ -4365,19 +4378,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStreamConsumerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStreamConsumerSync(DescribeStreamConsumerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStreamConsumerAsync(DescribeStreamConsumerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStreamConsumerAsync(DescribeStreamConsumerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SplitShard asynchronously, invoking a callback when done
 -- @param SplitShardInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SplitShardAsync(SplitShardInput, cb)
 	assert(SplitShardInput, "You must provide a SplitShardInput")
 	local headers = {
@@ -4400,19 +4414,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SplitShardInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SplitShardSync(SplitShardInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SplitShardAsync(SplitShardInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SplitShardAsync(SplitShardInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStream asynchronously, invoking a callback when done
 -- @param DescribeStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStreamAsync(DescribeStreamInput, cb)
 	assert(DescribeStreamInput, "You must provide a DescribeStreamInput")
 	local headers = {
@@ -4435,19 +4450,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStreamSync(DescribeStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStreamAsync(DescribeStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStreamAsync(DescribeStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStream asynchronously, invoking a callback when done
 -- @param CreateStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStreamAsync(CreateStreamInput, cb)
 	assert(CreateStreamInput, "You must provide a CreateStreamInput")
 	local headers = {
@@ -4470,19 +4486,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStreamSync(CreateStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStreamAsync(CreateStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStreamAsync(CreateStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterStreamConsumer asynchronously, invoking a callback when done
 -- @param RegisterStreamConsumerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterStreamConsumerAsync(RegisterStreamConsumerInput, cb)
 	assert(RegisterStreamConsumerInput, "You must provide a RegisterStreamConsumerInput")
 	local headers = {
@@ -4505,19 +4522,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterStreamConsumerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterStreamConsumerSync(RegisterStreamConsumerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterStreamConsumerAsync(RegisterStreamConsumerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterStreamConsumerAsync(RegisterStreamConsumerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableEnhancedMonitoring asynchronously, invoking a callback when done
 -- @param EnableEnhancedMonitoringInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableEnhancedMonitoringAsync(EnableEnhancedMonitoringInput, cb)
 	assert(EnableEnhancedMonitoringInput, "You must provide a EnableEnhancedMonitoringInput")
 	local headers = {
@@ -4540,19 +4558,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableEnhancedMonitoringInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableEnhancedMonitoringSync(EnableEnhancedMonitoringInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableEnhancedMonitoringAsync(EnableEnhancedMonitoringInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableEnhancedMonitoringAsync(EnableEnhancedMonitoringInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStream asynchronously, invoking a callback when done
 -- @param DeleteStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStreamAsync(DeleteStreamInput, cb)
 	assert(DeleteStreamInput, "You must provide a DeleteStreamInput")
 	local headers = {
@@ -4575,19 +4594,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStreamSync(DeleteStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStreamAsync(DeleteStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStreamAsync(DeleteStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromStream asynchronously, invoking a callback when done
 -- @param RemoveTagsFromStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromStreamAsync(RemoveTagsFromStreamInput, cb)
 	assert(RemoveTagsFromStreamInput, "You must provide a RemoveTagsFromStreamInput")
 	local headers = {
@@ -4610,19 +4630,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromStreamSync(RemoveTagsFromStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromStreamAsync(RemoveTagsFromStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromStreamAsync(RemoveTagsFromStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRecords asynchronously, invoking a callback when done
 -- @param GetRecordsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRecordsAsync(GetRecordsInput, cb)
 	assert(GetRecordsInput, "You must provide a GetRecordsInput")
 	local headers = {
@@ -4645,19 +4666,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRecordsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRecordsSync(GetRecordsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRecordsAsync(GetRecordsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRecordsAsync(GetRecordsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForStream asynchronously, invoking a callback when done
 -- @param ListTagsForStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForStreamAsync(ListTagsForStreamInput, cb)
 	assert(ListTagsForStreamInput, "You must provide a ListTagsForStreamInput")
 	local headers = {
@@ -4680,19 +4702,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForStreamSync(ListTagsForStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForStreamAsync(ListTagsForStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForStreamAsync(ListTagsForStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRecords asynchronously, invoking a callback when done
 -- @param PutRecordsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRecordsAsync(PutRecordsInput, cb)
 	assert(PutRecordsInput, "You must provide a PutRecordsInput")
 	local headers = {
@@ -4715,19 +4738,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRecordsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRecordsSync(PutRecordsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRecordsAsync(PutRecordsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRecordsAsync(PutRecordsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRecord asynchronously, invoking a callback when done
 -- @param PutRecordInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRecordAsync(PutRecordInput, cb)
 	assert(PutRecordInput, "You must provide a PutRecordInput")
 	local headers = {
@@ -4750,19 +4774,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRecordInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRecordSync(PutRecordInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRecordAsync(PutRecordInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRecordAsync(PutRecordInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call MergeShards asynchronously, invoking a callback when done
 -- @param MergeShardsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.MergeShardsAsync(MergeShardsInput, cb)
 	assert(MergeShardsInput, "You must provide a MergeShardsInput")
 	local headers = {
@@ -4785,19 +4810,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param MergeShardsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.MergeShardsSync(MergeShardsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.MergeShardsAsync(MergeShardsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.MergeShardsAsync(MergeShardsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopStreamEncryption asynchronously, invoking a callback when done
 -- @param StopStreamEncryptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopStreamEncryptionAsync(StopStreamEncryptionInput, cb)
 	assert(StopStreamEncryptionInput, "You must provide a StopStreamEncryptionInput")
 	local headers = {
@@ -4820,12 +4846,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopStreamEncryptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopStreamEncryptionSync(StopStreamEncryptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopStreamEncryptionAsync(StopStreamEncryptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopStreamEncryptionAsync(StopStreamEncryptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/kinesisanalytics.lua
+++ b/aws-sdk/kinesisanalytics.lua
@@ -4834,7 +4834,7 @@ end
 --
 --- Call DiscoverInputSchema asynchronously, invoking a callback when done
 -- @param DiscoverInputSchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DiscoverInputSchemaAsync(DiscoverInputSchemaRequest, cb)
 	assert(DiscoverInputSchemaRequest, "You must provide a DiscoverInputSchemaRequest")
 	local headers = {
@@ -4857,19 +4857,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DiscoverInputSchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DiscoverInputSchemaSync(DiscoverInputSchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DiscoverInputSchemaAsync(DiscoverInputSchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DiscoverInputSchemaAsync(DiscoverInputSchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplicationInputProcessingConfiguration asynchronously, invoking a callback when done
 -- @param DeleteApplicationInputProcessingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationInputProcessingConfigurationAsync(DeleteApplicationInputProcessingConfigurationRequest, cb)
 	assert(DeleteApplicationInputProcessingConfigurationRequest, "You must provide a DeleteApplicationInputProcessingConfigurationRequest")
 	local headers = {
@@ -4892,19 +4893,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationInputProcessingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationInputProcessingConfigurationSync(DeleteApplicationInputProcessingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationInputProcessingConfigurationAsync(DeleteApplicationInputProcessingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationInputProcessingConfigurationAsync(DeleteApplicationInputProcessingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddApplicationReferenceDataSource asynchronously, invoking a callback when done
 -- @param AddApplicationReferenceDataSourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddApplicationReferenceDataSourceAsync(AddApplicationReferenceDataSourceRequest, cb)
 	assert(AddApplicationReferenceDataSourceRequest, "You must provide a AddApplicationReferenceDataSourceRequest")
 	local headers = {
@@ -4927,19 +4929,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddApplicationReferenceDataSourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddApplicationReferenceDataSourceSync(AddApplicationReferenceDataSourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddApplicationReferenceDataSourceAsync(AddApplicationReferenceDataSourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddApplicationReferenceDataSourceAsync(AddApplicationReferenceDataSourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListApplications asynchronously, invoking a callback when done
 -- @param ListApplicationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListApplicationsAsync(ListApplicationsRequest, cb)
 	assert(ListApplicationsRequest, "You must provide a ListApplicationsRequest")
 	local headers = {
@@ -4962,19 +4965,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListApplicationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListApplicationsSync(ListApplicationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListApplicationsAsync(ListApplicationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListApplicationsAsync(ListApplicationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApplication asynchronously, invoking a callback when done
 -- @param UpdateApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationAsync(UpdateApplicationRequest, cb)
 	assert(UpdateApplicationRequest, "You must provide a UpdateApplicationRequest")
 	local headers = {
@@ -4997,19 +5001,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationSync(UpdateApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationAsync(UpdateApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationAsync(UpdateApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopApplication asynchronously, invoking a callback when done
 -- @param StopApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopApplicationAsync(StopApplicationRequest, cb)
 	assert(StopApplicationRequest, "You must provide a StopApplicationRequest")
 	local headers = {
@@ -5032,19 +5037,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopApplicationSync(StopApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopApplicationAsync(StopApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopApplicationAsync(StopApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddApplicationOutput asynchronously, invoking a callback when done
 -- @param AddApplicationOutputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddApplicationOutputAsync(AddApplicationOutputRequest, cb)
 	assert(AddApplicationOutputRequest, "You must provide a AddApplicationOutputRequest")
 	local headers = {
@@ -5067,19 +5073,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddApplicationOutputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddApplicationOutputSync(AddApplicationOutputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddApplicationOutputAsync(AddApplicationOutputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddApplicationOutputAsync(AddApplicationOutputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplication asynchronously, invoking a callback when done
 -- @param DeleteApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationAsync(DeleteApplicationRequest, cb)
 	assert(DeleteApplicationRequest, "You must provide a DeleteApplicationRequest")
 	local headers = {
@@ -5102,19 +5109,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationSync(DeleteApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationAsync(DeleteApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationAsync(DeleteApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddApplicationCloudWatchLoggingOption asynchronously, invoking a callback when done
 -- @param AddApplicationCloudWatchLoggingOptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddApplicationCloudWatchLoggingOptionAsync(AddApplicationCloudWatchLoggingOptionRequest, cb)
 	assert(AddApplicationCloudWatchLoggingOptionRequest, "You must provide a AddApplicationCloudWatchLoggingOptionRequest")
 	local headers = {
@@ -5137,19 +5145,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddApplicationCloudWatchLoggingOptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddApplicationCloudWatchLoggingOptionSync(AddApplicationCloudWatchLoggingOptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddApplicationCloudWatchLoggingOptionAsync(AddApplicationCloudWatchLoggingOptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddApplicationCloudWatchLoggingOptionAsync(AddApplicationCloudWatchLoggingOptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplicationOutput asynchronously, invoking a callback when done
 -- @param DeleteApplicationOutputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationOutputAsync(DeleteApplicationOutputRequest, cb)
 	assert(DeleteApplicationOutputRequest, "You must provide a DeleteApplicationOutputRequest")
 	local headers = {
@@ -5172,19 +5181,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationOutputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationOutputSync(DeleteApplicationOutputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationOutputAsync(DeleteApplicationOutputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationOutputAsync(DeleteApplicationOutputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplicationCloudWatchLoggingOption asynchronously, invoking a callback when done
 -- @param DeleteApplicationCloudWatchLoggingOptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationCloudWatchLoggingOptionAsync(DeleteApplicationCloudWatchLoggingOptionRequest, cb)
 	assert(DeleteApplicationCloudWatchLoggingOptionRequest, "You must provide a DeleteApplicationCloudWatchLoggingOptionRequest")
 	local headers = {
@@ -5207,19 +5217,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationCloudWatchLoggingOptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationCloudWatchLoggingOptionSync(DeleteApplicationCloudWatchLoggingOptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationCloudWatchLoggingOptionAsync(DeleteApplicationCloudWatchLoggingOptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationCloudWatchLoggingOptionAsync(DeleteApplicationCloudWatchLoggingOptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddApplicationInput asynchronously, invoking a callback when done
 -- @param AddApplicationInputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddApplicationInputAsync(AddApplicationInputRequest, cb)
 	assert(AddApplicationInputRequest, "You must provide a AddApplicationInputRequest")
 	local headers = {
@@ -5242,19 +5253,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddApplicationInputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddApplicationInputSync(AddApplicationInputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddApplicationInputAsync(AddApplicationInputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddApplicationInputAsync(AddApplicationInputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeApplication asynchronously, invoking a callback when done
 -- @param DescribeApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeApplicationAsync(DescribeApplicationRequest, cb)
 	assert(DescribeApplicationRequest, "You must provide a DescribeApplicationRequest")
 	local headers = {
@@ -5277,19 +5289,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeApplicationSync(DescribeApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeApplicationAsync(DescribeApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeApplicationAsync(DescribeApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddApplicationInputProcessingConfiguration asynchronously, invoking a callback when done
 -- @param AddApplicationInputProcessingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddApplicationInputProcessingConfigurationAsync(AddApplicationInputProcessingConfigurationRequest, cb)
 	assert(AddApplicationInputProcessingConfigurationRequest, "You must provide a AddApplicationInputProcessingConfigurationRequest")
 	local headers = {
@@ -5312,19 +5325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddApplicationInputProcessingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddApplicationInputProcessingConfigurationSync(AddApplicationInputProcessingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddApplicationInputProcessingConfigurationAsync(AddApplicationInputProcessingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddApplicationInputProcessingConfigurationAsync(AddApplicationInputProcessingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplicationReferenceDataSource asynchronously, invoking a callback when done
 -- @param DeleteApplicationReferenceDataSourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationReferenceDataSourceAsync(DeleteApplicationReferenceDataSourceRequest, cb)
 	assert(DeleteApplicationReferenceDataSourceRequest, "You must provide a DeleteApplicationReferenceDataSourceRequest")
 	local headers = {
@@ -5347,19 +5361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationReferenceDataSourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationReferenceDataSourceSync(DeleteApplicationReferenceDataSourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationReferenceDataSourceAsync(DeleteApplicationReferenceDataSourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationReferenceDataSourceAsync(DeleteApplicationReferenceDataSourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartApplication asynchronously, invoking a callback when done
 -- @param StartApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartApplicationAsync(StartApplicationRequest, cb)
 	assert(StartApplicationRequest, "You must provide a StartApplicationRequest")
 	local headers = {
@@ -5382,19 +5397,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartApplicationSync(StartApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartApplicationAsync(StartApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartApplicationAsync(StartApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApplication asynchronously, invoking a callback when done
 -- @param CreateApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApplicationAsync(CreateApplicationRequest, cb)
 	assert(CreateApplicationRequest, "You must provide a CreateApplicationRequest")
 	local headers = {
@@ -5417,12 +5433,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApplicationSync(CreateApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApplicationAsync(CreateApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApplicationAsync(CreateApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/kinesisvideo.lua
+++ b/aws-sdk/kinesisvideo.lua
@@ -1668,7 +1668,7 @@ end
 --
 --- Call GetDataEndpoint asynchronously, invoking a callback when done
 -- @param GetDataEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDataEndpointAsync(GetDataEndpointInput, cb)
 	assert(GetDataEndpointInput, "You must provide a GetDataEndpointInput")
 	local headers = {
@@ -1691,19 +1691,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDataEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDataEndpointSync(GetDataEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDataEndpointAsync(GetDataEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDataEndpointAsync(GetDataEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDataRetention asynchronously, invoking a callback when done
 -- @param UpdateDataRetentionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDataRetentionAsync(UpdateDataRetentionInput, cb)
 	assert(UpdateDataRetentionInput, "You must provide a UpdateDataRetentionInput")
 	local headers = {
@@ -1726,19 +1727,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDataRetentionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDataRetentionSync(UpdateDataRetentionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDataRetentionAsync(UpdateDataRetentionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDataRetentionAsync(UpdateDataRetentionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStream asynchronously, invoking a callback when done
 -- @param DeleteStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStreamAsync(DeleteStreamInput, cb)
 	assert(DeleteStreamInput, "You must provide a DeleteStreamInput")
 	local headers = {
@@ -1761,19 +1763,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStreamSync(DeleteStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStreamAsync(DeleteStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStreamAsync(DeleteStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStreams asynchronously, invoking a callback when done
 -- @param ListStreamsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStreamsAsync(ListStreamsInput, cb)
 	assert(ListStreamsInput, "You must provide a ListStreamsInput")
 	local headers = {
@@ -1796,19 +1799,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStreamsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStreamsSync(ListStreamsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStreamsAsync(ListStreamsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStreamsAsync(ListStreamsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagStream asynchronously, invoking a callback when done
 -- @param UntagStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagStreamAsync(UntagStreamInput, cb)
 	assert(UntagStreamInput, "You must provide a UntagStreamInput")
 	local headers = {
@@ -1831,19 +1835,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagStreamSync(UntagStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagStreamAsync(UntagStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagStreamAsync(UntagStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForStream asynchronously, invoking a callback when done
 -- @param ListTagsForStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForStreamAsync(ListTagsForStreamInput, cb)
 	assert(ListTagsForStreamInput, "You must provide a ListTagsForStreamInput")
 	local headers = {
@@ -1866,19 +1871,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForStreamSync(ListTagsForStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForStreamAsync(ListTagsForStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForStreamAsync(ListTagsForStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStream asynchronously, invoking a callback when done
 -- @param CreateStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStreamAsync(CreateStreamInput, cb)
 	assert(CreateStreamInput, "You must provide a CreateStreamInput")
 	local headers = {
@@ -1901,19 +1907,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStreamSync(CreateStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStreamAsync(CreateStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStreamAsync(CreateStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagStream asynchronously, invoking a callback when done
 -- @param TagStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagStreamAsync(TagStreamInput, cb)
 	assert(TagStreamInput, "You must provide a TagStreamInput")
 	local headers = {
@@ -1936,19 +1943,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagStreamSync(TagStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagStreamAsync(TagStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagStreamAsync(TagStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStream asynchronously, invoking a callback when done
 -- @param UpdateStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStreamAsync(UpdateStreamInput, cb)
 	assert(UpdateStreamInput, "You must provide a UpdateStreamInput")
 	local headers = {
@@ -1971,19 +1979,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStreamSync(UpdateStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStreamAsync(UpdateStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStreamAsync(UpdateStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStream asynchronously, invoking a callback when done
 -- @param DescribeStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStreamAsync(DescribeStreamInput, cb)
 	assert(DescribeStreamInput, "You must provide a DescribeStreamInput")
 	local headers = {
@@ -2006,12 +2015,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStreamSync(DescribeStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStreamAsync(DescribeStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStreamAsync(DescribeStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/kms.lua
+++ b/aws-sdk/kms.lua
@@ -4043,7 +4043,7 @@ end
 --
 --- Call Encrypt asynchronously, invoking a callback when done
 -- @param EncryptRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EncryptAsync(EncryptRequest, cb)
 	assert(EncryptRequest, "You must provide a EncryptRequest")
 	local headers = {
@@ -4066,19 +4066,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EncryptRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EncryptSync(EncryptRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EncryptAsync(EncryptRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EncryptAsync(EncryptRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Decrypt asynchronously, invoking a callback when done
 -- @param DecryptRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DecryptAsync(DecryptRequest, cb)
 	assert(DecryptRequest, "You must provide a DecryptRequest")
 	local headers = {
@@ -4101,19 +4102,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DecryptRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DecryptSync(DecryptRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DecryptAsync(DecryptRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DecryptAsync(DecryptRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAlias asynchronously, invoking a callback when done
 -- @param UpdateAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAliasAsync(UpdateAliasRequest, cb)
 	assert(UpdateAliasRequest, "You must provide a UpdateAliasRequest")
 	local headers = {
@@ -4136,19 +4138,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAliasSync(UpdateAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAliasAsync(UpdateAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAliasAsync(UpdateAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportKeyMaterial asynchronously, invoking a callback when done
 -- @param ImportKeyMaterialRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportKeyMaterialAsync(ImportKeyMaterialRequest, cb)
 	assert(ImportKeyMaterialRequest, "You must provide a ImportKeyMaterialRequest")
 	local headers = {
@@ -4171,19 +4174,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportKeyMaterialRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportKeyMaterialSync(ImportKeyMaterialRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportKeyMaterialAsync(ImportKeyMaterialRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportKeyMaterialAsync(ImportKeyMaterialRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableKey asynchronously, invoking a callback when done
 -- @param DisableKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableKeyAsync(DisableKeyRequest, cb)
 	assert(DisableKeyRequest, "You must provide a DisableKeyRequest")
 	local headers = {
@@ -4206,19 +4210,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableKeySync(DisableKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableKeyAsync(DisableKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableKeyAsync(DisableKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GenerateDataKeyWithoutPlaintext asynchronously, invoking a callback when done
 -- @param GenerateDataKeyWithoutPlaintextRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GenerateDataKeyWithoutPlaintextAsync(GenerateDataKeyWithoutPlaintextRequest, cb)
 	assert(GenerateDataKeyWithoutPlaintextRequest, "You must provide a GenerateDataKeyWithoutPlaintextRequest")
 	local headers = {
@@ -4241,19 +4246,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GenerateDataKeyWithoutPlaintextRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GenerateDataKeyWithoutPlaintextSync(GenerateDataKeyWithoutPlaintextRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GenerateDataKeyWithoutPlaintextAsync(GenerateDataKeyWithoutPlaintextRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GenerateDataKeyWithoutPlaintextAsync(GenerateDataKeyWithoutPlaintextRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GenerateDataKey asynchronously, invoking a callback when done
 -- @param GenerateDataKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GenerateDataKeyAsync(GenerateDataKeyRequest, cb)
 	assert(GenerateDataKeyRequest, "You must provide a GenerateDataKeyRequest")
 	local headers = {
@@ -4276,19 +4282,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GenerateDataKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GenerateDataKeySync(GenerateDataKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GenerateDataKeyAsync(GenerateDataKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GenerateDataKeyAsync(GenerateDataKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceTags asynchronously, invoking a callback when done
 -- @param ListResourceTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceTagsAsync(ListResourceTagsRequest, cb)
 	assert(ListResourceTagsRequest, "You must provide a ListResourceTagsRequest")
 	local headers = {
@@ -4311,19 +4318,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceTagsSync(ListResourceTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceTagsAsync(ListResourceTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceTagsAsync(ListResourceTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAliases asynchronously, invoking a callback when done
 -- @param ListAliasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAliasesAsync(ListAliasesRequest, cb)
 	assert(ListAliasesRequest, "You must provide a ListAliasesRequest")
 	local headers = {
@@ -4346,19 +4354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAliasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAliasesSync(ListAliasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAliasesAsync(ListAliasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAliasesAsync(ListAliasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelKeyDeletion asynchronously, invoking a callback when done
 -- @param CancelKeyDeletionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelKeyDeletionAsync(CancelKeyDeletionRequest, cb)
 	assert(CancelKeyDeletionRequest, "You must provide a CancelKeyDeletionRequest")
 	local headers = {
@@ -4381,19 +4390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelKeyDeletionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelKeyDeletionSync(CancelKeyDeletionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelKeyDeletionAsync(CancelKeyDeletionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelKeyDeletionAsync(CancelKeyDeletionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetKeyRotationStatus asynchronously, invoking a callback when done
 -- @param GetKeyRotationStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetKeyRotationStatusAsync(GetKeyRotationStatusRequest, cb)
 	assert(GetKeyRotationStatusRequest, "You must provide a GetKeyRotationStatusRequest")
 	local headers = {
@@ -4416,19 +4426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetKeyRotationStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetKeyRotationStatusSync(GetKeyRotationStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetKeyRotationStatusAsync(GetKeyRotationStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetKeyRotationStatusAsync(GetKeyRotationStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListKeyPolicies asynchronously, invoking a callback when done
 -- @param ListKeyPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListKeyPoliciesAsync(ListKeyPoliciesRequest, cb)
 	assert(ListKeyPoliciesRequest, "You must provide a ListKeyPoliciesRequest")
 	local headers = {
@@ -4451,19 +4462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListKeyPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListKeyPoliciesSync(ListKeyPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListKeyPoliciesAsync(ListKeyPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListKeyPoliciesAsync(ListKeyPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAlias asynchronously, invoking a callback when done
 -- @param DeleteAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAliasAsync(DeleteAliasRequest, cb)
 	assert(DeleteAliasRequest, "You must provide a DeleteAliasRequest")
 	local headers = {
@@ -4486,19 +4498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAliasSync(DeleteAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAliasAsync(DeleteAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAliasAsync(DeleteAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RetireGrant asynchronously, invoking a callback when done
 -- @param RetireGrantRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RetireGrantAsync(RetireGrantRequest, cb)
 	assert(RetireGrantRequest, "You must provide a RetireGrantRequest")
 	local headers = {
@@ -4521,19 +4534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RetireGrantRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RetireGrantSync(RetireGrantRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RetireGrantAsync(RetireGrantRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RetireGrantAsync(RetireGrantRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -4556,19 +4570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeKey asynchronously, invoking a callback when done
 -- @param DescribeKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeKeyAsync(DescribeKeyRequest, cb)
 	assert(DescribeKeyRequest, "You must provide a DescribeKeyRequest")
 	local headers = {
@@ -4591,19 +4606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeKeySync(DescribeKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeKeyAsync(DescribeKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeKeyAsync(DescribeKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListKeys asynchronously, invoking a callback when done
 -- @param ListKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListKeysAsync(ListKeysRequest, cb)
 	assert(ListKeysRequest, "You must provide a ListKeysRequest")
 	local headers = {
@@ -4626,19 +4642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListKeysSync(ListKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListKeysAsync(ListKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListKeysAsync(ListKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GenerateRandom asynchronously, invoking a callback when done
 -- @param GenerateRandomRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GenerateRandomAsync(GenerateRandomRequest, cb)
 	assert(GenerateRandomRequest, "You must provide a GenerateRandomRequest")
 	local headers = {
@@ -4661,19 +4678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GenerateRandomRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GenerateRandomSync(GenerateRandomRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GenerateRandomAsync(GenerateRandomRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GenerateRandomAsync(GenerateRandomRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetKeyPolicy asynchronously, invoking a callback when done
 -- @param GetKeyPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetKeyPolicyAsync(GetKeyPolicyRequest, cb)
 	assert(GetKeyPolicyRequest, "You must provide a GetKeyPolicyRequest")
 	local headers = {
@@ -4696,19 +4714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetKeyPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetKeyPolicySync(GetKeyPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetKeyPolicyAsync(GetKeyPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetKeyPolicyAsync(GetKeyPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGrant asynchronously, invoking a callback when done
 -- @param CreateGrantRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGrantAsync(CreateGrantRequest, cb)
 	assert(CreateGrantRequest, "You must provide a CreateGrantRequest")
 	local headers = {
@@ -4731,19 +4750,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGrantRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGrantSync(CreateGrantRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGrantAsync(CreateGrantRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGrantAsync(CreateGrantRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateKey asynchronously, invoking a callback when done
 -- @param CreateKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateKeyAsync(CreateKeyRequest, cb)
 	assert(CreateKeyRequest, "You must provide a CreateKeyRequest")
 	local headers = {
@@ -4766,19 +4786,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateKeySync(CreateKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateKeyAsync(CreateKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateKeyAsync(CreateKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReEncrypt asynchronously, invoking a callback when done
 -- @param ReEncryptRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReEncryptAsync(ReEncryptRequest, cb)
 	assert(ReEncryptRequest, "You must provide a ReEncryptRequest")
 	local headers = {
@@ -4801,19 +4822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReEncryptRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReEncryptSync(ReEncryptRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReEncryptAsync(ReEncryptRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReEncryptAsync(ReEncryptRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetParametersForImport asynchronously, invoking a callback when done
 -- @param GetParametersForImportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetParametersForImportAsync(GetParametersForImportRequest, cb)
 	assert(GetParametersForImportRequest, "You must provide a GetParametersForImportRequest")
 	local headers = {
@@ -4836,19 +4858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetParametersForImportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetParametersForImportSync(GetParametersForImportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetParametersForImportAsync(GetParametersForImportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetParametersForImportAsync(GetParametersForImportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableKeyRotation asynchronously, invoking a callback when done
 -- @param DisableKeyRotationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableKeyRotationAsync(DisableKeyRotationRequest, cb)
 	assert(DisableKeyRotationRequest, "You must provide a DisableKeyRotationRequest")
 	local headers = {
@@ -4871,19 +4894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableKeyRotationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableKeyRotationSync(DisableKeyRotationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableKeyRotationAsync(DisableKeyRotationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableKeyRotationAsync(DisableKeyRotationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRetirableGrants asynchronously, invoking a callback when done
 -- @param ListRetirableGrantsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRetirableGrantsAsync(ListRetirableGrantsRequest, cb)
 	assert(ListRetirableGrantsRequest, "You must provide a ListRetirableGrantsRequest")
 	local headers = {
@@ -4906,19 +4930,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRetirableGrantsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRetirableGrantsSync(ListRetirableGrantsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRetirableGrantsAsync(ListRetirableGrantsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRetirableGrantsAsync(ListRetirableGrantsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ScheduleKeyDeletion asynchronously, invoking a callback when done
 -- @param ScheduleKeyDeletionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ScheduleKeyDeletionAsync(ScheduleKeyDeletionRequest, cb)
 	assert(ScheduleKeyDeletionRequest, "You must provide a ScheduleKeyDeletionRequest")
 	local headers = {
@@ -4941,19 +4966,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ScheduleKeyDeletionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ScheduleKeyDeletionSync(ScheduleKeyDeletionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ScheduleKeyDeletionAsync(ScheduleKeyDeletionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ScheduleKeyDeletionAsync(ScheduleKeyDeletionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAlias asynchronously, invoking a callback when done
 -- @param CreateAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAliasAsync(CreateAliasRequest, cb)
 	assert(CreateAliasRequest, "You must provide a CreateAliasRequest")
 	local headers = {
@@ -4976,19 +5002,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAliasSync(CreateAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAliasAsync(CreateAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAliasAsync(CreateAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableKeyRotation asynchronously, invoking a callback when done
 -- @param EnableKeyRotationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableKeyRotationAsync(EnableKeyRotationRequest, cb)
 	assert(EnableKeyRotationRequest, "You must provide a EnableKeyRotationRequest")
 	local headers = {
@@ -5011,19 +5038,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableKeyRotationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableKeyRotationSync(EnableKeyRotationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableKeyRotationAsync(EnableKeyRotationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableKeyRotationAsync(EnableKeyRotationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -5046,19 +5074,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGrants asynchronously, invoking a callback when done
 -- @param ListGrantsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGrantsAsync(ListGrantsRequest, cb)
 	assert(ListGrantsRequest, "You must provide a ListGrantsRequest")
 	local headers = {
@@ -5081,19 +5110,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGrantsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGrantsSync(ListGrantsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGrantsAsync(ListGrantsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGrantsAsync(ListGrantsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableKey asynchronously, invoking a callback when done
 -- @param EnableKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableKeyAsync(EnableKeyRequest, cb)
 	assert(EnableKeyRequest, "You must provide a EnableKeyRequest")
 	local headers = {
@@ -5116,19 +5146,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableKeySync(EnableKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableKeyAsync(EnableKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableKeyAsync(EnableKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteImportedKeyMaterial asynchronously, invoking a callback when done
 -- @param DeleteImportedKeyMaterialRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteImportedKeyMaterialAsync(DeleteImportedKeyMaterialRequest, cb)
 	assert(DeleteImportedKeyMaterialRequest, "You must provide a DeleteImportedKeyMaterialRequest")
 	local headers = {
@@ -5151,19 +5182,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteImportedKeyMaterialRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteImportedKeyMaterialSync(DeleteImportedKeyMaterialRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteImportedKeyMaterialAsync(DeleteImportedKeyMaterialRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteImportedKeyMaterialAsync(DeleteImportedKeyMaterialRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateKeyDescription asynchronously, invoking a callback when done
 -- @param UpdateKeyDescriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateKeyDescriptionAsync(UpdateKeyDescriptionRequest, cb)
 	assert(UpdateKeyDescriptionRequest, "You must provide a UpdateKeyDescriptionRequest")
 	local headers = {
@@ -5186,19 +5218,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateKeyDescriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateKeyDescriptionSync(UpdateKeyDescriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateKeyDescriptionAsync(UpdateKeyDescriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateKeyDescriptionAsync(UpdateKeyDescriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeGrant asynchronously, invoking a callback when done
 -- @param RevokeGrantRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeGrantAsync(RevokeGrantRequest, cb)
 	assert(RevokeGrantRequest, "You must provide a RevokeGrantRequest")
 	local headers = {
@@ -5221,19 +5254,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeGrantRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeGrantSync(RevokeGrantRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeGrantAsync(RevokeGrantRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeGrantAsync(RevokeGrantRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutKeyPolicy asynchronously, invoking a callback when done
 -- @param PutKeyPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutKeyPolicyAsync(PutKeyPolicyRequest, cb)
 	assert(PutKeyPolicyRequest, "You must provide a PutKeyPolicyRequest")
 	local headers = {
@@ -5256,12 +5290,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutKeyPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutKeyPolicySync(PutKeyPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutKeyPolicyAsync(PutKeyPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutKeyPolicyAsync(PutKeyPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/lambda.lua
+++ b/aws-sdk/lambda.lua
@@ -3562,7 +3562,7 @@ end
 --
 --- Call ListEventSourceMappings asynchronously, invoking a callback when done
 -- @param ListEventSourceMappingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEventSourceMappingsAsync(ListEventSourceMappingsRequest, cb)
 	assert(ListEventSourceMappingsRequest, "You must provide a ListEventSourceMappingsRequest")
 	local headers = {
@@ -3585,19 +3585,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEventSourceMappingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEventSourceMappingsSync(ListEventSourceMappingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEventSourceMappingsAsync(ListEventSourceMappingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEventSourceMappingsAsync(ListEventSourceMappingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFunction asynchronously, invoking a callback when done
 -- @param DeleteFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFunctionAsync(DeleteFunctionRequest, cb)
 	assert(DeleteFunctionRequest, "You must provide a DeleteFunctionRequest")
 	local headers = {
@@ -3620,19 +3621,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFunctionSync(DeleteFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFunctionAsync(DeleteFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFunctionAsync(DeleteFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEventSourceMapping asynchronously, invoking a callback when done
 -- @param UpdateEventSourceMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEventSourceMappingAsync(UpdateEventSourceMappingRequest, cb)
 	assert(UpdateEventSourceMappingRequest, "You must provide a UpdateEventSourceMappingRequest")
 	local headers = {
@@ -3655,19 +3657,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEventSourceMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEventSourceMappingSync(UpdateEventSourceMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEventSourceMappingAsync(UpdateEventSourceMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEventSourceMappingAsync(UpdateEventSourceMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAlias asynchronously, invoking a callback when done
 -- @param UpdateAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAliasAsync(UpdateAliasRequest, cb)
 	assert(UpdateAliasRequest, "You must provide a UpdateAliasRequest")
 	local headers = {
@@ -3690,19 +3693,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAliasSync(UpdateAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAliasAsync(UpdateAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAliasAsync(UpdateAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFunctions asynchronously, invoking a callback when done
 -- @param ListFunctionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFunctionsAsync(ListFunctionsRequest, cb)
 	assert(ListFunctionsRequest, "You must provide a ListFunctionsRequest")
 	local headers = {
@@ -3725,19 +3729,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFunctionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFunctionsSync(ListFunctionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFunctionsAsync(ListFunctionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFunctionsAsync(ListFunctionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEventSourceMapping asynchronously, invoking a callback when done
 -- @param CreateEventSourceMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEventSourceMappingAsync(CreateEventSourceMappingRequest, cb)
 	assert(CreateEventSourceMappingRequest, "You must provide a CreateEventSourceMappingRequest")
 	local headers = {
@@ -3760,19 +3765,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEventSourceMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEventSourceMappingSync(CreateEventSourceMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEventSourceMappingAsync(CreateEventSourceMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEventSourceMappingAsync(CreateEventSourceMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFunctionConfiguration asynchronously, invoking a callback when done
 -- @param GetFunctionConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFunctionConfigurationAsync(GetFunctionConfigurationRequest, cb)
 	assert(GetFunctionConfigurationRequest, "You must provide a GetFunctionConfigurationRequest")
 	local headers = {
@@ -3795,19 +3801,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFunctionConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFunctionConfigurationSync(GetFunctionConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFunctionConfigurationAsync(GetFunctionConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFunctionConfigurationAsync(GetFunctionConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFunctionConcurrency asynchronously, invoking a callback when done
 -- @param DeleteFunctionConcurrencyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFunctionConcurrencyAsync(DeleteFunctionConcurrencyRequest, cb)
 	assert(DeleteFunctionConcurrencyRequest, "You must provide a DeleteFunctionConcurrencyRequest")
 	local headers = {
@@ -3830,19 +3837,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFunctionConcurrencyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFunctionConcurrencySync(DeleteFunctionConcurrencyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFunctionConcurrencyAsync(DeleteFunctionConcurrencyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFunctionConcurrencyAsync(DeleteFunctionConcurrencyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAliases asynchronously, invoking a callback when done
 -- @param ListAliasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAliasesAsync(ListAliasesRequest, cb)
 	assert(ListAliasesRequest, "You must provide a ListAliasesRequest")
 	local headers = {
@@ -3865,19 +3873,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAliasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAliasesSync(ListAliasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAliasesAsync(ListAliasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAliasesAsync(ListAliasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutFunctionConcurrency asynchronously, invoking a callback when done
 -- @param PutFunctionConcurrencyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutFunctionConcurrencyAsync(PutFunctionConcurrencyRequest, cb)
 	assert(PutFunctionConcurrencyRequest, "You must provide a PutFunctionConcurrencyRequest")
 	local headers = {
@@ -3900,19 +3909,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutFunctionConcurrencyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutFunctionConcurrencySync(PutFunctionConcurrencyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutFunctionConcurrencyAsync(PutFunctionConcurrencyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutFunctionConcurrencyAsync(PutFunctionConcurrencyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPolicy asynchronously, invoking a callback when done
 -- @param GetPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPolicyAsync(GetPolicyRequest, cb)
 	assert(GetPolicyRequest, "You must provide a GetPolicyRequest")
 	local headers = {
@@ -3935,19 +3945,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPolicySync(GetPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPolicyAsync(GetPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPolicyAsync(GetPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Invoke asynchronously, invoking a callback when done
 -- @param InvocationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InvokeAsync(InvocationRequest, cb)
 	assert(InvocationRequest, "You must provide a InvocationRequest")
 	local headers = {
@@ -3970,19 +3981,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InvocationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InvokeSync(InvocationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InvokeAsync(InvocationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InvokeAsync(InvocationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PublishVersion asynchronously, invoking a callback when done
 -- @param PublishVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PublishVersionAsync(PublishVersionRequest, cb)
 	assert(PublishVersionRequest, "You must provide a PublishVersionRequest")
 	local headers = {
@@ -4005,19 +4017,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PublishVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PublishVersionSync(PublishVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PublishVersionAsync(PublishVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PublishVersionAsync(PublishVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFunction asynchronously, invoking a callback when done
 -- @param GetFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFunctionAsync(GetFunctionRequest, cb)
 	assert(GetFunctionRequest, "You must provide a GetFunctionRequest")
 	local headers = {
@@ -4040,19 +4053,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFunctionSync(GetFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFunctionAsync(GetFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFunctionAsync(GetFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAlias asynchronously, invoking a callback when done
 -- @param DeleteAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAliasAsync(DeleteAliasRequest, cb)
 	assert(DeleteAliasRequest, "You must provide a DeleteAliasRequest")
 	local headers = {
@@ -4075,19 +4089,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAliasSync(DeleteAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAliasAsync(DeleteAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAliasAsync(DeleteAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddPermission asynchronously, invoking a callback when done
 -- @param AddPermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddPermissionAsync(AddPermissionRequest, cb)
 	assert(AddPermissionRequest, "You must provide a AddPermissionRequest")
 	local headers = {
@@ -4110,19 +4125,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddPermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddPermissionSync(AddPermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddPermissionAsync(AddPermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddPermissionAsync(AddPermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVersionsByFunction asynchronously, invoking a callback when done
 -- @param ListVersionsByFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVersionsByFunctionAsync(ListVersionsByFunctionRequest, cb)
 	assert(ListVersionsByFunctionRequest, "You must provide a ListVersionsByFunctionRequest")
 	local headers = {
@@ -4145,19 +4161,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVersionsByFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVersionsByFunctionSync(ListVersionsByFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVersionsByFunctionAsync(ListVersionsByFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVersionsByFunctionAsync(ListVersionsByFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemovePermission asynchronously, invoking a callback when done
 -- @param RemovePermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemovePermissionAsync(RemovePermissionRequest, cb)
 	assert(RemovePermissionRequest, "You must provide a RemovePermissionRequest")
 	local headers = {
@@ -4180,19 +4197,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemovePermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemovePermissionSync(RemovePermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemovePermissionAsync(RemovePermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemovePermissionAsync(RemovePermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAlias asynchronously, invoking a callback when done
 -- @param CreateAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAliasAsync(CreateAliasRequest, cb)
 	assert(CreateAliasRequest, "You must provide a CreateAliasRequest")
 	local headers = {
@@ -4215,19 +4233,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAliasSync(CreateAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAliasAsync(CreateAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAliasAsync(CreateAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -4250,19 +4269,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -4285,19 +4305,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEventSourceMapping asynchronously, invoking a callback when done
 -- @param DeleteEventSourceMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEventSourceMappingAsync(DeleteEventSourceMappingRequest, cb)
 	assert(DeleteEventSourceMappingRequest, "You must provide a DeleteEventSourceMappingRequest")
 	local headers = {
@@ -4320,19 +4341,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEventSourceMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEventSourceMappingSync(DeleteEventSourceMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEventSourceMappingAsync(DeleteEventSourceMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEventSourceMappingAsync(DeleteEventSourceMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFunctionConfiguration asynchronously, invoking a callback when done
 -- @param UpdateFunctionConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFunctionConfigurationAsync(UpdateFunctionConfigurationRequest, cb)
 	assert(UpdateFunctionConfigurationRequest, "You must provide a UpdateFunctionConfigurationRequest")
 	local headers = {
@@ -4355,19 +4377,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFunctionConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFunctionConfigurationSync(UpdateFunctionConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFunctionConfigurationAsync(UpdateFunctionConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFunctionConfigurationAsync(UpdateFunctionConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEventSourceMapping asynchronously, invoking a callback when done
 -- @param GetEventSourceMappingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEventSourceMappingAsync(GetEventSourceMappingRequest, cb)
 	assert(GetEventSourceMappingRequest, "You must provide a GetEventSourceMappingRequest")
 	local headers = {
@@ -4390,19 +4413,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEventSourceMappingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEventSourceMappingSync(GetEventSourceMappingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEventSourceMappingAsync(GetEventSourceMappingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEventSourceMappingAsync(GetEventSourceMappingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -4425,19 +4449,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAlias asynchronously, invoking a callback when done
 -- @param GetAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAliasAsync(GetAliasRequest, cb)
 	assert(GetAliasRequest, "You must provide a GetAliasRequest")
 	local headers = {
@@ -4460,19 +4485,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAliasSync(GetAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAliasAsync(GetAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAliasAsync(GetAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountSettings asynchronously, invoking a callback when done
 -- @param GetAccountSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountSettingsAsync(GetAccountSettingsRequest, cb)
 	assert(GetAccountSettingsRequest, "You must provide a GetAccountSettingsRequest")
 	local headers = {
@@ -4495,19 +4521,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountSettingsSync(GetAccountSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountSettingsAsync(GetAccountSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountSettingsAsync(GetAccountSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFunction asynchronously, invoking a callback when done
 -- @param CreateFunctionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFunctionAsync(CreateFunctionRequest, cb)
 	assert(CreateFunctionRequest, "You must provide a CreateFunctionRequest")
 	local headers = {
@@ -4530,19 +4557,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFunctionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFunctionSync(CreateFunctionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFunctionAsync(CreateFunctionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFunctionAsync(CreateFunctionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFunctionCode asynchronously, invoking a callback when done
 -- @param UpdateFunctionCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFunctionCodeAsync(UpdateFunctionCodeRequest, cb)
 	assert(UpdateFunctionCodeRequest, "You must provide a UpdateFunctionCodeRequest")
 	local headers = {
@@ -4565,12 +4593,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFunctionCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFunctionCodeSync(UpdateFunctionCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFunctionCodeAsync(UpdateFunctionCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFunctionCodeAsync(UpdateFunctionCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/lightsail.lua
+++ b/aws-sdk/lightsail.lua
@@ -11141,7 +11141,7 @@ end
 --
 --- Call GetKeyPair asynchronously, invoking a callback when done
 -- @param GetKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetKeyPairAsync(GetKeyPairRequest, cb)
 	assert(GetKeyPairRequest, "You must provide a GetKeyPairRequest")
 	local headers = {
@@ -11164,19 +11164,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetKeyPairSync(GetKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetKeyPairAsync(GetKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetKeyPairAsync(GetKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachDisk asynchronously, invoking a callback when done
 -- @param DetachDiskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachDiskAsync(DetachDiskRequest, cb)
 	assert(DetachDiskRequest, "You must provide a DetachDiskRequest")
 	local headers = {
@@ -11199,19 +11200,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachDiskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachDiskSync(DetachDiskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachDiskAsync(DetachDiskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachDiskAsync(DetachDiskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDiskSnapshot asynchronously, invoking a callback when done
 -- @param CreateDiskSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDiskSnapshotAsync(CreateDiskSnapshotRequest, cb)
 	assert(CreateDiskSnapshotRequest, "You must provide a CreateDiskSnapshotRequest")
 	local headers = {
@@ -11234,19 +11236,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDiskSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDiskSnapshotSync(CreateDiskSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDiskSnapshotAsync(CreateDiskSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDiskSnapshotAsync(CreateDiskSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachStaticIp asynchronously, invoking a callback when done
 -- @param AttachStaticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachStaticIpAsync(AttachStaticIpRequest, cb)
 	assert(AttachStaticIpRequest, "You must provide a AttachStaticIpRequest")
 	local headers = {
@@ -11269,19 +11272,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachStaticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachStaticIpSync(AttachStaticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachStaticIpAsync(AttachStaticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachStaticIpAsync(AttachStaticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDiskSnapshots asynchronously, invoking a callback when done
 -- @param GetDiskSnapshotsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDiskSnapshotsAsync(GetDiskSnapshotsRequest, cb)
 	assert(GetDiskSnapshotsRequest, "You must provide a GetDiskSnapshotsRequest")
 	local headers = {
@@ -11304,19 +11308,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDiskSnapshotsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDiskSnapshotsSync(GetDiskSnapshotsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDiskSnapshotsAsync(GetDiskSnapshotsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDiskSnapshotsAsync(GetDiskSnapshotsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetKeyPairs asynchronously, invoking a callback when done
 -- @param GetKeyPairsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetKeyPairsAsync(GetKeyPairsRequest, cb)
 	assert(GetKeyPairsRequest, "You must provide a GetKeyPairsRequest")
 	local headers = {
@@ -11339,19 +11344,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetKeyPairsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetKeyPairsSync(GetKeyPairsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetKeyPairsAsync(GetKeyPairsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetKeyPairsAsync(GetKeyPairsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportKeyPair asynchronously, invoking a callback when done
 -- @param ImportKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportKeyPairAsync(ImportKeyPairRequest, cb)
 	assert(ImportKeyPairRequest, "You must provide a ImportKeyPairRequest")
 	local headers = {
@@ -11374,19 +11380,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportKeyPairSync(ImportKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportKeyPairAsync(ImportKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportKeyPairAsync(ImportKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRelationalDatabase asynchronously, invoking a callback when done
 -- @param CreateRelationalDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRelationalDatabaseAsync(CreateRelationalDatabaseRequest, cb)
 	assert(CreateRelationalDatabaseRequest, "You must provide a CreateRelationalDatabaseRequest")
 	local headers = {
@@ -11409,19 +11416,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRelationalDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRelationalDatabaseSync(CreateRelationalDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRelationalDatabaseAsync(CreateRelationalDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRelationalDatabaseAsync(CreateRelationalDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseParameters asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseParametersAsync(GetRelationalDatabaseParametersRequest, cb)
 	assert(GetRelationalDatabaseParametersRequest, "You must provide a GetRelationalDatabaseParametersRequest")
 	local headers = {
@@ -11444,19 +11452,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseParametersSync(GetRelationalDatabaseParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseParametersAsync(GetRelationalDatabaseParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseParametersAsync(GetRelationalDatabaseParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachInstancesToLoadBalancer asynchronously, invoking a callback when done
 -- @param AttachInstancesToLoadBalancerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachInstancesToLoadBalancerAsync(AttachInstancesToLoadBalancerRequest, cb)
 	assert(AttachInstancesToLoadBalancerRequest, "You must provide a AttachInstancesToLoadBalancerRequest")
 	local headers = {
@@ -11479,19 +11488,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachInstancesToLoadBalancerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachInstancesToLoadBalancerSync(AttachInstancesToLoadBalancerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachInstancesToLoadBalancerAsync(AttachInstancesToLoadBalancerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachInstancesToLoadBalancerAsync(AttachInstancesToLoadBalancerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachInstancesFromLoadBalancer asynchronously, invoking a callback when done
 -- @param DetachInstancesFromLoadBalancerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachInstancesFromLoadBalancerAsync(DetachInstancesFromLoadBalancerRequest, cb)
 	assert(DetachInstancesFromLoadBalancerRequest, "You must provide a DetachInstancesFromLoadBalancerRequest")
 	local headers = {
@@ -11514,19 +11524,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachInstancesFromLoadBalancerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachInstancesFromLoadBalancerSync(DetachInstancesFromLoadBalancerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachInstancesFromLoadBalancerAsync(DetachInstancesFromLoadBalancerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachInstancesFromLoadBalancerAsync(DetachInstancesFromLoadBalancerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstance asynchronously, invoking a callback when done
 -- @param GetInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceAsync(GetInstanceRequest, cb)
 	assert(GetInstanceRequest, "You must provide a GetInstanceRequest")
 	local headers = {
@@ -11549,19 +11560,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceSync(GetInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceAsync(GetInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceAsync(GetInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDomainEntry asynchronously, invoking a callback when done
 -- @param UpdateDomainEntryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDomainEntryAsync(UpdateDomainEntryRequest, cb)
 	assert(UpdateDomainEntryRequest, "You must provide a UpdateDomainEntryRequest")
 	local headers = {
@@ -11584,19 +11596,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDomainEntryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDomainEntrySync(UpdateDomainEntryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDomainEntryAsync(UpdateDomainEntryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDomainEntryAsync(UpdateDomainEntryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AllocateStaticIp asynchronously, invoking a callback when done
 -- @param AllocateStaticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AllocateStaticIpAsync(AllocateStaticIpRequest, cb)
 	assert(AllocateStaticIpRequest, "You must provide a AllocateStaticIpRequest")
 	local headers = {
@@ -11619,19 +11632,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AllocateStaticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AllocateStaticIpSync(AllocateStaticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AllocateStaticIpAsync(AllocateStaticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AllocateStaticIpAsync(AllocateStaticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstances asynchronously, invoking a callback when done
 -- @param GetInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstancesAsync(GetInstancesRequest, cb)
 	assert(GetInstancesRequest, "You must provide a GetInstancesRequest")
 	local headers = {
@@ -11654,19 +11668,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstancesSync(GetInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstancesAsync(GetInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstancesAsync(GetInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopRelationalDatabase asynchronously, invoking a callback when done
 -- @param StopRelationalDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopRelationalDatabaseAsync(StopRelationalDatabaseRequest, cb)
 	assert(StopRelationalDatabaseRequest, "You must provide a StopRelationalDatabaseRequest")
 	local headers = {
@@ -11689,19 +11704,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopRelationalDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopRelationalDatabaseSync(StopRelationalDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopRelationalDatabaseAsync(StopRelationalDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopRelationalDatabaseAsync(StopRelationalDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDisk asynchronously, invoking a callback when done
 -- @param GetDiskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDiskAsync(GetDiskRequest, cb)
 	assert(GetDiskRequest, "You must provide a GetDiskRequest")
 	local headers = {
@@ -11724,19 +11740,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDiskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDiskSync(GetDiskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDiskAsync(GetDiskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDiskAsync(GetDiskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseBlueprints asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseBlueprintsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseBlueprintsAsync(GetRelationalDatabaseBlueprintsRequest, cb)
 	assert(GetRelationalDatabaseBlueprintsRequest, "You must provide a GetRelationalDatabaseBlueprintsRequest")
 	local headers = {
@@ -11759,19 +11776,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseBlueprintsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseBlueprintsSync(GetRelationalDatabaseBlueprintsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseBlueprintsAsync(GetRelationalDatabaseBlueprintsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseBlueprintsAsync(GetRelationalDatabaseBlueprintsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDisks asynchronously, invoking a callback when done
 -- @param GetDisksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDisksAsync(GetDisksRequest, cb)
 	assert(GetDisksRequest, "You must provide a GetDisksRequest")
 	local headers = {
@@ -11794,19 +11812,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDisksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDisksSync(GetDisksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDisksAsync(GetDisksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDisksAsync(GetDisksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDiskFromSnapshot asynchronously, invoking a callback when done
 -- @param CreateDiskFromSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDiskFromSnapshotAsync(CreateDiskFromSnapshotRequest, cb)
 	assert(CreateDiskFromSnapshotRequest, "You must provide a CreateDiskFromSnapshotRequest")
 	local headers = {
@@ -11829,19 +11848,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDiskFromSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDiskFromSnapshotSync(CreateDiskFromSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDiskFromSnapshotAsync(CreateDiskFromSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDiskFromSnapshotAsync(CreateDiskFromSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDomain asynchronously, invoking a callback when done
 -- @param GetDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDomainAsync(GetDomainRequest, cb)
 	assert(GetDomainRequest, "You must provide a GetDomainRequest")
 	local headers = {
@@ -11864,19 +11884,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDomainSync(GetDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDomainAsync(GetDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDomainAsync(GetDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLoadBalancerTlsCertificate asynchronously, invoking a callback when done
 -- @param CreateLoadBalancerTlsCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLoadBalancerTlsCertificateAsync(CreateLoadBalancerTlsCertificateRequest, cb)
 	assert(CreateLoadBalancerTlsCertificateRequest, "You must provide a CreateLoadBalancerTlsCertificateRequest")
 	local headers = {
@@ -11899,19 +11920,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLoadBalancerTlsCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLoadBalancerTlsCertificateSync(CreateLoadBalancerTlsCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLoadBalancerTlsCertificateAsync(CreateLoadBalancerTlsCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLoadBalancerTlsCertificateAsync(CreateLoadBalancerTlsCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoadBalancers asynchronously, invoking a callback when done
 -- @param GetLoadBalancersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoadBalancersAsync(GetLoadBalancersRequest, cb)
 	assert(GetLoadBalancersRequest, "You must provide a GetLoadBalancersRequest")
 	local headers = {
@@ -11934,19 +11956,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoadBalancersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoadBalancersSync(GetLoadBalancersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoadBalancersAsync(GetLoadBalancersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoadBalancersAsync(GetLoadBalancersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutInstancePublicPorts asynchronously, invoking a callback when done
 -- @param PutInstancePublicPortsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutInstancePublicPortsAsync(PutInstancePublicPortsRequest, cb)
 	assert(PutInstancePublicPortsRequest, "You must provide a PutInstancePublicPortsRequest")
 	local headers = {
@@ -11969,19 +11992,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutInstancePublicPortsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutInstancePublicPortsSync(PutInstancePublicPortsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutInstancePublicPortsAsync(PutInstancePublicPortsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutInstancePublicPortsAsync(PutInstancePublicPortsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDomain asynchronously, invoking a callback when done
 -- @param DeleteDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDomainAsync(DeleteDomainRequest, cb)
 	assert(DeleteDomainRequest, "You must provide a DeleteDomainRequest")
 	local headers = {
@@ -12004,19 +12028,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDomainSync(DeleteDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDomainAsync(DeleteDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDomainAsync(DeleteDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDomainEntry asynchronously, invoking a callback when done
 -- @param CreateDomainEntryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDomainEntryAsync(CreateDomainEntryRequest, cb)
 	assert(CreateDomainEntryRequest, "You must provide a CreateDomainEntryRequest")
 	local headers = {
@@ -12039,19 +12064,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDomainEntryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDomainEntrySync(CreateDomainEntryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDomainEntryAsync(CreateDomainEntryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDomainEntryAsync(CreateDomainEntryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartRelationalDatabase asynchronously, invoking a callback when done
 -- @param StartRelationalDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartRelationalDatabaseAsync(StartRelationalDatabaseRequest, cb)
 	assert(StartRelationalDatabaseRequest, "You must provide a StartRelationalDatabaseRequest")
 	local headers = {
@@ -12074,19 +12100,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartRelationalDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartRelationalDatabaseSync(StartRelationalDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartRelationalDatabaseAsync(StartRelationalDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartRelationalDatabaseAsync(StartRelationalDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInstancesFromSnapshot asynchronously, invoking a callback when done
 -- @param CreateInstancesFromSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInstancesFromSnapshotAsync(CreateInstancesFromSnapshotRequest, cb)
 	assert(CreateInstancesFromSnapshotRequest, "You must provide a CreateInstancesFromSnapshotRequest")
 	local headers = {
@@ -12109,19 +12136,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInstancesFromSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInstancesFromSnapshotSync(CreateInstancesFromSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInstancesFromSnapshotAsync(CreateInstancesFromSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInstancesFromSnapshotAsync(CreateInstancesFromSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOperation asynchronously, invoking a callback when done
 -- @param GetOperationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOperationAsync(GetOperationRequest, cb)
 	assert(GetOperationRequest, "You must provide a GetOperationRequest")
 	local headers = {
@@ -12144,19 +12172,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOperationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOperationSync(GetOperationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOperationAsync(GetOperationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOperationAsync(GetOperationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateLoadBalancerAttribute asynchronously, invoking a callback when done
 -- @param UpdateLoadBalancerAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateLoadBalancerAttributeAsync(UpdateLoadBalancerAttributeRequest, cb)
 	assert(UpdateLoadBalancerAttributeRequest, "You must provide a UpdateLoadBalancerAttributeRequest")
 	local headers = {
@@ -12179,19 +12208,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateLoadBalancerAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateLoadBalancerAttributeSync(UpdateLoadBalancerAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateLoadBalancerAttributeAsync(UpdateLoadBalancerAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateLoadBalancerAttributeAsync(UpdateLoadBalancerAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRelationalDatabase asynchronously, invoking a callback when done
 -- @param DeleteRelationalDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRelationalDatabaseAsync(DeleteRelationalDatabaseRequest, cb)
 	assert(DeleteRelationalDatabaseRequest, "You must provide a DeleteRelationalDatabaseRequest")
 	local headers = {
@@ -12214,19 +12244,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRelationalDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRelationalDatabaseSync(DeleteRelationalDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRelationalDatabaseAsync(DeleteRelationalDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRelationalDatabaseAsync(DeleteRelationalDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceState asynchronously, invoking a callback when done
 -- @param GetInstanceStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceStateAsync(GetInstanceStateRequest, cb)
 	assert(GetInstanceStateRequest, "You must provide a GetInstanceStateRequest")
 	local headers = {
@@ -12249,19 +12280,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceStateSync(GetInstanceStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceStateAsync(GetInstanceStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceStateAsync(GetInstanceStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInstanceSnapshot asynchronously, invoking a callback when done
 -- @param CreateInstanceSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInstanceSnapshotAsync(CreateInstanceSnapshotRequest, cb)
 	assert(CreateInstanceSnapshotRequest, "You must provide a CreateInstanceSnapshotRequest")
 	local headers = {
@@ -12284,19 +12316,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInstanceSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInstanceSnapshotSync(CreateInstanceSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInstanceSnapshotAsync(CreateInstanceSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInstanceSnapshotAsync(CreateInstanceSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootInstance asynchronously, invoking a callback when done
 -- @param RebootInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootInstanceAsync(RebootInstanceRequest, cb)
 	assert(RebootInstanceRequest, "You must provide a RebootInstanceRequest")
 	local headers = {
@@ -12319,19 +12352,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootInstanceSync(RebootInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootInstanceAsync(RebootInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootInstanceAsync(RebootInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDisk asynchronously, invoking a callback when done
 -- @param CreateDiskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDiskAsync(CreateDiskRequest, cb)
 	assert(CreateDiskRequest, "You must provide a CreateDiskRequest")
 	local headers = {
@@ -12354,19 +12388,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDiskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDiskSync(CreateDiskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDiskAsync(CreateDiskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDiskAsync(CreateDiskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopInstance asynchronously, invoking a callback when done
 -- @param StopInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopInstanceAsync(StopInstanceRequest, cb)
 	assert(StopInstanceRequest, "You must provide a StopInstanceRequest")
 	local headers = {
@@ -12389,19 +12424,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopInstanceSync(StopInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopInstanceAsync(StopInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopInstanceAsync(StopInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRelationalDatabaseSnapshot asynchronously, invoking a callback when done
 -- @param DeleteRelationalDatabaseSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRelationalDatabaseSnapshotAsync(DeleteRelationalDatabaseSnapshotRequest, cb)
 	assert(DeleteRelationalDatabaseSnapshotRequest, "You must provide a DeleteRelationalDatabaseSnapshotRequest")
 	local headers = {
@@ -12424,19 +12460,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRelationalDatabaseSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRelationalDatabaseSnapshotSync(DeleteRelationalDatabaseSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRelationalDatabaseSnapshotAsync(DeleteRelationalDatabaseSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRelationalDatabaseSnapshotAsync(DeleteRelationalDatabaseSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PeerVpc asynchronously, invoking a callback when done
 -- @param PeerVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PeerVpcAsync(PeerVpcRequest, cb)
 	assert(PeerVpcRequest, "You must provide a PeerVpcRequest")
 	local headers = {
@@ -12459,19 +12496,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PeerVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PeerVpcSync(PeerVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PeerVpcAsync(PeerVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PeerVpcAsync(PeerVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRelationalDatabaseSnapshot asynchronously, invoking a callback when done
 -- @param CreateRelationalDatabaseSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRelationalDatabaseSnapshotAsync(CreateRelationalDatabaseSnapshotRequest, cb)
 	assert(CreateRelationalDatabaseSnapshotRequest, "You must provide a CreateRelationalDatabaseSnapshotRequest")
 	local headers = {
@@ -12494,19 +12532,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRelationalDatabaseSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRelationalDatabaseSnapshotSync(CreateRelationalDatabaseSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRelationalDatabaseSnapshotAsync(CreateRelationalDatabaseSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRelationalDatabaseSnapshotAsync(CreateRelationalDatabaseSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInstanceSnapshot asynchronously, invoking a callback when done
 -- @param DeleteInstanceSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInstanceSnapshotAsync(DeleteInstanceSnapshotRequest, cb)
 	assert(DeleteInstanceSnapshotRequest, "You must provide a DeleteInstanceSnapshotRequest")
 	local headers = {
@@ -12529,19 +12568,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInstanceSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInstanceSnapshotSync(DeleteInstanceSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInstanceSnapshotAsync(DeleteInstanceSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInstanceSnapshotAsync(DeleteInstanceSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoadBalancer asynchronously, invoking a callback when done
 -- @param GetLoadBalancerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoadBalancerAsync(GetLoadBalancerRequest, cb)
 	assert(GetLoadBalancerRequest, "You must provide a GetLoadBalancerRequest")
 	local headers = {
@@ -12564,19 +12604,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoadBalancerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoadBalancerSync(GetLoadBalancerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoadBalancerAsync(GetLoadBalancerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoadBalancerAsync(GetLoadBalancerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRegions asynchronously, invoking a callback when done
 -- @param GetRegionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRegionsAsync(GetRegionsRequest, cb)
 	assert(GetRegionsRequest, "You must provide a GetRegionsRequest")
 	local headers = {
@@ -12599,19 +12640,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRegionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRegionsSync(GetRegionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRegionsAsync(GetRegionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRegionsAsync(GetRegionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstancePortStates asynchronously, invoking a callback when done
 -- @param GetInstancePortStatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstancePortStatesAsync(GetInstancePortStatesRequest, cb)
 	assert(GetInstancePortStatesRequest, "You must provide a GetInstancePortStatesRequest")
 	local headers = {
@@ -12634,19 +12676,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstancePortStatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstancePortStatesSync(GetInstancePortStatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstancePortStatesAsync(GetInstancePortStatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstancePortStatesAsync(GetInstancePortStatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceSnapshots asynchronously, invoking a callback when done
 -- @param GetInstanceSnapshotsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceSnapshotsAsync(GetInstanceSnapshotsRequest, cb)
 	assert(GetInstanceSnapshotsRequest, "You must provide a GetInstanceSnapshotsRequest")
 	local headers = {
@@ -12669,19 +12712,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceSnapshotsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceSnapshotsSync(GetInstanceSnapshotsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceSnapshotsAsync(GetInstanceSnapshotsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceSnapshotsAsync(GetInstanceSnapshotsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRelationalDatabase asynchronously, invoking a callback when done
 -- @param UpdateRelationalDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRelationalDatabaseAsync(UpdateRelationalDatabaseRequest, cb)
 	assert(UpdateRelationalDatabaseRequest, "You must provide a UpdateRelationalDatabaseRequest")
 	local headers = {
@@ -12704,19 +12748,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRelationalDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRelationalDatabaseSync(UpdateRelationalDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRelationalDatabaseAsync(UpdateRelationalDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRelationalDatabaseAsync(UpdateRelationalDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoadBalancerMetricData asynchronously, invoking a callback when done
 -- @param GetLoadBalancerMetricDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoadBalancerMetricDataAsync(GetLoadBalancerMetricDataRequest, cb)
 	assert(GetLoadBalancerMetricDataRequest, "You must provide a GetLoadBalancerMetricDataRequest")
 	local headers = {
@@ -12739,19 +12784,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoadBalancerMetricDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoadBalancerMetricDataSync(GetLoadBalancerMetricDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoadBalancerMetricDataAsync(GetLoadBalancerMetricDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoadBalancerMetricDataAsync(GetLoadBalancerMetricDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStaticIps asynchronously, invoking a callback when done
 -- @param GetStaticIpsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStaticIpsAsync(GetStaticIpsRequest, cb)
 	assert(GetStaticIpsRequest, "You must provide a GetStaticIpsRequest")
 	local headers = {
@@ -12774,19 +12820,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStaticIpsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStaticIpsSync(GetStaticIpsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStaticIpsAsync(GetStaticIpsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStaticIpsAsync(GetStaticIpsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabase asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseAsync(GetRelationalDatabaseRequest, cb)
 	assert(GetRelationalDatabaseRequest, "You must provide a GetRelationalDatabaseRequest")
 	local headers = {
@@ -12809,19 +12856,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseSync(GetRelationalDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseAsync(GetRelationalDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseAsync(GetRelationalDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CloseInstancePublicPorts asynchronously, invoking a callback when done
 -- @param CloseInstancePublicPortsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CloseInstancePublicPortsAsync(CloseInstancePublicPortsRequest, cb)
 	assert(CloseInstancePublicPortsRequest, "You must provide a CloseInstancePublicPortsRequest")
 	local headers = {
@@ -12844,19 +12892,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CloseInstancePublicPortsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CloseInstancePublicPortsSync(CloseInstancePublicPortsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CloseInstancePublicPortsAsync(CloseInstancePublicPortsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CloseInstancePublicPortsAsync(CloseInstancePublicPortsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetActiveNames asynchronously, invoking a callback when done
 -- @param GetActiveNamesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetActiveNamesAsync(GetActiveNamesRequest, cb)
 	assert(GetActiveNamesRequest, "You must provide a GetActiveNamesRequest")
 	local headers = {
@@ -12879,19 +12928,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetActiveNamesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetActiveNamesSync(GetActiveNamesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetActiveNamesAsync(GetActiveNamesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetActiveNamesAsync(GetActiveNamesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInstance asynchronously, invoking a callback when done
 -- @param DeleteInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInstanceAsync(DeleteInstanceRequest, cb)
 	assert(DeleteInstanceRequest, "You must provide a DeleteInstanceRequest")
 	local headers = {
@@ -12914,19 +12964,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInstanceSync(DeleteInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInstanceAsync(DeleteInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInstanceAsync(DeleteInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetStaticIp asynchronously, invoking a callback when done
 -- @param GetStaticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetStaticIpAsync(GetStaticIpRequest, cb)
 	assert(GetStaticIpRequest, "You must provide a GetStaticIpRequest")
 	local headers = {
@@ -12949,19 +13000,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetStaticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetStaticIpSync(GetStaticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetStaticIpAsync(GetStaticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetStaticIpAsync(GetStaticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateKeyPair asynchronously, invoking a callback when done
 -- @param CreateKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateKeyPairAsync(CreateKeyPairRequest, cb)
 	assert(CreateKeyPairRequest, "You must provide a CreateKeyPairRequest")
 	local headers = {
@@ -12984,19 +13036,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateKeyPairSync(CreateKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateKeyPairAsync(CreateKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateKeyPairAsync(CreateKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call OpenInstancePublicPorts asynchronously, invoking a callback when done
 -- @param OpenInstancePublicPortsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.OpenInstancePublicPortsAsync(OpenInstancePublicPortsRequest, cb)
 	assert(OpenInstancePublicPortsRequest, "You must provide a OpenInstancePublicPortsRequest")
 	local headers = {
@@ -13019,19 +13072,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param OpenInstancePublicPortsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.OpenInstancePublicPortsSync(OpenInstancePublicPortsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.OpenInstancePublicPortsAsync(OpenInstancePublicPortsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.OpenInstancePublicPortsAsync(OpenInstancePublicPortsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDiskSnapshot asynchronously, invoking a callback when done
 -- @param GetDiskSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDiskSnapshotAsync(GetDiskSnapshotRequest, cb)
 	assert(GetDiskSnapshotRequest, "You must provide a GetDiskSnapshotRequest")
 	local headers = {
@@ -13054,19 +13108,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDiskSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDiskSnapshotSync(GetDiskSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDiskSnapshotAsync(GetDiskSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDiskSnapshotAsync(GetDiskSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLoadBalancer asynchronously, invoking a callback when done
 -- @param DeleteLoadBalancerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLoadBalancerAsync(DeleteLoadBalancerRequest, cb)
 	assert(DeleteLoadBalancerRequest, "You must provide a DeleteLoadBalancerRequest")
 	local headers = {
@@ -13089,19 +13144,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLoadBalancerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLoadBalancerSync(DeleteLoadBalancerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLoadBalancerAsync(DeleteLoadBalancerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLoadBalancerAsync(DeleteLoadBalancerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseLogEvents asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseLogEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseLogEventsAsync(GetRelationalDatabaseLogEventsRequest, cb)
 	assert(GetRelationalDatabaseLogEventsRequest, "You must provide a GetRelationalDatabaseLogEventsRequest")
 	local headers = {
@@ -13124,19 +13180,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseLogEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseLogEventsSync(GetRelationalDatabaseLogEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseLogEventsAsync(GetRelationalDatabaseLogEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseLogEventsAsync(GetRelationalDatabaseLogEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabases asynchronously, invoking a callback when done
 -- @param GetRelationalDatabasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabasesAsync(GetRelationalDatabasesRequest, cb)
 	assert(GetRelationalDatabasesRequest, "You must provide a GetRelationalDatabasesRequest")
 	local headers = {
@@ -13159,19 +13216,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabasesSync(GetRelationalDatabasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabasesAsync(GetRelationalDatabasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabasesAsync(GetRelationalDatabasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartInstance asynchronously, invoking a callback when done
 -- @param StartInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartInstanceAsync(StartInstanceRequest, cb)
 	assert(StartInstanceRequest, "You must provide a StartInstanceRequest")
 	local headers = {
@@ -13194,19 +13252,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartInstanceSync(StartInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartInstanceAsync(StartInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartInstanceAsync(StartInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseEvents asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseEventsAsync(GetRelationalDatabaseEventsRequest, cb)
 	assert(GetRelationalDatabaseEventsRequest, "You must provide a GetRelationalDatabaseEventsRequest")
 	local headers = {
@@ -13229,19 +13288,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseEventsSync(GetRelationalDatabaseEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseEventsAsync(GetRelationalDatabaseEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseEventsAsync(GetRelationalDatabaseEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDomain asynchronously, invoking a callback when done
 -- @param CreateDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDomainAsync(CreateDomainRequest, cb)
 	assert(CreateDomainRequest, "You must provide a CreateDomainRequest")
 	local headers = {
@@ -13264,19 +13324,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDomainSync(CreateDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDomainAsync(CreateDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDomainAsync(CreateDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseMetricData asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseMetricDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseMetricDataAsync(GetRelationalDatabaseMetricDataRequest, cb)
 	assert(GetRelationalDatabaseMetricDataRequest, "You must provide a GetRelationalDatabaseMetricDataRequest")
 	local headers = {
@@ -13299,19 +13360,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseMetricDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseMetricDataSync(GetRelationalDatabaseMetricDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseMetricDataAsync(GetRelationalDatabaseMetricDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseMetricDataAsync(GetRelationalDatabaseMetricDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachDisk asynchronously, invoking a callback when done
 -- @param AttachDiskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachDiskAsync(AttachDiskRequest, cb)
 	assert(AttachDiskRequest, "You must provide a AttachDiskRequest")
 	local headers = {
@@ -13334,19 +13396,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachDiskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachDiskSync(AttachDiskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachDiskAsync(AttachDiskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachDiskAsync(AttachDiskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoadBalancerTlsCertificates asynchronously, invoking a callback when done
 -- @param GetLoadBalancerTlsCertificatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoadBalancerTlsCertificatesAsync(GetLoadBalancerTlsCertificatesRequest, cb)
 	assert(GetLoadBalancerTlsCertificatesRequest, "You must provide a GetLoadBalancerTlsCertificatesRequest")
 	local headers = {
@@ -13369,19 +13432,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoadBalancerTlsCertificatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoadBalancerTlsCertificatesSync(GetLoadBalancerTlsCertificatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoadBalancerTlsCertificatesAsync(GetLoadBalancerTlsCertificatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoadBalancerTlsCertificatesAsync(GetLoadBalancerTlsCertificatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachLoadBalancerTlsCertificate asynchronously, invoking a callback when done
 -- @param AttachLoadBalancerTlsCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachLoadBalancerTlsCertificateAsync(AttachLoadBalancerTlsCertificateRequest, cb)
 	assert(AttachLoadBalancerTlsCertificateRequest, "You must provide a AttachLoadBalancerTlsCertificateRequest")
 	local headers = {
@@ -13404,19 +13468,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachLoadBalancerTlsCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachLoadBalancerTlsCertificateSync(AttachLoadBalancerTlsCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachLoadBalancerTlsCertificateAsync(AttachLoadBalancerTlsCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachLoadBalancerTlsCertificateAsync(AttachLoadBalancerTlsCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDisk asynchronously, invoking a callback when done
 -- @param DeleteDiskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDiskAsync(DeleteDiskRequest, cb)
 	assert(DeleteDiskRequest, "You must provide a DeleteDiskRequest")
 	local headers = {
@@ -13439,19 +13504,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDiskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDiskSync(DeleteDiskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDiskAsync(DeleteDiskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDiskAsync(DeleteDiskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseLogStreams asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseLogStreamsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseLogStreamsAsync(GetRelationalDatabaseLogStreamsRequest, cb)
 	assert(GetRelationalDatabaseLogStreamsRequest, "You must provide a GetRelationalDatabaseLogStreamsRequest")
 	local headers = {
@@ -13474,19 +13540,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseLogStreamsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseLogStreamsSync(GetRelationalDatabaseLogStreamsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseLogStreamsAsync(GetRelationalDatabaseLogStreamsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseLogStreamsAsync(GetRelationalDatabaseLogStreamsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceAccessDetails asynchronously, invoking a callback when done
 -- @param GetInstanceAccessDetailsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceAccessDetailsAsync(GetInstanceAccessDetailsRequest, cb)
 	assert(GetInstanceAccessDetailsRequest, "You must provide a GetInstanceAccessDetailsRequest")
 	local headers = {
@@ -13509,19 +13576,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceAccessDetailsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceAccessDetailsSync(GetInstanceAccessDetailsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceAccessDetailsAsync(GetInstanceAccessDetailsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceAccessDetailsAsync(GetInstanceAccessDetailsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDiskSnapshot asynchronously, invoking a callback when done
 -- @param DeleteDiskSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDiskSnapshotAsync(DeleteDiskSnapshotRequest, cb)
 	assert(DeleteDiskSnapshotRequest, "You must provide a DeleteDiskSnapshotRequest")
 	local headers = {
@@ -13544,19 +13612,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDiskSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDiskSnapshotSync(DeleteDiskSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDiskSnapshotAsync(DeleteDiskSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDiskSnapshotAsync(DeleteDiskSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call IsVpcPeered asynchronously, invoking a callback when done
 -- @param IsVpcPeeredRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.IsVpcPeeredAsync(IsVpcPeeredRequest, cb)
 	assert(IsVpcPeeredRequest, "You must provide a IsVpcPeeredRequest")
 	local headers = {
@@ -13579,19 +13648,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IsVpcPeeredRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.IsVpcPeeredSync(IsVpcPeeredRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.IsVpcPeeredAsync(IsVpcPeeredRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.IsVpcPeeredAsync(IsVpcPeeredRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLoadBalancer asynchronously, invoking a callback when done
 -- @param CreateLoadBalancerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLoadBalancerAsync(CreateLoadBalancerRequest, cb)
 	assert(CreateLoadBalancerRequest, "You must provide a CreateLoadBalancerRequest")
 	local headers = {
@@ -13614,19 +13684,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLoadBalancerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLoadBalancerSync(CreateLoadBalancerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLoadBalancerAsync(CreateLoadBalancerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLoadBalancerAsync(CreateLoadBalancerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceMetricData asynchronously, invoking a callback when done
 -- @param GetInstanceMetricDataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceMetricDataAsync(GetInstanceMetricDataRequest, cb)
 	assert(GetInstanceMetricDataRequest, "You must provide a GetInstanceMetricDataRequest")
 	local headers = {
@@ -13649,19 +13720,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceMetricDataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceMetricDataSync(GetInstanceMetricDataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceMetricDataAsync(GetInstanceMetricDataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceMetricDataAsync(GetInstanceMetricDataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReleaseStaticIp asynchronously, invoking a callback when done
 -- @param ReleaseStaticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReleaseStaticIpAsync(ReleaseStaticIpRequest, cb)
 	assert(ReleaseStaticIpRequest, "You must provide a ReleaseStaticIpRequest")
 	local headers = {
@@ -13684,19 +13756,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReleaseStaticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReleaseStaticIpSync(ReleaseStaticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReleaseStaticIpAsync(ReleaseStaticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReleaseStaticIpAsync(ReleaseStaticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRelationalDatabaseParameters asynchronously, invoking a callback when done
 -- @param UpdateRelationalDatabaseParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRelationalDatabaseParametersAsync(UpdateRelationalDatabaseParametersRequest, cb)
 	assert(UpdateRelationalDatabaseParametersRequest, "You must provide a UpdateRelationalDatabaseParametersRequest")
 	local headers = {
@@ -13719,19 +13792,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRelationalDatabaseParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRelationalDatabaseParametersSync(UpdateRelationalDatabaseParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRelationalDatabaseParametersAsync(UpdateRelationalDatabaseParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRelationalDatabaseParametersAsync(UpdateRelationalDatabaseParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOperationsForResource asynchronously, invoking a callback when done
 -- @param GetOperationsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOperationsForResourceAsync(GetOperationsForResourceRequest, cb)
 	assert(GetOperationsForResourceRequest, "You must provide a GetOperationsForResourceRequest")
 	local headers = {
@@ -13754,19 +13828,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOperationsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOperationsForResourceSync(GetOperationsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOperationsForResourceAsync(GetOperationsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOperationsForResourceAsync(GetOperationsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstanceSnapshot asynchronously, invoking a callback when done
 -- @param GetInstanceSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceSnapshotAsync(GetInstanceSnapshotRequest, cb)
 	assert(GetInstanceSnapshotRequest, "You must provide a GetInstanceSnapshotRequest")
 	local headers = {
@@ -13789,19 +13864,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceSnapshotSync(GetInstanceSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceSnapshotAsync(GetInstanceSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceSnapshotAsync(GetInstanceSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLoadBalancerTlsCertificate asynchronously, invoking a callback when done
 -- @param DeleteLoadBalancerTlsCertificateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLoadBalancerTlsCertificateAsync(DeleteLoadBalancerTlsCertificateRequest, cb)
 	assert(DeleteLoadBalancerTlsCertificateRequest, "You must provide a DeleteLoadBalancerTlsCertificateRequest")
 	local headers = {
@@ -13824,19 +13900,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLoadBalancerTlsCertificateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLoadBalancerTlsCertificateSync(DeleteLoadBalancerTlsCertificateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLoadBalancerTlsCertificateAsync(DeleteLoadBalancerTlsCertificateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLoadBalancerTlsCertificateAsync(DeleteLoadBalancerTlsCertificateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBlueprints asynchronously, invoking a callback when done
 -- @param GetBlueprintsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBlueprintsAsync(GetBlueprintsRequest, cb)
 	assert(GetBlueprintsRequest, "You must provide a GetBlueprintsRequest")
 	local headers = {
@@ -13859,19 +13936,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBlueprintsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBlueprintsSync(GetBlueprintsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBlueprintsAsync(GetBlueprintsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBlueprintsAsync(GetBlueprintsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DownloadDefaultKeyPair asynchronously, invoking a callback when done
 -- @param DownloadDefaultKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DownloadDefaultKeyPairAsync(DownloadDefaultKeyPairRequest, cb)
 	assert(DownloadDefaultKeyPairRequest, "You must provide a DownloadDefaultKeyPairRequest")
 	local headers = {
@@ -13894,19 +13972,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DownloadDefaultKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DownloadDefaultKeyPairSync(DownloadDefaultKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DownloadDefaultKeyPairAsync(DownloadDefaultKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DownloadDefaultKeyPairAsync(DownloadDefaultKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseSnapshots asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseSnapshotsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseSnapshotsAsync(GetRelationalDatabaseSnapshotsRequest, cb)
 	assert(GetRelationalDatabaseSnapshotsRequest, "You must provide a GetRelationalDatabaseSnapshotsRequest")
 	local headers = {
@@ -13929,19 +14008,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseSnapshotsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseSnapshotsSync(GetRelationalDatabaseSnapshotsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseSnapshotsAsync(GetRelationalDatabaseSnapshotsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseSnapshotsAsync(GetRelationalDatabaseSnapshotsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDomainEntry asynchronously, invoking a callback when done
 -- @param DeleteDomainEntryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDomainEntryAsync(DeleteDomainEntryRequest, cb)
 	assert(DeleteDomainEntryRequest, "You must provide a DeleteDomainEntryRequest")
 	local headers = {
@@ -13964,19 +14044,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDomainEntryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDomainEntrySync(DeleteDomainEntryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDomainEntryAsync(DeleteDomainEntryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDomainEntryAsync(DeleteDomainEntryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBundles asynchronously, invoking a callback when done
 -- @param GetBundlesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBundlesAsync(GetBundlesRequest, cb)
 	assert(GetBundlesRequest, "You must provide a GetBundlesRequest")
 	local headers = {
@@ -13999,19 +14080,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBundlesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBundlesSync(GetBundlesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBundlesAsync(GetBundlesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBundlesAsync(GetBundlesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRelationalDatabaseFromSnapshot asynchronously, invoking a callback when done
 -- @param CreateRelationalDatabaseFromSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRelationalDatabaseFromSnapshotAsync(CreateRelationalDatabaseFromSnapshotRequest, cb)
 	assert(CreateRelationalDatabaseFromSnapshotRequest, "You must provide a CreateRelationalDatabaseFromSnapshotRequest")
 	local headers = {
@@ -14034,19 +14116,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRelationalDatabaseFromSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRelationalDatabaseFromSnapshotSync(CreateRelationalDatabaseFromSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRelationalDatabaseFromSnapshotAsync(CreateRelationalDatabaseFromSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRelationalDatabaseFromSnapshotAsync(CreateRelationalDatabaseFromSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOperations asynchronously, invoking a callback when done
 -- @param GetOperationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOperationsAsync(GetOperationsRequest, cb)
 	assert(GetOperationsRequest, "You must provide a GetOperationsRequest")
 	local headers = {
@@ -14069,19 +14152,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOperationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOperationsSync(GetOperationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOperationsAsync(GetOperationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOperationsAsync(GetOperationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseBundles asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseBundlesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseBundlesAsync(GetRelationalDatabaseBundlesRequest, cb)
 	assert(GetRelationalDatabaseBundlesRequest, "You must provide a GetRelationalDatabaseBundlesRequest")
 	local headers = {
@@ -14104,19 +14188,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseBundlesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseBundlesSync(GetRelationalDatabaseBundlesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseBundlesAsync(GetRelationalDatabaseBundlesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseBundlesAsync(GetRelationalDatabaseBundlesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseSnapshot asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseSnapshotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseSnapshotAsync(GetRelationalDatabaseSnapshotRequest, cb)
 	assert(GetRelationalDatabaseSnapshotRequest, "You must provide a GetRelationalDatabaseSnapshotRequest")
 	local headers = {
@@ -14139,19 +14224,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseSnapshotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseSnapshotSync(GetRelationalDatabaseSnapshotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseSnapshotAsync(GetRelationalDatabaseSnapshotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseSnapshotAsync(GetRelationalDatabaseSnapshotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDomains asynchronously, invoking a callback when done
 -- @param GetDomainsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDomainsAsync(GetDomainsRequest, cb)
 	assert(GetDomainsRequest, "You must provide a GetDomainsRequest")
 	local headers = {
@@ -14174,19 +14260,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDomainsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDomainsSync(GetDomainsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDomainsAsync(GetDomainsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDomainsAsync(GetDomainsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteKeyPair asynchronously, invoking a callback when done
 -- @param DeleteKeyPairRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteKeyPairAsync(DeleteKeyPairRequest, cb)
 	assert(DeleteKeyPairRequest, "You must provide a DeleteKeyPairRequest")
 	local headers = {
@@ -14209,19 +14296,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteKeyPairRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteKeyPairSync(DeleteKeyPairRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteKeyPairAsync(DeleteKeyPairRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteKeyPairAsync(DeleteKeyPairRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootRelationalDatabase asynchronously, invoking a callback when done
 -- @param RebootRelationalDatabaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootRelationalDatabaseAsync(RebootRelationalDatabaseRequest, cb)
 	assert(RebootRelationalDatabaseRequest, "You must provide a RebootRelationalDatabaseRequest")
 	local headers = {
@@ -14244,19 +14332,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootRelationalDatabaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootRelationalDatabaseSync(RebootRelationalDatabaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootRelationalDatabaseAsync(RebootRelationalDatabaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootRelationalDatabaseAsync(RebootRelationalDatabaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachStaticIp asynchronously, invoking a callback when done
 -- @param DetachStaticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachStaticIpAsync(DetachStaticIpRequest, cb)
 	assert(DetachStaticIpRequest, "You must provide a DetachStaticIpRequest")
 	local headers = {
@@ -14279,19 +14368,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachStaticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachStaticIpSync(DetachStaticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachStaticIpAsync(DetachStaticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachStaticIpAsync(DetachStaticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRelationalDatabaseMasterUserPassword asynchronously, invoking a callback when done
 -- @param GetRelationalDatabaseMasterUserPasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRelationalDatabaseMasterUserPasswordAsync(GetRelationalDatabaseMasterUserPasswordRequest, cb)
 	assert(GetRelationalDatabaseMasterUserPasswordRequest, "You must provide a GetRelationalDatabaseMasterUserPasswordRequest")
 	local headers = {
@@ -14314,19 +14404,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRelationalDatabaseMasterUserPasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRelationalDatabaseMasterUserPasswordSync(GetRelationalDatabaseMasterUserPasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRelationalDatabaseMasterUserPasswordAsync(GetRelationalDatabaseMasterUserPasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRelationalDatabaseMasterUserPasswordAsync(GetRelationalDatabaseMasterUserPasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnpeerVpc asynchronously, invoking a callback when done
 -- @param UnpeerVpcRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnpeerVpcAsync(UnpeerVpcRequest, cb)
 	assert(UnpeerVpcRequest, "You must provide a UnpeerVpcRequest")
 	local headers = {
@@ -14349,19 +14440,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnpeerVpcRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnpeerVpcSync(UnpeerVpcRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnpeerVpcAsync(UnpeerVpcRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnpeerVpcAsync(UnpeerVpcRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInstances asynchronously, invoking a callback when done
 -- @param CreateInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInstancesAsync(CreateInstancesRequest, cb)
 	assert(CreateInstancesRequest, "You must provide a CreateInstancesRequest")
 	local headers = {
@@ -14384,12 +14476,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInstancesSync(CreateInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInstancesAsync(CreateInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInstancesAsync(CreateInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/logs.lua
+++ b/aws-sdk/logs.lua
@@ -3748,7 +3748,7 @@ end
 --
 --- Call PutDestination asynchronously, invoking a callback when done
 -- @param PutDestinationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutDestinationAsync(PutDestinationRequest, cb)
 	assert(PutDestinationRequest, "You must provide a PutDestinationRequest")
 	local headers = {
@@ -3771,19 +3771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutDestinationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutDestinationSync(PutDestinationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutDestinationAsync(PutDestinationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutDestinationAsync(PutDestinationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutResourcePolicy asynchronously, invoking a callback when done
 -- @param PutResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutResourcePolicyAsync(PutResourcePolicyRequest, cb)
 	assert(PutResourcePolicyRequest, "You must provide a PutResourcePolicyRequest")
 	local headers = {
@@ -3806,19 +3807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutResourcePolicySync(PutResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutResourcePolicyAsync(PutResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutResourcePolicyAsync(PutResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDestination asynchronously, invoking a callback when done
 -- @param DeleteDestinationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDestinationAsync(DeleteDestinationRequest, cb)
 	assert(DeleteDestinationRequest, "You must provide a DeleteDestinationRequest")
 	local headers = {
@@ -3841,19 +3843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDestinationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDestinationSync(DeleteDestinationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDestinationAsync(DeleteDestinationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDestinationAsync(DeleteDestinationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsLogGroup asynchronously, invoking a callback when done
 -- @param ListTagsLogGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsLogGroupAsync(ListTagsLogGroupRequest, cb)
 	assert(ListTagsLogGroupRequest, "You must provide a ListTagsLogGroupRequest")
 	local headers = {
@@ -3876,19 +3879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsLogGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsLogGroupSync(ListTagsLogGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsLogGroupAsync(ListTagsLogGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsLogGroupAsync(ListTagsLogGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLogStreams asynchronously, invoking a callback when done
 -- @param DescribeLogStreamsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLogStreamsAsync(DescribeLogStreamsRequest, cb)
 	assert(DescribeLogStreamsRequest, "You must provide a DescribeLogStreamsRequest")
 	local headers = {
@@ -3911,19 +3915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLogStreamsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLogStreamsSync(DescribeLogStreamsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLogStreamsAsync(DescribeLogStreamsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLogStreamsAsync(DescribeLogStreamsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateExportTask asynchronously, invoking a callback when done
 -- @param CreateExportTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateExportTaskAsync(CreateExportTaskRequest, cb)
 	assert(CreateExportTaskRequest, "You must provide a CreateExportTaskRequest")
 	local headers = {
@@ -3946,19 +3951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateExportTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateExportTaskSync(CreateExportTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateExportTaskAsync(CreateExportTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateExportTaskAsync(CreateExportTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestMetricFilter asynchronously, invoking a callback when done
 -- @param TestMetricFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestMetricFilterAsync(TestMetricFilterRequest, cb)
 	assert(TestMetricFilterRequest, "You must provide a TestMetricFilterRequest")
 	local headers = {
@@ -3981,19 +3987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestMetricFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestMetricFilterSync(TestMetricFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestMetricFilterAsync(TestMetricFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestMetricFilterAsync(TestMetricFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLogGroup asynchronously, invoking a callback when done
 -- @param DeleteLogGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLogGroupAsync(DeleteLogGroupRequest, cb)
 	assert(DeleteLogGroupRequest, "You must provide a DeleteLogGroupRequest")
 	local headers = {
@@ -4016,19 +4023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLogGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLogGroupSync(DeleteLogGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLogGroupAsync(DeleteLogGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLogGroupAsync(DeleteLogGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMetricFilters asynchronously, invoking a callback when done
 -- @param DescribeMetricFiltersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMetricFiltersAsync(DescribeMetricFiltersRequest, cb)
 	assert(DescribeMetricFiltersRequest, "You must provide a DescribeMetricFiltersRequest")
 	local headers = {
@@ -4051,19 +4059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMetricFiltersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMetricFiltersSync(DescribeMetricFiltersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMetricFiltersAsync(DescribeMetricFiltersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMetricFiltersAsync(DescribeMetricFiltersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call FilterLogEvents asynchronously, invoking a callback when done
 -- @param FilterLogEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.FilterLogEventsAsync(FilterLogEventsRequest, cb)
 	assert(FilterLogEventsRequest, "You must provide a FilterLogEventsRequest")
 	local headers = {
@@ -4086,19 +4095,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param FilterLogEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.FilterLogEventsSync(FilterLogEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.FilterLogEventsAsync(FilterLogEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.FilterLogEventsAsync(FilterLogEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLogGroup asynchronously, invoking a callback when done
 -- @param CreateLogGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLogGroupAsync(CreateLogGroupRequest, cb)
 	assert(CreateLogGroupRequest, "You must provide a CreateLogGroupRequest")
 	local headers = {
@@ -4121,19 +4131,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLogGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLogGroupSync(CreateLogGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLogGroupAsync(CreateLogGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLogGroupAsync(CreateLogGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSubscriptionFilter asynchronously, invoking a callback when done
 -- @param DeleteSubscriptionFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSubscriptionFilterAsync(DeleteSubscriptionFilterRequest, cb)
 	assert(DeleteSubscriptionFilterRequest, "You must provide a DeleteSubscriptionFilterRequest")
 	local headers = {
@@ -4156,19 +4167,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSubscriptionFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSubscriptionFilterSync(DeleteSubscriptionFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSubscriptionFilterAsync(DeleteSubscriptionFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSubscriptionFilterAsync(DeleteSubscriptionFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutMetricFilter asynchronously, invoking a callback when done
 -- @param PutMetricFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutMetricFilterAsync(PutMetricFilterRequest, cb)
 	assert(PutMetricFilterRequest, "You must provide a PutMetricFilterRequest")
 	local headers = {
@@ -4191,19 +4203,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutMetricFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutMetricFilterSync(PutMetricFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutMetricFilterAsync(PutMetricFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutMetricFilterAsync(PutMetricFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResourcePolicy asynchronously, invoking a callback when done
 -- @param DeleteResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, cb)
 	assert(DeleteResourcePolicyRequest, "You must provide a DeleteResourcePolicyRequest")
 	local headers = {
@@ -4226,19 +4239,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourcePolicySync(DeleteResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutLogEvents asynchronously, invoking a callback when done
 -- @param PutLogEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutLogEventsAsync(PutLogEventsRequest, cb)
 	assert(PutLogEventsRequest, "You must provide a PutLogEventsRequest")
 	local headers = {
@@ -4261,19 +4275,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutLogEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutLogEventsSync(PutLogEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutLogEventsAsync(PutLogEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutLogEventsAsync(PutLogEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLogGroups asynchronously, invoking a callback when done
 -- @param DescribeLogGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLogGroupsAsync(DescribeLogGroupsRequest, cb)
 	assert(DescribeLogGroupsRequest, "You must provide a DescribeLogGroupsRequest")
 	local headers = {
@@ -4296,19 +4311,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLogGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLogGroupsSync(DescribeLogGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLogGroupsAsync(DescribeLogGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLogGroupsAsync(DescribeLogGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDestinations asynchronously, invoking a callback when done
 -- @param DescribeDestinationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDestinationsAsync(DescribeDestinationsRequest, cb)
 	assert(DescribeDestinationsRequest, "You must provide a DescribeDestinationsRequest")
 	local headers = {
@@ -4331,19 +4347,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDestinationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDestinationsSync(DescribeDestinationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDestinationsAsync(DescribeDestinationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDestinationsAsync(DescribeDestinationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateKmsKey asynchronously, invoking a callback when done
 -- @param AssociateKmsKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateKmsKeyAsync(AssociateKmsKeyRequest, cb)
 	assert(AssociateKmsKeyRequest, "You must provide a AssociateKmsKeyRequest")
 	local headers = {
@@ -4366,19 +4383,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateKmsKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateKmsKeySync(AssociateKmsKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateKmsKeyAsync(AssociateKmsKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateKmsKeyAsync(AssociateKmsKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutRetentionPolicy asynchronously, invoking a callback when done
 -- @param PutRetentionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutRetentionPolicyAsync(PutRetentionPolicyRequest, cb)
 	assert(PutRetentionPolicyRequest, "You must provide a PutRetentionPolicyRequest")
 	local headers = {
@@ -4401,19 +4419,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutRetentionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutRetentionPolicySync(PutRetentionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutRetentionPolicyAsync(PutRetentionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutRetentionPolicyAsync(PutRetentionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSubscriptionFilters asynchronously, invoking a callback when done
 -- @param DescribeSubscriptionFiltersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSubscriptionFiltersAsync(DescribeSubscriptionFiltersRequest, cb)
 	assert(DescribeSubscriptionFiltersRequest, "You must provide a DescribeSubscriptionFiltersRequest")
 	local headers = {
@@ -4436,19 +4455,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSubscriptionFiltersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSubscriptionFiltersSync(DescribeSubscriptionFiltersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSubscriptionFiltersAsync(DescribeSubscriptionFiltersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSubscriptionFiltersAsync(DescribeSubscriptionFiltersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeExportTasks asynchronously, invoking a callback when done
 -- @param DescribeExportTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeExportTasksAsync(DescribeExportTasksRequest, cb)
 	assert(DescribeExportTasksRequest, "You must provide a DescribeExportTasksRequest")
 	local headers = {
@@ -4471,19 +4491,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeExportTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeExportTasksSync(DescribeExportTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeExportTasksAsync(DescribeExportTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeExportTasksAsync(DescribeExportTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagLogGroup asynchronously, invoking a callback when done
 -- @param TagLogGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagLogGroupAsync(TagLogGroupRequest, cb)
 	assert(TagLogGroupRequest, "You must provide a TagLogGroupRequest")
 	local headers = {
@@ -4506,19 +4527,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagLogGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagLogGroupSync(TagLogGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagLogGroupAsync(TagLogGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagLogGroupAsync(TagLogGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutSubscriptionFilter asynchronously, invoking a callback when done
 -- @param PutSubscriptionFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutSubscriptionFilterAsync(PutSubscriptionFilterRequest, cb)
 	assert(PutSubscriptionFilterRequest, "You must provide a PutSubscriptionFilterRequest")
 	local headers = {
@@ -4541,19 +4563,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutSubscriptionFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutSubscriptionFilterSync(PutSubscriptionFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutSubscriptionFilterAsync(PutSubscriptionFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutSubscriptionFilterAsync(PutSubscriptionFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMetricFilter asynchronously, invoking a callback when done
 -- @param DeleteMetricFilterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMetricFilterAsync(DeleteMetricFilterRequest, cb)
 	assert(DeleteMetricFilterRequest, "You must provide a DeleteMetricFilterRequest")
 	local headers = {
@@ -4576,19 +4599,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMetricFilterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMetricFilterSync(DeleteMetricFilterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMetricFilterAsync(DeleteMetricFilterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMetricFilterAsync(DeleteMetricFilterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutDestinationPolicy asynchronously, invoking a callback when done
 -- @param PutDestinationPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutDestinationPolicyAsync(PutDestinationPolicyRequest, cb)
 	assert(PutDestinationPolicyRequest, "You must provide a PutDestinationPolicyRequest")
 	local headers = {
@@ -4611,19 +4635,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutDestinationPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutDestinationPolicySync(PutDestinationPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutDestinationPolicyAsync(PutDestinationPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutDestinationPolicyAsync(PutDestinationPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLogStream asynchronously, invoking a callback when done
 -- @param CreateLogStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLogStreamAsync(CreateLogStreamRequest, cb)
 	assert(CreateLogStreamRequest, "You must provide a CreateLogStreamRequest")
 	local headers = {
@@ -4646,19 +4671,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLogStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLogStreamSync(CreateLogStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLogStreamAsync(CreateLogStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLogStreamAsync(CreateLogStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelExportTask asynchronously, invoking a callback when done
 -- @param CancelExportTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelExportTaskAsync(CancelExportTaskRequest, cb)
 	assert(CancelExportTaskRequest, "You must provide a CancelExportTaskRequest")
 	local headers = {
@@ -4681,19 +4707,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelExportTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelExportTaskSync(CancelExportTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelExportTaskAsync(CancelExportTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelExportTaskAsync(CancelExportTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagLogGroup asynchronously, invoking a callback when done
 -- @param UntagLogGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagLogGroupAsync(UntagLogGroupRequest, cb)
 	assert(UntagLogGroupRequest, "You must provide a UntagLogGroupRequest")
 	local headers = {
@@ -4716,19 +4743,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagLogGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagLogGroupSync(UntagLogGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagLogGroupAsync(UntagLogGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagLogGroupAsync(UntagLogGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateKmsKey asynchronously, invoking a callback when done
 -- @param DisassociateKmsKeyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateKmsKeyAsync(DisassociateKmsKeyRequest, cb)
 	assert(DisassociateKmsKeyRequest, "You must provide a DisassociateKmsKeyRequest")
 	local headers = {
@@ -4751,19 +4779,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateKmsKeyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateKmsKeySync(DisassociateKmsKeyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateKmsKeyAsync(DisassociateKmsKeyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateKmsKeyAsync(DisassociateKmsKeyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRetentionPolicy asynchronously, invoking a callback when done
 -- @param DeleteRetentionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRetentionPolicyAsync(DeleteRetentionPolicyRequest, cb)
 	assert(DeleteRetentionPolicyRequest, "You must provide a DeleteRetentionPolicyRequest")
 	local headers = {
@@ -4786,19 +4815,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRetentionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRetentionPolicySync(DeleteRetentionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRetentionPolicyAsync(DeleteRetentionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRetentionPolicyAsync(DeleteRetentionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLogEvents asynchronously, invoking a callback when done
 -- @param GetLogEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLogEventsAsync(GetLogEventsRequest, cb)
 	assert(GetLogEventsRequest, "You must provide a GetLogEventsRequest")
 	local headers = {
@@ -4821,19 +4851,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLogEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLogEventsSync(GetLogEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLogEventsAsync(GetLogEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLogEventsAsync(GetLogEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeResourcePolicies asynchronously, invoking a callback when done
 -- @param DescribeResourcePoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeResourcePoliciesAsync(DescribeResourcePoliciesRequest, cb)
 	assert(DescribeResourcePoliciesRequest, "You must provide a DescribeResourcePoliciesRequest")
 	local headers = {
@@ -4856,19 +4887,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeResourcePoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeResourcePoliciesSync(DescribeResourcePoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeResourcePoliciesAsync(DescribeResourcePoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeResourcePoliciesAsync(DescribeResourcePoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLogStream asynchronously, invoking a callback when done
 -- @param DeleteLogStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLogStreamAsync(DeleteLogStreamRequest, cb)
 	assert(DeleteLogStreamRequest, "You must provide a DeleteLogStreamRequest")
 	local headers = {
@@ -4891,12 +4923,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLogStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLogStreamSync(DeleteLogStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLogStreamAsync(DeleteLogStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLogStreamAsync(DeleteLogStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/machinelearning.lua
+++ b/aws-sdk/machinelearning.lua
@@ -4853,7 +4853,7 @@ end
 --
 --- Call DeleteTags asynchronously, invoking a callback when done
 -- @param DeleteTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsAsync(DeleteTagsInput, cb)
 	assert(DeleteTagsInput, "You must provide a DeleteTagsInput")
 	local headers = {
@@ -4876,19 +4876,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsSync(DeleteTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsAsync(DeleteTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsAsync(DeleteTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateBatchPrediction asynchronously, invoking a callback when done
 -- @param UpdateBatchPredictionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateBatchPredictionAsync(UpdateBatchPredictionInput, cb)
 	assert(UpdateBatchPredictionInput, "You must provide a UpdateBatchPredictionInput")
 	local headers = {
@@ -4911,19 +4912,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateBatchPredictionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateBatchPredictionSync(UpdateBatchPredictionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateBatchPredictionAsync(UpdateBatchPredictionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateBatchPredictionAsync(UpdateBatchPredictionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEvaluation asynchronously, invoking a callback when done
 -- @param GetEvaluationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEvaluationAsync(GetEvaluationInput, cb)
 	assert(GetEvaluationInput, "You must provide a GetEvaluationInput")
 	local headers = {
@@ -4946,19 +4948,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEvaluationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEvaluationSync(GetEvaluationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEvaluationAsync(GetEvaluationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEvaluationAsync(GetEvaluationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBatchPredictions asynchronously, invoking a callback when done
 -- @param DescribeBatchPredictionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBatchPredictionsAsync(DescribeBatchPredictionsInput, cb)
 	assert(DescribeBatchPredictionsInput, "You must provide a DescribeBatchPredictionsInput")
 	local headers = {
@@ -4981,19 +4984,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBatchPredictionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBatchPredictionsSync(DescribeBatchPredictionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBatchPredictionsAsync(DescribeBatchPredictionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBatchPredictionsAsync(DescribeBatchPredictionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEvaluation asynchronously, invoking a callback when done
 -- @param CreateEvaluationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEvaluationAsync(CreateEvaluationInput, cb)
 	assert(CreateEvaluationInput, "You must provide a CreateEvaluationInput")
 	local headers = {
@@ -5016,19 +5020,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEvaluationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEvaluationSync(CreateEvaluationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEvaluationAsync(CreateEvaluationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEvaluationAsync(CreateEvaluationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMLModels asynchronously, invoking a callback when done
 -- @param DescribeMLModelsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMLModelsAsync(DescribeMLModelsInput, cb)
 	assert(DescribeMLModelsInput, "You must provide a DescribeMLModelsInput")
 	local headers = {
@@ -5051,19 +5056,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMLModelsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMLModelsSync(DescribeMLModelsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMLModelsAsync(DescribeMLModelsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMLModelsAsync(DescribeMLModelsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMLModel asynchronously, invoking a callback when done
 -- @param DeleteMLModelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMLModelAsync(DeleteMLModelInput, cb)
 	assert(DeleteMLModelInput, "You must provide a DeleteMLModelInput")
 	local headers = {
@@ -5086,19 +5092,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMLModelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMLModelSync(DeleteMLModelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMLModelAsync(DeleteMLModelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMLModelAsync(DeleteMLModelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDataSourceFromS3 asynchronously, invoking a callback when done
 -- @param CreateDataSourceFromS3Input
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDataSourceFromS3Async(CreateDataSourceFromS3Input, cb)
 	assert(CreateDataSourceFromS3Input, "You must provide a CreateDataSourceFromS3Input")
 	local headers = {
@@ -5121,19 +5128,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDataSourceFromS3Input
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDataSourceFromS3Sync(CreateDataSourceFromS3Input, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDataSourceFromS3Async(CreateDataSourceFromS3Input, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDataSourceFromS3Async(CreateDataSourceFromS3Input, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDataSource asynchronously, invoking a callback when done
 -- @param UpdateDataSourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDataSourceAsync(UpdateDataSourceInput, cb)
 	assert(UpdateDataSourceInput, "You must provide a UpdateDataSourceInput")
 	local headers = {
@@ -5156,19 +5164,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDataSourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDataSourceSync(UpdateDataSourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDataSourceAsync(UpdateDataSourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDataSourceAsync(UpdateDataSourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvaluations asynchronously, invoking a callback when done
 -- @param DescribeEvaluationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEvaluationsAsync(DescribeEvaluationsInput, cb)
 	assert(DescribeEvaluationsInput, "You must provide a DescribeEvaluationsInput")
 	local headers = {
@@ -5191,19 +5200,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEvaluationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEvaluationsSync(DescribeEvaluationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEvaluationsAsync(DescribeEvaluationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEvaluationsAsync(DescribeEvaluationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDataSourceFromRedshift asynchronously, invoking a callback when done
 -- @param CreateDataSourceFromRedshiftInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDataSourceFromRedshiftAsync(CreateDataSourceFromRedshiftInput, cb)
 	assert(CreateDataSourceFromRedshiftInput, "You must provide a CreateDataSourceFromRedshiftInput")
 	local headers = {
@@ -5226,19 +5236,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDataSourceFromRedshiftInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDataSourceFromRedshiftSync(CreateDataSourceFromRedshiftInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDataSourceFromRedshiftAsync(CreateDataSourceFromRedshiftInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDataSourceFromRedshiftAsync(CreateDataSourceFromRedshiftInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDataSources asynchronously, invoking a callback when done
 -- @param DescribeDataSourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDataSourcesAsync(DescribeDataSourcesInput, cb)
 	assert(DescribeDataSourcesInput, "You must provide a DescribeDataSourcesInput")
 	local headers = {
@@ -5261,19 +5272,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDataSourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDataSourcesSync(DescribeDataSourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDataSourcesAsync(DescribeDataSourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDataSourcesAsync(DescribeDataSourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDataSource asynchronously, invoking a callback when done
 -- @param GetDataSourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDataSourceAsync(GetDataSourceInput, cb)
 	assert(GetDataSourceInput, "You must provide a GetDataSourceInput")
 	local headers = {
@@ -5296,19 +5308,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDataSourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDataSourceSync(GetDataSourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDataSourceAsync(GetDataSourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDataSourceAsync(GetDataSourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRealtimeEndpoint asynchronously, invoking a callback when done
 -- @param CreateRealtimeEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRealtimeEndpointAsync(CreateRealtimeEndpointInput, cb)
 	assert(CreateRealtimeEndpointInput, "You must provide a CreateRealtimeEndpointInput")
 	local headers = {
@@ -5331,19 +5344,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRealtimeEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRealtimeEndpointSync(CreateRealtimeEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRealtimeEndpointAsync(CreateRealtimeEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRealtimeEndpointAsync(CreateRealtimeEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMLModel asynchronously, invoking a callback when done
 -- @param UpdateMLModelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMLModelAsync(UpdateMLModelInput, cb)
 	assert(UpdateMLModelInput, "You must provide a UpdateMLModelInput")
 	local headers = {
@@ -5366,19 +5380,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMLModelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMLModelSync(UpdateMLModelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMLModelAsync(UpdateMLModelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMLModelAsync(UpdateMLModelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRealtimeEndpoint asynchronously, invoking a callback when done
 -- @param DeleteRealtimeEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRealtimeEndpointAsync(DeleteRealtimeEndpointInput, cb)
 	assert(DeleteRealtimeEndpointInput, "You must provide a DeleteRealtimeEndpointInput")
 	local headers = {
@@ -5401,19 +5416,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRealtimeEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRealtimeEndpointSync(DeleteRealtimeEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRealtimeEndpointAsync(DeleteRealtimeEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRealtimeEndpointAsync(DeleteRealtimeEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsInput, cb)
 	assert(DescribeTagsInput, "You must provide a DescribeTagsInput")
 	local headers = {
@@ -5436,19 +5452,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDataSource asynchronously, invoking a callback when done
 -- @param DeleteDataSourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDataSourceAsync(DeleteDataSourceInput, cb)
 	assert(DeleteDataSourceInput, "You must provide a DeleteDataSourceInput")
 	local headers = {
@@ -5471,19 +5488,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDataSourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDataSourceSync(DeleteDataSourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDataSourceAsync(DeleteDataSourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDataSourceAsync(DeleteDataSourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDataSourceFromRDS asynchronously, invoking a callback when done
 -- @param CreateDataSourceFromRDSInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDataSourceFromRDSAsync(CreateDataSourceFromRDSInput, cb)
 	assert(CreateDataSourceFromRDSInput, "You must provide a CreateDataSourceFromRDSInput")
 	local headers = {
@@ -5506,19 +5524,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDataSourceFromRDSInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDataSourceFromRDSSync(CreateDataSourceFromRDSInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDataSourceFromRDSAsync(CreateDataSourceFromRDSInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDataSourceFromRDSAsync(CreateDataSourceFromRDSInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEvaluation asynchronously, invoking a callback when done
 -- @param UpdateEvaluationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEvaluationAsync(UpdateEvaluationInput, cb)
 	assert(UpdateEvaluationInput, "You must provide a UpdateEvaluationInput")
 	local headers = {
@@ -5541,19 +5560,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEvaluationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEvaluationSync(UpdateEvaluationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEvaluationAsync(UpdateEvaluationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEvaluationAsync(UpdateEvaluationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTags asynchronously, invoking a callback when done
 -- @param AddTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsAsync(AddTagsInput, cb)
 	assert(AddTagsInput, "You must provide a AddTagsInput")
 	local headers = {
@@ -5576,19 +5596,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsSync(AddTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsAsync(AddTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsAsync(AddTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Predict asynchronously, invoking a callback when done
 -- @param PredictInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PredictAsync(PredictInput, cb)
 	assert(PredictInput, "You must provide a PredictInput")
 	local headers = {
@@ -5611,19 +5632,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PredictInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PredictSync(PredictInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PredictAsync(PredictInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PredictAsync(PredictInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBatchPrediction asynchronously, invoking a callback when done
 -- @param GetBatchPredictionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBatchPredictionAsync(GetBatchPredictionInput, cb)
 	assert(GetBatchPredictionInput, "You must provide a GetBatchPredictionInput")
 	local headers = {
@@ -5646,19 +5668,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBatchPredictionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBatchPredictionSync(GetBatchPredictionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBatchPredictionAsync(GetBatchPredictionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBatchPredictionAsync(GetBatchPredictionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEvaluation asynchronously, invoking a callback when done
 -- @param DeleteEvaluationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEvaluationAsync(DeleteEvaluationInput, cb)
 	assert(DeleteEvaluationInput, "You must provide a DeleteEvaluationInput")
 	local headers = {
@@ -5681,19 +5704,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEvaluationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEvaluationSync(DeleteEvaluationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEvaluationAsync(DeleteEvaluationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEvaluationAsync(DeleteEvaluationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBatchPrediction asynchronously, invoking a callback when done
 -- @param DeleteBatchPredictionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBatchPredictionAsync(DeleteBatchPredictionInput, cb)
 	assert(DeleteBatchPredictionInput, "You must provide a DeleteBatchPredictionInput")
 	local headers = {
@@ -5716,19 +5740,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBatchPredictionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBatchPredictionSync(DeleteBatchPredictionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBatchPredictionAsync(DeleteBatchPredictionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBatchPredictionAsync(DeleteBatchPredictionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMLModel asynchronously, invoking a callback when done
 -- @param CreateMLModelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMLModelAsync(CreateMLModelInput, cb)
 	assert(CreateMLModelInput, "You must provide a CreateMLModelInput")
 	local headers = {
@@ -5751,19 +5776,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMLModelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMLModelSync(CreateMLModelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMLModelAsync(CreateMLModelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMLModelAsync(CreateMLModelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBatchPrediction asynchronously, invoking a callback when done
 -- @param CreateBatchPredictionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBatchPredictionAsync(CreateBatchPredictionInput, cb)
 	assert(CreateBatchPredictionInput, "You must provide a CreateBatchPredictionInput")
 	local headers = {
@@ -5786,19 +5812,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBatchPredictionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBatchPredictionSync(CreateBatchPredictionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBatchPredictionAsync(CreateBatchPredictionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBatchPredictionAsync(CreateBatchPredictionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMLModel asynchronously, invoking a callback when done
 -- @param GetMLModelInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMLModelAsync(GetMLModelInput, cb)
 	assert(GetMLModelInput, "You must provide a GetMLModelInput")
 	local headers = {
@@ -5821,12 +5848,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMLModelInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMLModelSync(GetMLModelInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMLModelAsync(GetMLModelInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMLModelAsync(GetMLModelInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/macie.lua
+++ b/aws-sdk/macie.lua
@@ -1214,7 +1214,7 @@ end
 --
 --- Call ListS3Resources asynchronously, invoking a callback when done
 -- @param ListS3ResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListS3ResourcesAsync(ListS3ResourcesRequest, cb)
 	assert(ListS3ResourcesRequest, "You must provide a ListS3ResourcesRequest")
 	local headers = {
@@ -1237,19 +1237,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListS3ResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListS3ResourcesSync(ListS3ResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListS3ResourcesAsync(ListS3ResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListS3ResourcesAsync(ListS3ResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateMemberAccount asynchronously, invoking a callback when done
 -- @param DisassociateMemberAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateMemberAccountAsync(DisassociateMemberAccountRequest, cb)
 	assert(DisassociateMemberAccountRequest, "You must provide a DisassociateMemberAccountRequest")
 	local headers = {
@@ -1272,19 +1273,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateMemberAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateMemberAccountSync(DisassociateMemberAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateMemberAccountAsync(DisassociateMemberAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateMemberAccountAsync(DisassociateMemberAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateMemberAccount asynchronously, invoking a callback when done
 -- @param AssociateMemberAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateMemberAccountAsync(AssociateMemberAccountRequest, cb)
 	assert(AssociateMemberAccountRequest, "You must provide a AssociateMemberAccountRequest")
 	local headers = {
@@ -1307,19 +1309,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateMemberAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateMemberAccountSync(AssociateMemberAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateMemberAccountAsync(AssociateMemberAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateMemberAccountAsync(AssociateMemberAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateS3Resources asynchronously, invoking a callback when done
 -- @param DisassociateS3ResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateS3ResourcesAsync(DisassociateS3ResourcesRequest, cb)
 	assert(DisassociateS3ResourcesRequest, "You must provide a DisassociateS3ResourcesRequest")
 	local headers = {
@@ -1342,19 +1345,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateS3ResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateS3ResourcesSync(DisassociateS3ResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateS3ResourcesAsync(DisassociateS3ResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateS3ResourcesAsync(DisassociateS3ResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateS3Resources asynchronously, invoking a callback when done
 -- @param UpdateS3ResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateS3ResourcesAsync(UpdateS3ResourcesRequest, cb)
 	assert(UpdateS3ResourcesRequest, "You must provide a UpdateS3ResourcesRequest")
 	local headers = {
@@ -1377,19 +1381,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateS3ResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateS3ResourcesSync(UpdateS3ResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateS3ResourcesAsync(UpdateS3ResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateS3ResourcesAsync(UpdateS3ResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMemberAccounts asynchronously, invoking a callback when done
 -- @param ListMemberAccountsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMemberAccountsAsync(ListMemberAccountsRequest, cb)
 	assert(ListMemberAccountsRequest, "You must provide a ListMemberAccountsRequest")
 	local headers = {
@@ -1412,19 +1417,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMemberAccountsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMemberAccountsSync(ListMemberAccountsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMemberAccountsAsync(ListMemberAccountsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMemberAccountsAsync(ListMemberAccountsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateS3Resources asynchronously, invoking a callback when done
 -- @param AssociateS3ResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateS3ResourcesAsync(AssociateS3ResourcesRequest, cb)
 	assert(AssociateS3ResourcesRequest, "You must provide a AssociateS3ResourcesRequest")
 	local headers = {
@@ -1447,12 +1453,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateS3ResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateS3ResourcesSync(AssociateS3ResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateS3ResourcesAsync(AssociateS3ResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateS3ResourcesAsync(AssociateS3ResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/marketplacecommerceanalytics.lua
+++ b/aws-sdk/marketplacecommerceanalytics.lua
@@ -462,7 +462,7 @@ end
 --
 --- Call GenerateDataSet asynchronously, invoking a callback when done
 -- @param GenerateDataSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GenerateDataSetAsync(GenerateDataSetRequest, cb)
 	assert(GenerateDataSetRequest, "You must provide a GenerateDataSetRequest")
 	local headers = {
@@ -485,19 +485,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GenerateDataSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GenerateDataSetSync(GenerateDataSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GenerateDataSetAsync(GenerateDataSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GenerateDataSetAsync(GenerateDataSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSupportDataExport asynchronously, invoking a callback when done
 -- @param StartSupportDataExportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSupportDataExportAsync(StartSupportDataExportRequest, cb)
 	assert(StartSupportDataExportRequest, "You must provide a StartSupportDataExportRequest")
 	local headers = {
@@ -520,12 +521,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSupportDataExportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSupportDataExportSync(StartSupportDataExportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSupportDataExportAsync(StartSupportDataExportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSupportDataExportAsync(StartSupportDataExportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mediaconvert.lua
+++ b/aws-sdk/mediaconvert.lua
@@ -11411,7 +11411,7 @@ end
 --
 --- Call CreateQueue asynchronously, invoking a callback when done
 -- @param CreateQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateQueueAsync(CreateQueueRequest, cb)
 	assert(CreateQueueRequest, "You must provide a CreateQueueRequest")
 	local headers = {
@@ -11434,19 +11434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateQueueSync(CreateQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateQueueAsync(CreateQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateQueueAsync(CreateQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePreset asynchronously, invoking a callback when done
 -- @param UpdatePresetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePresetAsync(UpdatePresetRequest, cb)
 	assert(UpdatePresetRequest, "You must provide a UpdatePresetRequest")
 	local headers = {
@@ -11469,19 +11470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePresetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePresetSync(UpdatePresetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePresetAsync(UpdatePresetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePresetAsync(UpdatePresetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPresets asynchronously, invoking a callback when done
 -- @param ListPresetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPresetsAsync(ListPresetsRequest, cb)
 	assert(ListPresetsRequest, "You must provide a ListPresetsRequest")
 	local headers = {
@@ -11504,19 +11506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPresetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPresetsSync(ListPresetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPresetsAsync(ListPresetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPresetsAsync(ListPresetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePreset asynchronously, invoking a callback when done
 -- @param DeletePresetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePresetAsync(DeletePresetRequest, cb)
 	assert(DeletePresetRequest, "You must provide a DeletePresetRequest")
 	local headers = {
@@ -11539,19 +11542,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePresetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePresetSync(DeletePresetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePresetAsync(DeletePresetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePresetAsync(DeletePresetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobTemplates asynchronously, invoking a callback when done
 -- @param ListJobTemplatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobTemplatesAsync(ListJobTemplatesRequest, cb)
 	assert(ListJobTemplatesRequest, "You must provide a ListJobTemplatesRequest")
 	local headers = {
@@ -11574,19 +11578,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobTemplatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobTemplatesSync(ListJobTemplatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobTemplatesAsync(ListJobTemplatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobTemplatesAsync(ListJobTemplatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListQueues asynchronously, invoking a callback when done
 -- @param ListQueuesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListQueuesAsync(ListQueuesRequest, cb)
 	assert(ListQueuesRequest, "You must provide a ListQueuesRequest")
 	local headers = {
@@ -11609,19 +11614,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListQueuesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListQueuesSync(ListQueuesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListQueuesAsync(ListQueuesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListQueuesAsync(ListQueuesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobTemplate asynchronously, invoking a callback when done
 -- @param GetJobTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobTemplateAsync(GetJobTemplateRequest, cb)
 	assert(GetJobTemplateRequest, "You must provide a GetJobTemplateRequest")
 	local headers = {
@@ -11644,19 +11650,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobTemplateSync(GetJobTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobTemplateAsync(GetJobTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobTemplateAsync(GetJobTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEndpoints asynchronously, invoking a callback when done
 -- @param DescribeEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEndpointsAsync(DescribeEndpointsRequest, cb)
 	assert(DescribeEndpointsRequest, "You must provide a DescribeEndpointsRequest")
 	local headers = {
@@ -11679,19 +11686,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEndpointsSync(DescribeEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEndpointsAsync(DescribeEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEndpointsAsync(DescribeEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -11714,19 +11722,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQueue asynchronously, invoking a callback when done
 -- @param GetQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQueueAsync(GetQueueRequest, cb)
 	assert(GetQueueRequest, "You must provide a GetQueueRequest")
 	local headers = {
@@ -11749,19 +11758,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQueueSync(GetQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQueueAsync(GetQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQueueAsync(GetQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteJobTemplate asynchronously, invoking a callback when done
 -- @param DeleteJobTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteJobTemplateAsync(DeleteJobTemplateRequest, cb)
 	assert(DeleteJobTemplateRequest, "You must provide a DeleteJobTemplateRequest")
 	local headers = {
@@ -11784,19 +11794,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteJobTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteJobTemplateSync(DeleteJobTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteJobTemplateAsync(DeleteJobTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteJobTemplateAsync(DeleteJobTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListJobs asynchronously, invoking a callback when done
 -- @param ListJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsAsync(ListJobsRequest, cb)
 	assert(ListJobsRequest, "You must provide a ListJobsRequest")
 	local headers = {
@@ -11819,19 +11830,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsSync(ListJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsAsync(ListJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsAsync(ListJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJob asynchronously, invoking a callback when done
 -- @param CreateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobAsync(CreateJobRequest, cb)
 	assert(CreateJobRequest, "You must provide a CreateJobRequest")
 	local headers = {
@@ -11854,19 +11866,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobSync(CreateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobAsync(CreateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobAsync(CreateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPreset asynchronously, invoking a callback when done
 -- @param GetPresetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPresetAsync(GetPresetRequest, cb)
 	assert(GetPresetRequest, "You must provide a GetPresetRequest")
 	local headers = {
@@ -11889,19 +11902,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPresetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPresetSync(GetPresetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPresetAsync(GetPresetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPresetAsync(GetPresetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateQueue asynchronously, invoking a callback when done
 -- @param UpdateQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateQueueAsync(UpdateQueueRequest, cb)
 	assert(UpdateQueueRequest, "You must provide a UpdateQueueRequest")
 	local headers = {
@@ -11924,19 +11938,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateQueueSync(UpdateQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateQueueAsync(UpdateQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateQueueAsync(UpdateQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelJob asynchronously, invoking a callback when done
 -- @param CancelJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelJobAsync(CancelJobRequest, cb)
 	assert(CancelJobRequest, "You must provide a CancelJobRequest")
 	local headers = {
@@ -11959,19 +11974,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelJobSync(CancelJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelJobAsync(CancelJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelJobAsync(CancelJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePreset asynchronously, invoking a callback when done
 -- @param CreatePresetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePresetAsync(CreatePresetRequest, cb)
 	assert(CreatePresetRequest, "You must provide a CreatePresetRequest")
 	local headers = {
@@ -11994,19 +12010,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePresetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePresetSync(CreatePresetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePresetAsync(CreatePresetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePresetAsync(CreatePresetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -12029,19 +12046,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJob asynchronously, invoking a callback when done
 -- @param GetJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobAsync(GetJobRequest, cb)
 	assert(GetJobRequest, "You must provide a GetJobRequest")
 	local headers = {
@@ -12064,19 +12082,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobSync(GetJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobAsync(GetJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobAsync(GetJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteQueue asynchronously, invoking a callback when done
 -- @param DeleteQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteQueueAsync(DeleteQueueRequest, cb)
 	assert(DeleteQueueRequest, "You must provide a DeleteQueueRequest")
 	local headers = {
@@ -12099,19 +12118,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteQueueSync(DeleteQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteQueueAsync(DeleteQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteQueueAsync(DeleteQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJobTemplate asynchronously, invoking a callback when done
 -- @param CreateJobTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobTemplateAsync(CreateJobTemplateRequest, cb)
 	assert(CreateJobTemplateRequest, "You must provide a CreateJobTemplateRequest")
 	local headers = {
@@ -12134,19 +12154,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobTemplateSync(CreateJobTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobTemplateAsync(CreateJobTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobTemplateAsync(CreateJobTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateJobTemplate asynchronously, invoking a callback when done
 -- @param UpdateJobTemplateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateJobTemplateAsync(UpdateJobTemplateRequest, cb)
 	assert(UpdateJobTemplateRequest, "You must provide a UpdateJobTemplateRequest")
 	local headers = {
@@ -12169,19 +12190,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateJobTemplateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateJobTemplateSync(UpdateJobTemplateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateJobTemplateAsync(UpdateJobTemplateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateJobTemplateAsync(UpdateJobTemplateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -12204,12 +12226,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/medialive.lua
+++ b/aws-sdk/medialive.lua
@@ -11736,7 +11736,7 @@ end
 --
 --- Call PurchaseOffering asynchronously, invoking a callback when done
 -- @param PurchaseOfferingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseOfferingAsync(PurchaseOfferingRequest, cb)
 	assert(PurchaseOfferingRequest, "You must provide a PurchaseOfferingRequest")
 	local headers = {
@@ -11759,19 +11759,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseOfferingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseOfferingSync(PurchaseOfferingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseOfferingAsync(PurchaseOfferingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseOfferingAsync(PurchaseOfferingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateChannel asynchronously, invoking a callback when done
 -- @param UpdateChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateChannelAsync(UpdateChannelRequest, cb)
 	assert(UpdateChannelRequest, "You must provide a UpdateChannelRequest")
 	local headers = {
@@ -11794,19 +11795,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateChannelSync(UpdateChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateChannelAsync(UpdateChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateChannelAsync(UpdateChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOfferings asynchronously, invoking a callback when done
 -- @param ListOfferingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOfferingsAsync(ListOfferingsRequest, cb)
 	assert(ListOfferingsRequest, "You must provide a ListOfferingsRequest")
 	local headers = {
@@ -11829,19 +11831,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOfferingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOfferingsSync(ListOfferingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOfferingsAsync(ListOfferingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOfferingsAsync(ListOfferingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateChannel asynchronously, invoking a callback when done
 -- @param CreateChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateChannelAsync(CreateChannelRequest, cb)
 	assert(CreateChannelRequest, "You must provide a CreateChannelRequest")
 	local headers = {
@@ -11864,19 +11867,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateChannelSync(CreateChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateChannelAsync(CreateChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateChannelAsync(CreateChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInputSecurityGroup asynchronously, invoking a callback when done
 -- @param DeleteInputSecurityGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInputSecurityGroupAsync(DeleteInputSecurityGroupRequest, cb)
 	assert(DeleteInputSecurityGroupRequest, "You must provide a DeleteInputSecurityGroupRequest")
 	local headers = {
@@ -11899,19 +11903,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInputSecurityGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInputSecurityGroupSync(DeleteInputSecurityGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInputSecurityGroupAsync(DeleteInputSecurityGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInputSecurityGroupAsync(DeleteInputSecurityGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopChannel asynchronously, invoking a callback when done
 -- @param StopChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopChannelAsync(StopChannelRequest, cb)
 	assert(StopChannelRequest, "You must provide a StopChannelRequest")
 	local headers = {
@@ -11934,19 +11939,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopChannelSync(StopChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopChannelAsync(StopChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopChannelAsync(StopChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeChannel asynchronously, invoking a callback when done
 -- @param DescribeChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeChannelAsync(DescribeChannelRequest, cb)
 	assert(DescribeChannelRequest, "You must provide a DescribeChannelRequest")
 	local headers = {
@@ -11969,19 +11975,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeChannelSync(DescribeChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeChannelAsync(DescribeChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeChannelAsync(DescribeChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInputs asynchronously, invoking a callback when done
 -- @param ListInputsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInputsAsync(ListInputsRequest, cb)
 	assert(ListInputsRequest, "You must provide a ListInputsRequest")
 	local headers = {
@@ -12004,19 +12011,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInputsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInputsSync(ListInputsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInputsAsync(ListInputsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInputsAsync(ListInputsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInputSecurityGroups asynchronously, invoking a callback when done
 -- @param ListInputSecurityGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInputSecurityGroupsAsync(ListInputSecurityGroupsRequest, cb)
 	assert(ListInputSecurityGroupsRequest, "You must provide a ListInputSecurityGroupsRequest")
 	local headers = {
@@ -12039,19 +12047,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInputSecurityGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInputSecurityGroupsSync(ListInputSecurityGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInputSecurityGroupsAsync(ListInputSecurityGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInputSecurityGroupsAsync(ListInputSecurityGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteChannel asynchronously, invoking a callback when done
 -- @param DeleteChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteChannelAsync(DeleteChannelRequest, cb)
 	assert(DeleteChannelRequest, "You must provide a DeleteChannelRequest")
 	local headers = {
@@ -12074,19 +12083,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteChannelSync(DeleteChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteChannelAsync(DeleteChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteChannelAsync(DeleteChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListReservations asynchronously, invoking a callback when done
 -- @param ListReservationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListReservationsAsync(ListReservationsRequest, cb)
 	assert(ListReservationsRequest, "You must provide a ListReservationsRequest")
 	local headers = {
@@ -12109,19 +12119,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListReservationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListReservationsSync(ListReservationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListReservationsAsync(ListReservationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListReservationsAsync(ListReservationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInput asynchronously, invoking a callback when done
 -- @param DescribeInputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInputAsync(DescribeInputRequest, cb)
 	assert(DescribeInputRequest, "You must provide a DescribeInputRequest")
 	local headers = {
@@ -12144,19 +12155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInputSync(DescribeInputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInputAsync(DescribeInputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInputAsync(DescribeInputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInput asynchronously, invoking a callback when done
 -- @param DeleteInputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInputAsync(DeleteInputRequest, cb)
 	assert(DeleteInputRequest, "You must provide a DeleteInputRequest")
 	local headers = {
@@ -12179,19 +12191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInputSync(DeleteInputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInputAsync(DeleteInputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInputAsync(DeleteInputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateInputSecurityGroup asynchronously, invoking a callback when done
 -- @param UpdateInputSecurityGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateInputSecurityGroupAsync(UpdateInputSecurityGroupRequest, cb)
 	assert(UpdateInputSecurityGroupRequest, "You must provide a UpdateInputSecurityGroupRequest")
 	local headers = {
@@ -12214,19 +12227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateInputSecurityGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateInputSecurityGroupSync(UpdateInputSecurityGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateInputSecurityGroupAsync(UpdateInputSecurityGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateInputSecurityGroupAsync(UpdateInputSecurityGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInput asynchronously, invoking a callback when done
 -- @param CreateInputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInputAsync(CreateInputRequest, cb)
 	assert(CreateInputRequest, "You must provide a CreateInputRequest")
 	local headers = {
@@ -12249,19 +12263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInputSync(CreateInputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInputAsync(CreateInputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInputAsync(CreateInputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReservation asynchronously, invoking a callback when done
 -- @param DeleteReservationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReservationAsync(DeleteReservationRequest, cb)
 	assert(DeleteReservationRequest, "You must provide a DeleteReservationRequest")
 	local headers = {
@@ -12284,19 +12299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReservationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReservationSync(DeleteReservationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReservationAsync(DeleteReservationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReservationAsync(DeleteReservationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOffering asynchronously, invoking a callback when done
 -- @param DescribeOfferingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOfferingAsync(DescribeOfferingRequest, cb)
 	assert(DescribeOfferingRequest, "You must provide a DescribeOfferingRequest")
 	local headers = {
@@ -12319,19 +12335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOfferingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOfferingSync(DescribeOfferingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOfferingAsync(DescribeOfferingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOfferingAsync(DescribeOfferingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInputSecurityGroup asynchronously, invoking a callback when done
 -- @param CreateInputSecurityGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInputSecurityGroupAsync(CreateInputSecurityGroupRequest, cb)
 	assert(CreateInputSecurityGroupRequest, "You must provide a CreateInputSecurityGroupRequest")
 	local headers = {
@@ -12354,19 +12371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInputSecurityGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInputSecurityGroupSync(CreateInputSecurityGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInputSecurityGroupAsync(CreateInputSecurityGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInputSecurityGroupAsync(CreateInputSecurityGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInputSecurityGroup asynchronously, invoking a callback when done
 -- @param DescribeInputSecurityGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInputSecurityGroupAsync(DescribeInputSecurityGroupRequest, cb)
 	assert(DescribeInputSecurityGroupRequest, "You must provide a DescribeInputSecurityGroupRequest")
 	local headers = {
@@ -12389,19 +12407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInputSecurityGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInputSecurityGroupSync(DescribeInputSecurityGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInputSecurityGroupAsync(DescribeInputSecurityGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInputSecurityGroupAsync(DescribeInputSecurityGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservation asynchronously, invoking a callback when done
 -- @param DescribeReservationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservationAsync(DescribeReservationRequest, cb)
 	assert(DescribeReservationRequest, "You must provide a DescribeReservationRequest")
 	local headers = {
@@ -12424,19 +12443,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservationSync(DescribeReservationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservationAsync(DescribeReservationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservationAsync(DescribeReservationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchUpdateSchedule asynchronously, invoking a callback when done
 -- @param BatchUpdateScheduleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchUpdateScheduleAsync(BatchUpdateScheduleRequest, cb)
 	assert(BatchUpdateScheduleRequest, "You must provide a BatchUpdateScheduleRequest")
 	local headers = {
@@ -12459,19 +12479,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchUpdateScheduleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchUpdateScheduleSync(BatchUpdateScheduleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchUpdateScheduleAsync(BatchUpdateScheduleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchUpdateScheduleAsync(BatchUpdateScheduleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListChannels asynchronously, invoking a callback when done
 -- @param ListChannelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListChannelsAsync(ListChannelsRequest, cb)
 	assert(ListChannelsRequest, "You must provide a ListChannelsRequest")
 	local headers = {
@@ -12494,19 +12515,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListChannelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListChannelsSync(ListChannelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListChannelsAsync(ListChannelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListChannelsAsync(ListChannelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateInput asynchronously, invoking a callback when done
 -- @param UpdateInputRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateInputAsync(UpdateInputRequest, cb)
 	assert(UpdateInputRequest, "You must provide a UpdateInputRequest")
 	local headers = {
@@ -12529,19 +12551,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateInputRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateInputSync(UpdateInputRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateInputAsync(UpdateInputRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateInputAsync(UpdateInputRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSchedule asynchronously, invoking a callback when done
 -- @param DescribeScheduleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeScheduleAsync(DescribeScheduleRequest, cb)
 	assert(DescribeScheduleRequest, "You must provide a DescribeScheduleRequest")
 	local headers = {
@@ -12564,19 +12587,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeScheduleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeScheduleSync(DescribeScheduleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeScheduleAsync(DescribeScheduleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeScheduleAsync(DescribeScheduleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartChannel asynchronously, invoking a callback when done
 -- @param StartChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartChannelAsync(StartChannelRequest, cb)
 	assert(StartChannelRequest, "You must provide a StartChannelRequest")
 	local headers = {
@@ -12599,12 +12623,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartChannelSync(StartChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartChannelAsync(StartChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartChannelAsync(StartChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mediapackage.lua
+++ b/aws-sdk/mediapackage.lua
@@ -2292,7 +2292,7 @@ end
 --
 --- Call DeleteOriginEndpoint asynchronously, invoking a callback when done
 -- @param DeleteOriginEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteOriginEndpointAsync(DeleteOriginEndpointRequest, cb)
 	assert(DeleteOriginEndpointRequest, "You must provide a DeleteOriginEndpointRequest")
 	local headers = {
@@ -2315,19 +2315,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteOriginEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteOriginEndpointSync(DeleteOriginEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteOriginEndpointAsync(DeleteOriginEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteOriginEndpointAsync(DeleteOriginEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RotateIngestEndpointCredentials asynchronously, invoking a callback when done
 -- @param RotateIngestEndpointCredentialsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RotateIngestEndpointCredentialsAsync(RotateIngestEndpointCredentialsRequest, cb)
 	assert(RotateIngestEndpointCredentialsRequest, "You must provide a RotateIngestEndpointCredentialsRequest")
 	local headers = {
@@ -2350,19 +2351,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RotateIngestEndpointCredentialsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RotateIngestEndpointCredentialsSync(RotateIngestEndpointCredentialsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RotateIngestEndpointCredentialsAsync(RotateIngestEndpointCredentialsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RotateIngestEndpointCredentialsAsync(RotateIngestEndpointCredentialsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateOriginEndpoint asynchronously, invoking a callback when done
 -- @param CreateOriginEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateOriginEndpointAsync(CreateOriginEndpointRequest, cb)
 	assert(CreateOriginEndpointRequest, "You must provide a CreateOriginEndpointRequest")
 	local headers = {
@@ -2385,19 +2387,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateOriginEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateOriginEndpointSync(CreateOriginEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateOriginEndpointAsync(CreateOriginEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateOriginEndpointAsync(CreateOriginEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateOriginEndpoint asynchronously, invoking a callback when done
 -- @param UpdateOriginEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateOriginEndpointAsync(UpdateOriginEndpointRequest, cb)
 	assert(UpdateOriginEndpointRequest, "You must provide a UpdateOriginEndpointRequest")
 	local headers = {
@@ -2420,19 +2423,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateOriginEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateOriginEndpointSync(UpdateOriginEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateOriginEndpointAsync(UpdateOriginEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateOriginEndpointAsync(UpdateOriginEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteChannel asynchronously, invoking a callback when done
 -- @param DeleteChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteChannelAsync(DeleteChannelRequest, cb)
 	assert(DeleteChannelRequest, "You must provide a DeleteChannelRequest")
 	local headers = {
@@ -2455,19 +2459,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteChannelSync(DeleteChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteChannelAsync(DeleteChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteChannelAsync(DeleteChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListChannels asynchronously, invoking a callback when done
 -- @param ListChannelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListChannelsAsync(ListChannelsRequest, cb)
 	assert(ListChannelsRequest, "You must provide a ListChannelsRequest")
 	local headers = {
@@ -2490,19 +2495,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListChannelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListChannelsSync(ListChannelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListChannelsAsync(ListChannelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListChannelsAsync(ListChannelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateChannel asynchronously, invoking a callback when done
 -- @param CreateChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateChannelAsync(CreateChannelRequest, cb)
 	assert(CreateChannelRequest, "You must provide a CreateChannelRequest")
 	local headers = {
@@ -2525,19 +2531,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateChannelSync(CreateChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateChannelAsync(CreateChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateChannelAsync(CreateChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateChannel asynchronously, invoking a callback when done
 -- @param UpdateChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateChannelAsync(UpdateChannelRequest, cb)
 	assert(UpdateChannelRequest, "You must provide a UpdateChannelRequest")
 	local headers = {
@@ -2560,19 +2567,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateChannelSync(UpdateChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateChannelAsync(UpdateChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateChannelAsync(UpdateChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOriginEndpoints asynchronously, invoking a callback when done
 -- @param ListOriginEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOriginEndpointsAsync(ListOriginEndpointsRequest, cb)
 	assert(ListOriginEndpointsRequest, "You must provide a ListOriginEndpointsRequest")
 	local headers = {
@@ -2595,19 +2603,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOriginEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOriginEndpointsSync(ListOriginEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOriginEndpointsAsync(ListOriginEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOriginEndpointsAsync(ListOriginEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOriginEndpoint asynchronously, invoking a callback when done
 -- @param DescribeOriginEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOriginEndpointAsync(DescribeOriginEndpointRequest, cb)
 	assert(DescribeOriginEndpointRequest, "You must provide a DescribeOriginEndpointRequest")
 	local headers = {
@@ -2630,19 +2639,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOriginEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOriginEndpointSync(DescribeOriginEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOriginEndpointAsync(DescribeOriginEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOriginEndpointAsync(DescribeOriginEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeChannel asynchronously, invoking a callback when done
 -- @param DescribeChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeChannelAsync(DescribeChannelRequest, cb)
 	assert(DescribeChannelRequest, "You must provide a DescribeChannelRequest")
 	local headers = {
@@ -2665,12 +2675,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeChannelSync(DescribeChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeChannelAsync(DescribeChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeChannelAsync(DescribeChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mediastore.lua
+++ b/aws-sdk/mediastore.lua
@@ -1406,7 +1406,7 @@ end
 --
 --- Call PutContainerPolicy asynchronously, invoking a callback when done
 -- @param PutContainerPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutContainerPolicyAsync(PutContainerPolicyInput, cb)
 	assert(PutContainerPolicyInput, "You must provide a PutContainerPolicyInput")
 	local headers = {
@@ -1429,19 +1429,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutContainerPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutContainerPolicySync(PutContainerPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutContainerPolicyAsync(PutContainerPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutContainerPolicyAsync(PutContainerPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCorsPolicy asynchronously, invoking a callback when done
 -- @param DeleteCorsPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCorsPolicyAsync(DeleteCorsPolicyInput, cb)
 	assert(DeleteCorsPolicyInput, "You must provide a DeleteCorsPolicyInput")
 	local headers = {
@@ -1464,19 +1465,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCorsPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCorsPolicySync(DeleteCorsPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCorsPolicyAsync(DeleteCorsPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCorsPolicyAsync(DeleteCorsPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteContainerPolicy asynchronously, invoking a callback when done
 -- @param DeleteContainerPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteContainerPolicyAsync(DeleteContainerPolicyInput, cb)
 	assert(DeleteContainerPolicyInput, "You must provide a DeleteContainerPolicyInput")
 	local headers = {
@@ -1499,19 +1501,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteContainerPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteContainerPolicySync(DeleteContainerPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteContainerPolicyAsync(DeleteContainerPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteContainerPolicyAsync(DeleteContainerPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCorsPolicy asynchronously, invoking a callback when done
 -- @param GetCorsPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCorsPolicyAsync(GetCorsPolicyInput, cb)
 	assert(GetCorsPolicyInput, "You must provide a GetCorsPolicyInput")
 	local headers = {
@@ -1534,19 +1537,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCorsPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCorsPolicySync(GetCorsPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCorsPolicyAsync(GetCorsPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCorsPolicyAsync(GetCorsPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListContainers asynchronously, invoking a callback when done
 -- @param ListContainersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListContainersAsync(ListContainersInput, cb)
 	assert(ListContainersInput, "You must provide a ListContainersInput")
 	local headers = {
@@ -1569,19 +1573,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListContainersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListContainersSync(ListContainersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListContainersAsync(ListContainersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListContainersAsync(ListContainersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeContainer asynchronously, invoking a callback when done
 -- @param DescribeContainerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeContainerAsync(DescribeContainerInput, cb)
 	assert(DescribeContainerInput, "You must provide a DescribeContainerInput")
 	local headers = {
@@ -1604,19 +1609,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeContainerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeContainerSync(DescribeContainerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeContainerAsync(DescribeContainerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeContainerAsync(DescribeContainerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateContainer asynchronously, invoking a callback when done
 -- @param CreateContainerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateContainerAsync(CreateContainerInput, cb)
 	assert(CreateContainerInput, "You must provide a CreateContainerInput")
 	local headers = {
@@ -1639,19 +1645,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateContainerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateContainerSync(CreateContainerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateContainerAsync(CreateContainerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateContainerAsync(CreateContainerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutCorsPolicy asynchronously, invoking a callback when done
 -- @param PutCorsPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutCorsPolicyAsync(PutCorsPolicyInput, cb)
 	assert(PutCorsPolicyInput, "You must provide a PutCorsPolicyInput")
 	local headers = {
@@ -1674,19 +1681,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutCorsPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutCorsPolicySync(PutCorsPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutCorsPolicyAsync(PutCorsPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutCorsPolicyAsync(PutCorsPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteContainer asynchronously, invoking a callback when done
 -- @param DeleteContainerInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteContainerAsync(DeleteContainerInput, cb)
 	assert(DeleteContainerInput, "You must provide a DeleteContainerInput")
 	local headers = {
@@ -1709,19 +1717,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteContainerInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteContainerSync(DeleteContainerInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteContainerAsync(DeleteContainerInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteContainerAsync(DeleteContainerInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetContainerPolicy asynchronously, invoking a callback when done
 -- @param GetContainerPolicyInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetContainerPolicyAsync(GetContainerPolicyInput, cb)
 	assert(GetContainerPolicyInput, "You must provide a GetContainerPolicyInput")
 	local headers = {
@@ -1744,12 +1753,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetContainerPolicyInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetContainerPolicySync(GetContainerPolicyInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetContainerPolicyAsync(GetContainerPolicyInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetContainerPolicyAsync(GetContainerPolicyInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/metering_marketplace.lua
+++ b/aws-sdk/metering_marketplace.lua
@@ -938,7 +938,7 @@ end
 --
 --- Call BatchMeterUsage asynchronously, invoking a callback when done
 -- @param BatchMeterUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchMeterUsageAsync(BatchMeterUsageRequest, cb)
 	assert(BatchMeterUsageRequest, "You must provide a BatchMeterUsageRequest")
 	local headers = {
@@ -961,19 +961,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchMeterUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchMeterUsageSync(BatchMeterUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchMeterUsageAsync(BatchMeterUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchMeterUsageAsync(BatchMeterUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call MeterUsage asynchronously, invoking a callback when done
 -- @param MeterUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.MeterUsageAsync(MeterUsageRequest, cb)
 	assert(MeterUsageRequest, "You must provide a MeterUsageRequest")
 	local headers = {
@@ -996,19 +997,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param MeterUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.MeterUsageSync(MeterUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.MeterUsageAsync(MeterUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.MeterUsageAsync(MeterUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResolveCustomer asynchronously, invoking a callback when done
 -- @param ResolveCustomerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResolveCustomerAsync(ResolveCustomerRequest, cb)
 	assert(ResolveCustomerRequest, "You must provide a ResolveCustomerRequest")
 	local headers = {
@@ -1031,12 +1033,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResolveCustomerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResolveCustomerSync(ResolveCustomerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResolveCustomerAsync(ResolveCustomerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResolveCustomerAsync(ResolveCustomerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mgh.lua
+++ b/aws-sdk/mgh.lua
@@ -2372,7 +2372,7 @@ end
 --
 --- Call CreateProgressUpdateStream asynchronously, invoking a callback when done
 -- @param CreateProgressUpdateStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProgressUpdateStreamAsync(CreateProgressUpdateStreamRequest, cb)
 	assert(CreateProgressUpdateStreamRequest, "You must provide a CreateProgressUpdateStreamRequest")
 	local headers = {
@@ -2395,19 +2395,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProgressUpdateStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProgressUpdateStreamSync(CreateProgressUpdateStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProgressUpdateStreamAsync(CreateProgressUpdateStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProgressUpdateStreamAsync(CreateProgressUpdateStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call NotifyApplicationState asynchronously, invoking a callback when done
 -- @param NotifyApplicationStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.NotifyApplicationStateAsync(NotifyApplicationStateRequest, cb)
 	assert(NotifyApplicationStateRequest, "You must provide a NotifyApplicationStateRequest")
 	local headers = {
@@ -2430,19 +2431,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param NotifyApplicationStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.NotifyApplicationStateSync(NotifyApplicationStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.NotifyApplicationStateAsync(NotifyApplicationStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.NotifyApplicationStateAsync(NotifyApplicationStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateDiscoveredResource asynchronously, invoking a callback when done
 -- @param AssociateDiscoveredResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateDiscoveredResourceAsync(AssociateDiscoveredResourceRequest, cb)
 	assert(AssociateDiscoveredResourceRequest, "You must provide a AssociateDiscoveredResourceRequest")
 	local headers = {
@@ -2465,19 +2467,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateDiscoveredResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateDiscoveredResourceSync(AssociateDiscoveredResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateDiscoveredResourceAsync(AssociateDiscoveredResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateDiscoveredResourceAsync(AssociateDiscoveredResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutResourceAttributes asynchronously, invoking a callback when done
 -- @param PutResourceAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutResourceAttributesAsync(PutResourceAttributesRequest, cb)
 	assert(PutResourceAttributesRequest, "You must provide a PutResourceAttributesRequest")
 	local headers = {
@@ -2500,19 +2503,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutResourceAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutResourceAttributesSync(PutResourceAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutResourceAttributesAsync(PutResourceAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutResourceAttributesAsync(PutResourceAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProgressUpdateStreams asynchronously, invoking a callback when done
 -- @param ListProgressUpdateStreamsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProgressUpdateStreamsAsync(ListProgressUpdateStreamsRequest, cb)
 	assert(ListProgressUpdateStreamsRequest, "You must provide a ListProgressUpdateStreamsRequest")
 	local headers = {
@@ -2535,19 +2539,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProgressUpdateStreamsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProgressUpdateStreamsSync(ListProgressUpdateStreamsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProgressUpdateStreamsAsync(ListProgressUpdateStreamsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProgressUpdateStreamsAsync(ListProgressUpdateStreamsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateDiscoveredResource asynchronously, invoking a callback when done
 -- @param DisassociateDiscoveredResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateDiscoveredResourceAsync(DisassociateDiscoveredResourceRequest, cb)
 	assert(DisassociateDiscoveredResourceRequest, "You must provide a DisassociateDiscoveredResourceRequest")
 	local headers = {
@@ -2570,19 +2575,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateDiscoveredResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateDiscoveredResourceSync(DisassociateDiscoveredResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateDiscoveredResourceAsync(DisassociateDiscoveredResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateDiscoveredResourceAsync(DisassociateDiscoveredResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProgressUpdateStream asynchronously, invoking a callback when done
 -- @param DeleteProgressUpdateStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProgressUpdateStreamAsync(DeleteProgressUpdateStreamRequest, cb)
 	assert(DeleteProgressUpdateStreamRequest, "You must provide a DeleteProgressUpdateStreamRequest")
 	local headers = {
@@ -2605,19 +2611,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProgressUpdateStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProgressUpdateStreamSync(DeleteProgressUpdateStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProgressUpdateStreamAsync(DeleteProgressUpdateStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProgressUpdateStreamAsync(DeleteProgressUpdateStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCreatedArtifacts asynchronously, invoking a callback when done
 -- @param ListCreatedArtifactsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCreatedArtifactsAsync(ListCreatedArtifactsRequest, cb)
 	assert(ListCreatedArtifactsRequest, "You must provide a ListCreatedArtifactsRequest")
 	local headers = {
@@ -2640,19 +2647,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCreatedArtifactsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCreatedArtifactsSync(ListCreatedArtifactsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCreatedArtifactsAsync(ListCreatedArtifactsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCreatedArtifactsAsync(ListCreatedArtifactsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call NotifyMigrationTaskState asynchronously, invoking a callback when done
 -- @param NotifyMigrationTaskStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.NotifyMigrationTaskStateAsync(NotifyMigrationTaskStateRequest, cb)
 	assert(NotifyMigrationTaskStateRequest, "You must provide a NotifyMigrationTaskStateRequest")
 	local headers = {
@@ -2675,19 +2683,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param NotifyMigrationTaskStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.NotifyMigrationTaskStateSync(NotifyMigrationTaskStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.NotifyMigrationTaskStateAsync(NotifyMigrationTaskStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.NotifyMigrationTaskStateAsync(NotifyMigrationTaskStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ImportMigrationTask asynchronously, invoking a callback when done
 -- @param ImportMigrationTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportMigrationTaskAsync(ImportMigrationTaskRequest, cb)
 	assert(ImportMigrationTaskRequest, "You must provide a ImportMigrationTaskRequest")
 	local headers = {
@@ -2710,19 +2719,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportMigrationTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportMigrationTaskSync(ImportMigrationTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportMigrationTaskAsync(ImportMigrationTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportMigrationTaskAsync(ImportMigrationTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMigrationTask asynchronously, invoking a callback when done
 -- @param DescribeMigrationTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMigrationTaskAsync(DescribeMigrationTaskRequest, cb)
 	assert(DescribeMigrationTaskRequest, "You must provide a DescribeMigrationTaskRequest")
 	local headers = {
@@ -2745,19 +2755,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMigrationTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMigrationTaskSync(DescribeMigrationTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMigrationTaskAsync(DescribeMigrationTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMigrationTaskAsync(DescribeMigrationTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMigrationTasks asynchronously, invoking a callback when done
 -- @param ListMigrationTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMigrationTasksAsync(ListMigrationTasksRequest, cb)
 	assert(ListMigrationTasksRequest, "You must provide a ListMigrationTasksRequest")
 	local headers = {
@@ -2780,19 +2791,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMigrationTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMigrationTasksSync(ListMigrationTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMigrationTasksAsync(ListMigrationTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMigrationTasksAsync(ListMigrationTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateCreatedArtifact asynchronously, invoking a callback when done
 -- @param DisassociateCreatedArtifactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateCreatedArtifactAsync(DisassociateCreatedArtifactRequest, cb)
 	assert(DisassociateCreatedArtifactRequest, "You must provide a DisassociateCreatedArtifactRequest")
 	local headers = {
@@ -2815,19 +2827,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateCreatedArtifactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateCreatedArtifactSync(DisassociateCreatedArtifactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateCreatedArtifactAsync(DisassociateCreatedArtifactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateCreatedArtifactAsync(DisassociateCreatedArtifactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateCreatedArtifact asynchronously, invoking a callback when done
 -- @param AssociateCreatedArtifactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateCreatedArtifactAsync(AssociateCreatedArtifactRequest, cb)
 	assert(AssociateCreatedArtifactRequest, "You must provide a AssociateCreatedArtifactRequest")
 	local headers = {
@@ -2850,19 +2863,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateCreatedArtifactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateCreatedArtifactSync(AssociateCreatedArtifactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateCreatedArtifactAsync(AssociateCreatedArtifactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateCreatedArtifactAsync(AssociateCreatedArtifactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDiscoveredResources asynchronously, invoking a callback when done
 -- @param ListDiscoveredResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDiscoveredResourcesAsync(ListDiscoveredResourcesRequest, cb)
 	assert(ListDiscoveredResourcesRequest, "You must provide a ListDiscoveredResourcesRequest")
 	local headers = {
@@ -2885,19 +2899,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDiscoveredResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDiscoveredResourcesSync(ListDiscoveredResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDiscoveredResourcesAsync(ListDiscoveredResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDiscoveredResourcesAsync(ListDiscoveredResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeApplicationState asynchronously, invoking a callback when done
 -- @param DescribeApplicationStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeApplicationStateAsync(DescribeApplicationStateRequest, cb)
 	assert(DescribeApplicationStateRequest, "You must provide a DescribeApplicationStateRequest")
 	local headers = {
@@ -2920,12 +2935,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeApplicationStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeApplicationStateSync(DescribeApplicationStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeApplicationStateAsync(DescribeApplicationStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeApplicationStateAsync(DescribeApplicationStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mobile.lua
+++ b/aws-sdk/mobile.lua
@@ -1666,7 +1666,7 @@ end
 --
 --- Call ExportProject asynchronously, invoking a callback when done
 -- @param ExportProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExportProjectAsync(ExportProjectRequest, cb)
 	assert(ExportProjectRequest, "You must provide a ExportProjectRequest")
 	local headers = {
@@ -1689,19 +1689,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExportProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExportProjectSync(ExportProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExportProjectAsync(ExportProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExportProjectAsync(ExportProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBundle asynchronously, invoking a callback when done
 -- @param DescribeBundleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBundleAsync(DescribeBundleRequest, cb)
 	assert(DescribeBundleRequest, "You must provide a DescribeBundleRequest")
 	local headers = {
@@ -1724,19 +1725,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBundleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBundleSync(DescribeBundleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBundleAsync(DescribeBundleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBundleAsync(DescribeBundleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBundles asynchronously, invoking a callback when done
 -- @param ListBundlesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBundlesAsync(ListBundlesRequest, cb)
 	assert(ListBundlesRequest, "You must provide a ListBundlesRequest")
 	local headers = {
@@ -1759,19 +1761,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBundlesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBundlesSync(ListBundlesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBundlesAsync(ListBundlesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBundlesAsync(ListBundlesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProject asynchronously, invoking a callback when done
 -- @param DescribeProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProjectAsync(DescribeProjectRequest, cb)
 	assert(DescribeProjectRequest, "You must provide a DescribeProjectRequest")
 	local headers = {
@@ -1794,19 +1797,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProjectSync(DescribeProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProjectAsync(DescribeProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProjectAsync(DescribeProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProject asynchronously, invoking a callback when done
 -- @param CreateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProjectAsync(CreateProjectRequest, cb)
 	assert(CreateProjectRequest, "You must provide a CreateProjectRequest")
 	local headers = {
@@ -1829,19 +1833,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProjectSync(CreateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProjectAsync(CreateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProjectAsync(CreateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProjects asynchronously, invoking a callback when done
 -- @param ListProjectsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProjectsAsync(ListProjectsRequest, cb)
 	assert(ListProjectsRequest, "You must provide a ListProjectsRequest")
 	local headers = {
@@ -1864,19 +1869,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProjectsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProjectsSync(ListProjectsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProjectsAsync(ListProjectsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProjectsAsync(ListProjectsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProject asynchronously, invoking a callback when done
 -- @param UpdateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProjectAsync(UpdateProjectRequest, cb)
 	assert(UpdateProjectRequest, "You must provide a UpdateProjectRequest")
 	local headers = {
@@ -1899,19 +1905,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProjectSync(UpdateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProject asynchronously, invoking a callback when done
 -- @param DeleteProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProjectAsync(DeleteProjectRequest, cb)
 	assert(DeleteProjectRequest, "You must provide a DeleteProjectRequest")
 	local headers = {
@@ -1934,19 +1941,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProjectSync(DeleteProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ExportBundle asynchronously, invoking a callback when done
 -- @param ExportBundleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExportBundleAsync(ExportBundleRequest, cb)
 	assert(ExportBundleRequest, "You must provide a ExportBundleRequest")
 	local headers = {
@@ -1969,12 +1977,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExportBundleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExportBundleSync(ExportBundleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExportBundleAsync(ExportBundleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExportBundleAsync(ExportBundleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mobileanalytics.lua
+++ b/aws-sdk/mobileanalytics.lua
@@ -378,7 +378,7 @@ end
 --
 --- Call PutEvents asynchronously, invoking a callback when done
 -- @param PutEventsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutEventsAsync(PutEventsInput, cb)
 	assert(PutEventsInput, "You must provide a PutEventsInput")
 	local headers = {
@@ -401,12 +401,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutEventsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutEventsSync(PutEventsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutEventsAsync(PutEventsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutEventsAsync(PutEventsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/models_lex.lua
+++ b/aws-sdk/models_lex.lua
@@ -5087,7 +5087,7 @@ end
 --
 --- Call CreateBotVersion asynchronously, invoking a callback when done
 -- @param CreateBotVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBotVersionAsync(CreateBotVersionRequest, cb)
 	assert(CreateBotVersionRequest, "You must provide a CreateBotVersionRequest")
 	local headers = {
@@ -5110,19 +5110,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBotVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBotVersionSync(CreateBotVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBotVersionAsync(CreateBotVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBotVersionAsync(CreateBotVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBotAlias asynchronously, invoking a callback when done
 -- @param DeleteBotAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBotAliasAsync(DeleteBotAliasRequest, cb)
 	assert(DeleteBotAliasRequest, "You must provide a DeleteBotAliasRequest")
 	local headers = {
@@ -5145,19 +5146,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBotAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBotAliasSync(DeleteBotAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBotAliasAsync(DeleteBotAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBotAliasAsync(DeleteBotAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIntents asynchronously, invoking a callback when done
 -- @param GetIntentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIntentsAsync(GetIntentsRequest, cb)
 	assert(GetIntentsRequest, "You must provide a GetIntentsRequest")
 	local headers = {
@@ -5180,19 +5182,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIntentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIntentsSync(GetIntentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIntentsAsync(GetIntentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIntentsAsync(GetIntentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSlotTypes asynchronously, invoking a callback when done
 -- @param GetSlotTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSlotTypesAsync(GetSlotTypesRequest, cb)
 	assert(GetSlotTypesRequest, "You must provide a GetSlotTypesRequest")
 	local headers = {
@@ -5215,19 +5218,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSlotTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSlotTypesSync(GetSlotTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSlotTypesAsync(GetSlotTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSlotTypesAsync(GetSlotTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSlotTypeVersion asynchronously, invoking a callback when done
 -- @param DeleteSlotTypeVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSlotTypeVersionAsync(DeleteSlotTypeVersionRequest, cb)
 	assert(DeleteSlotTypeVersionRequest, "You must provide a DeleteSlotTypeVersionRequest")
 	local headers = {
@@ -5250,19 +5254,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSlotTypeVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSlotTypeVersionSync(DeleteSlotTypeVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSlotTypeVersionAsync(DeleteSlotTypeVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSlotTypeVersionAsync(DeleteSlotTypeVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartImport asynchronously, invoking a callback when done
 -- @param StartImportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartImportAsync(StartImportRequest, cb)
 	assert(StartImportRequest, "You must provide a StartImportRequest")
 	local headers = {
@@ -5285,19 +5290,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartImportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartImportSync(StartImportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartImportAsync(StartImportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartImportAsync(StartImportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSlotTypeVersion asynchronously, invoking a callback when done
 -- @param CreateSlotTypeVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSlotTypeVersionAsync(CreateSlotTypeVersionRequest, cb)
 	assert(CreateSlotTypeVersionRequest, "You must provide a CreateSlotTypeVersionRequest")
 	local headers = {
@@ -5320,19 +5326,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSlotTypeVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSlotTypeVersionSync(CreateSlotTypeVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSlotTypeVersionAsync(CreateSlotTypeVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSlotTypeVersionAsync(CreateSlotTypeVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIntentVersions asynchronously, invoking a callback when done
 -- @param GetIntentVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIntentVersionsAsync(GetIntentVersionsRequest, cb)
 	assert(GetIntentVersionsRequest, "You must provide a GetIntentVersionsRequest")
 	local headers = {
@@ -5355,19 +5362,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIntentVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIntentVersionsSync(GetIntentVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIntentVersionsAsync(GetIntentVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIntentVersionsAsync(GetIntentVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBuiltinSlotTypes asynchronously, invoking a callback when done
 -- @param GetBuiltinSlotTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBuiltinSlotTypesAsync(GetBuiltinSlotTypesRequest, cb)
 	assert(GetBuiltinSlotTypesRequest, "You must provide a GetBuiltinSlotTypesRequest")
 	local headers = {
@@ -5390,19 +5398,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBuiltinSlotTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBuiltinSlotTypesSync(GetBuiltinSlotTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBuiltinSlotTypesAsync(GetBuiltinSlotTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBuiltinSlotTypesAsync(GetBuiltinSlotTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIntentVersion asynchronously, invoking a callback when done
 -- @param CreateIntentVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIntentVersionAsync(CreateIntentVersionRequest, cb)
 	assert(CreateIntentVersionRequest, "You must provide a CreateIntentVersionRequest")
 	local headers = {
@@ -5425,19 +5434,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIntentVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIntentVersionSync(CreateIntentVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIntentVersionAsync(CreateIntentVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIntentVersionAsync(CreateIntentVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUtterancesView asynchronously, invoking a callback when done
 -- @param GetUtterancesViewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUtterancesViewAsync(GetUtterancesViewRequest, cb)
 	assert(GetUtterancesViewRequest, "You must provide a GetUtterancesViewRequest")
 	local headers = {
@@ -5460,19 +5470,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUtterancesViewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUtterancesViewSync(GetUtterancesViewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUtterancesViewAsync(GetUtterancesViewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUtterancesViewAsync(GetUtterancesViewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBot asynchronously, invoking a callback when done
 -- @param GetBotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBotAsync(GetBotRequest, cb)
 	assert(GetBotRequest, "You must provide a GetBotRequest")
 	local headers = {
@@ -5495,19 +5506,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBotSync(GetBotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBotAsync(GetBotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBotAsync(GetBotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSlotTypeVersions asynchronously, invoking a callback when done
 -- @param GetSlotTypeVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSlotTypeVersionsAsync(GetSlotTypeVersionsRequest, cb)
 	assert(GetSlotTypeVersionsRequest, "You must provide a GetSlotTypeVersionsRequest")
 	local headers = {
@@ -5530,19 +5542,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSlotTypeVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSlotTypeVersionsSync(GetSlotTypeVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSlotTypeVersionsAsync(GetSlotTypeVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSlotTypeVersionsAsync(GetSlotTypeVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIntentVersion asynchronously, invoking a callback when done
 -- @param DeleteIntentVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIntentVersionAsync(DeleteIntentVersionRequest, cb)
 	assert(DeleteIntentVersionRequest, "You must provide a DeleteIntentVersionRequest")
 	local headers = {
@@ -5565,19 +5578,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIntentVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIntentVersionSync(DeleteIntentVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIntentVersionAsync(DeleteIntentVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIntentVersionAsync(DeleteIntentVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUtterances asynchronously, invoking a callback when done
 -- @param DeleteUtterancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUtterancesAsync(DeleteUtterancesRequest, cb)
 	assert(DeleteUtterancesRequest, "You must provide a DeleteUtterancesRequest")
 	local headers = {
@@ -5600,19 +5614,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUtterancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUtterancesSync(DeleteUtterancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUtterancesAsync(DeleteUtterancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUtterancesAsync(DeleteUtterancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBotAlias asynchronously, invoking a callback when done
 -- @param GetBotAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBotAliasAsync(GetBotAliasRequest, cb)
 	assert(GetBotAliasRequest, "You must provide a GetBotAliasRequest")
 	local headers = {
@@ -5635,19 +5650,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBotAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBotAliasSync(GetBotAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBotAliasAsync(GetBotAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBotAliasAsync(GetBotAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIntent asynchronously, invoking a callback when done
 -- @param DeleteIntentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIntentAsync(DeleteIntentRequest, cb)
 	assert(DeleteIntentRequest, "You must provide a DeleteIntentRequest")
 	local headers = {
@@ -5670,19 +5686,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIntentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIntentSync(DeleteIntentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIntentAsync(DeleteIntentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIntentAsync(DeleteIntentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetImport asynchronously, invoking a callback when done
 -- @param GetImportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetImportAsync(GetImportRequest, cb)
 	assert(GetImportRequest, "You must provide a GetImportRequest")
 	local headers = {
@@ -5705,19 +5722,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetImportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetImportSync(GetImportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetImportAsync(GetImportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetImportAsync(GetImportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBotVersions asynchronously, invoking a callback when done
 -- @param GetBotVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBotVersionsAsync(GetBotVersionsRequest, cb)
 	assert(GetBotVersionsRequest, "You must provide a GetBotVersionsRequest")
 	local headers = {
@@ -5740,19 +5758,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBotVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBotVersionsSync(GetBotVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBotVersionsAsync(GetBotVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBotVersionsAsync(GetBotVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetExport asynchronously, invoking a callback when done
 -- @param GetExportRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetExportAsync(GetExportRequest, cb)
 	assert(GetExportRequest, "You must provide a GetExportRequest")
 	local headers = {
@@ -5775,19 +5794,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetExportRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetExportSync(GetExportRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetExportAsync(GetExportRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetExportAsync(GetExportRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBotChannelAssociation asynchronously, invoking a callback when done
 -- @param DeleteBotChannelAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBotChannelAssociationAsync(DeleteBotChannelAssociationRequest, cb)
 	assert(DeleteBotChannelAssociationRequest, "You must provide a DeleteBotChannelAssociationRequest")
 	local headers = {
@@ -5810,19 +5830,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBotChannelAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBotChannelAssociationSync(DeleteBotChannelAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBotChannelAssociationAsync(DeleteBotChannelAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBotChannelAssociationAsync(DeleteBotChannelAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBotVersion asynchronously, invoking a callback when done
 -- @param DeleteBotVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBotVersionAsync(DeleteBotVersionRequest, cb)
 	assert(DeleteBotVersionRequest, "You must provide a DeleteBotVersionRequest")
 	local headers = {
@@ -5845,19 +5866,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBotVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBotVersionSync(DeleteBotVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBotVersionAsync(DeleteBotVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBotVersionAsync(DeleteBotVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBotChannelAssociations asynchronously, invoking a callback when done
 -- @param GetBotChannelAssociationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBotChannelAssociationsAsync(GetBotChannelAssociationsRequest, cb)
 	assert(GetBotChannelAssociationsRequest, "You must provide a GetBotChannelAssociationsRequest")
 	local headers = {
@@ -5880,19 +5902,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBotChannelAssociationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBotChannelAssociationsSync(GetBotChannelAssociationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBotChannelAssociationsAsync(GetBotChannelAssociationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBotChannelAssociationsAsync(GetBotChannelAssociationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBot asynchronously, invoking a callback when done
 -- @param PutBotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBotAsync(PutBotRequest, cb)
 	assert(PutBotRequest, "You must provide a PutBotRequest")
 	local headers = {
@@ -5915,19 +5938,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBotSync(PutBotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBotAsync(PutBotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBotAsync(PutBotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBotChannelAssociation asynchronously, invoking a callback when done
 -- @param GetBotChannelAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBotChannelAssociationAsync(GetBotChannelAssociationRequest, cb)
 	assert(GetBotChannelAssociationRequest, "You must provide a GetBotChannelAssociationRequest")
 	local headers = {
@@ -5950,19 +5974,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBotChannelAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBotChannelAssociationSync(GetBotChannelAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBotChannelAssociationAsync(GetBotChannelAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBotChannelAssociationAsync(GetBotChannelAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBotAliases asynchronously, invoking a callback when done
 -- @param GetBotAliasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBotAliasesAsync(GetBotAliasesRequest, cb)
 	assert(GetBotAliasesRequest, "You must provide a GetBotAliasesRequest")
 	local headers = {
@@ -5985,19 +6010,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBotAliasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBotAliasesSync(GetBotAliasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBotAliasesAsync(GetBotAliasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBotAliasesAsync(GetBotAliasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBot asynchronously, invoking a callback when done
 -- @param DeleteBotRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBotAsync(DeleteBotRequest, cb)
 	assert(DeleteBotRequest, "You must provide a DeleteBotRequest")
 	local headers = {
@@ -6020,19 +6046,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBotRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBotSync(DeleteBotRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBotAsync(DeleteBotRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBotAsync(DeleteBotRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBuiltinIntents asynchronously, invoking a callback when done
 -- @param GetBuiltinIntentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBuiltinIntentsAsync(GetBuiltinIntentsRequest, cb)
 	assert(GetBuiltinIntentsRequest, "You must provide a GetBuiltinIntentsRequest")
 	local headers = {
@@ -6055,19 +6082,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBuiltinIntentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBuiltinIntentsSync(GetBuiltinIntentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBuiltinIntentsAsync(GetBuiltinIntentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBuiltinIntentsAsync(GetBuiltinIntentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBots asynchronously, invoking a callback when done
 -- @param GetBotsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBotsAsync(GetBotsRequest, cb)
 	assert(GetBotsRequest, "You must provide a GetBotsRequest")
 	local headers = {
@@ -6090,19 +6118,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBotsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBotsSync(GetBotsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBotsAsync(GetBotsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBotsAsync(GetBotsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSlotType asynchronously, invoking a callback when done
 -- @param DeleteSlotTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSlotTypeAsync(DeleteSlotTypeRequest, cb)
 	assert(DeleteSlotTypeRequest, "You must provide a DeleteSlotTypeRequest")
 	local headers = {
@@ -6125,19 +6154,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSlotTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSlotTypeSync(DeleteSlotTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSlotTypeAsync(DeleteSlotTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSlotTypeAsync(DeleteSlotTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSlotType asynchronously, invoking a callback when done
 -- @param GetSlotTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSlotTypeAsync(GetSlotTypeRequest, cb)
 	assert(GetSlotTypeRequest, "You must provide a GetSlotTypeRequest")
 	local headers = {
@@ -6160,19 +6190,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSlotTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSlotTypeSync(GetSlotTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSlotTypeAsync(GetSlotTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSlotTypeAsync(GetSlotTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIntent asynchronously, invoking a callback when done
 -- @param GetIntentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIntentAsync(GetIntentRequest, cb)
 	assert(GetIntentRequest, "You must provide a GetIntentRequest")
 	local headers = {
@@ -6195,19 +6226,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIntentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIntentSync(GetIntentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIntentAsync(GetIntentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIntentAsync(GetIntentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutSlotType asynchronously, invoking a callback when done
 -- @param PutSlotTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutSlotTypeAsync(PutSlotTypeRequest, cb)
 	assert(PutSlotTypeRequest, "You must provide a PutSlotTypeRequest")
 	local headers = {
@@ -6230,19 +6262,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutSlotTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutSlotTypeSync(PutSlotTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutSlotTypeAsync(PutSlotTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutSlotTypeAsync(PutSlotTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBuiltinIntent asynchronously, invoking a callback when done
 -- @param GetBuiltinIntentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBuiltinIntentAsync(GetBuiltinIntentRequest, cb)
 	assert(GetBuiltinIntentRequest, "You must provide a GetBuiltinIntentRequest")
 	local headers = {
@@ -6265,19 +6298,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBuiltinIntentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBuiltinIntentSync(GetBuiltinIntentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBuiltinIntentAsync(GetBuiltinIntentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBuiltinIntentAsync(GetBuiltinIntentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutIntent asynchronously, invoking a callback when done
 -- @param PutIntentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutIntentAsync(PutIntentRequest, cb)
 	assert(PutIntentRequest, "You must provide a PutIntentRequest")
 	local headers = {
@@ -6300,19 +6334,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutIntentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutIntentSync(PutIntentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutIntentAsync(PutIntentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutIntentAsync(PutIntentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBotAlias asynchronously, invoking a callback when done
 -- @param PutBotAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBotAliasAsync(PutBotAliasRequest, cb)
 	assert(PutBotAliasRequest, "You must provide a PutBotAliasRequest")
 	local headers = {
@@ -6335,12 +6370,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBotAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBotAliasSync(PutBotAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBotAliasAsync(PutBotAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBotAliasAsync(PutBotAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/monitoring.lua
+++ b/aws-sdk/monitoring.lua
@@ -3050,7 +3050,7 @@ end
 --
 --- Call ListDashboards asynchronously, invoking a callback when done
 -- @param ListDashboardsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDashboardsAsync(ListDashboardsInput, cb)
 	assert(ListDashboardsInput, "You must provide a ListDashboardsInput")
 	local headers = {
@@ -3073,19 +3073,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDashboardsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDashboardsSync(ListDashboardsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDashboardsAsync(ListDashboardsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDashboardsAsync(ListDashboardsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMetrics asynchronously, invoking a callback when done
 -- @param ListMetricsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMetricsAsync(ListMetricsInput, cb)
 	assert(ListMetricsInput, "You must provide a ListMetricsInput")
 	local headers = {
@@ -3108,19 +3109,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMetricsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMetricsSync(ListMetricsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMetricsAsync(ListMetricsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMetricsAsync(ListMetricsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDashboards asynchronously, invoking a callback when done
 -- @param DeleteDashboardsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDashboardsAsync(DeleteDashboardsInput, cb)
 	assert(DeleteDashboardsInput, "You must provide a DeleteDashboardsInput")
 	local headers = {
@@ -3143,19 +3145,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDashboardsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDashboardsSync(DeleteDashboardsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDashboardsAsync(DeleteDashboardsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDashboardsAsync(DeleteDashboardsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAlarms asynchronously, invoking a callback when done
 -- @param DeleteAlarmsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAlarmsAsync(DeleteAlarmsInput, cb)
 	assert(DeleteAlarmsInput, "You must provide a DeleteAlarmsInput")
 	local headers = {
@@ -3178,19 +3181,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAlarmsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAlarmsSync(DeleteAlarmsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAlarmsAsync(DeleteAlarmsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAlarmsAsync(DeleteAlarmsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableAlarmActions asynchronously, invoking a callback when done
 -- @param EnableAlarmActionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableAlarmActionsAsync(EnableAlarmActionsInput, cb)
 	assert(EnableAlarmActionsInput, "You must provide a EnableAlarmActionsInput")
 	local headers = {
@@ -3213,19 +3217,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableAlarmActionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableAlarmActionsSync(EnableAlarmActionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableAlarmActionsAsync(EnableAlarmActionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableAlarmActionsAsync(EnableAlarmActionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMetricData asynchronously, invoking a callback when done
 -- @param GetMetricDataInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMetricDataAsync(GetMetricDataInput, cb)
 	assert(GetMetricDataInput, "You must provide a GetMetricDataInput")
 	local headers = {
@@ -3248,19 +3253,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMetricDataInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMetricDataSync(GetMetricDataInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMetricDataAsync(GetMetricDataInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMetricDataAsync(GetMetricDataInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutMetricAlarm asynchronously, invoking a callback when done
 -- @param PutMetricAlarmInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutMetricAlarmAsync(PutMetricAlarmInput, cb)
 	assert(PutMetricAlarmInput, "You must provide a PutMetricAlarmInput")
 	local headers = {
@@ -3283,19 +3289,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutMetricAlarmInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutMetricAlarmSync(PutMetricAlarmInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutMetricAlarmAsync(PutMetricAlarmInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutMetricAlarmAsync(PutMetricAlarmInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMetricStatistics asynchronously, invoking a callback when done
 -- @param GetMetricStatisticsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMetricStatisticsAsync(GetMetricStatisticsInput, cb)
 	assert(GetMetricStatisticsInput, "You must provide a GetMetricStatisticsInput")
 	local headers = {
@@ -3318,19 +3325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMetricStatisticsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMetricStatisticsSync(GetMetricStatisticsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMetricStatisticsAsync(GetMetricStatisticsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMetricStatisticsAsync(GetMetricStatisticsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableAlarmActions asynchronously, invoking a callback when done
 -- @param DisableAlarmActionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableAlarmActionsAsync(DisableAlarmActionsInput, cb)
 	assert(DisableAlarmActionsInput, "You must provide a DisableAlarmActionsInput")
 	local headers = {
@@ -3353,19 +3361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableAlarmActionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableAlarmActionsSync(DisableAlarmActionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableAlarmActionsAsync(DisableAlarmActionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableAlarmActionsAsync(DisableAlarmActionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetAlarmState asynchronously, invoking a callback when done
 -- @param SetAlarmStateInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetAlarmStateAsync(SetAlarmStateInput, cb)
 	assert(SetAlarmStateInput, "You must provide a SetAlarmStateInput")
 	local headers = {
@@ -3388,19 +3397,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetAlarmStateInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetAlarmStateSync(SetAlarmStateInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetAlarmStateAsync(SetAlarmStateInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetAlarmStateAsync(SetAlarmStateInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutDashboard asynchronously, invoking a callback when done
 -- @param PutDashboardInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutDashboardAsync(PutDashboardInput, cb)
 	assert(PutDashboardInput, "You must provide a PutDashboardInput")
 	local headers = {
@@ -3423,19 +3433,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutDashboardInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutDashboardSync(PutDashboardInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutDashboardAsync(PutDashboardInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutDashboardAsync(PutDashboardInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutMetricData asynchronously, invoking a callback when done
 -- @param PutMetricDataInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutMetricDataAsync(PutMetricDataInput, cb)
 	assert(PutMetricDataInput, "You must provide a PutMetricDataInput")
 	local headers = {
@@ -3458,19 +3469,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutMetricDataInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutMetricDataSync(PutMetricDataInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutMetricDataAsync(PutMetricDataInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutMetricDataAsync(PutMetricDataInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAlarms asynchronously, invoking a callback when done
 -- @param DescribeAlarmsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAlarmsAsync(DescribeAlarmsInput, cb)
 	assert(DescribeAlarmsInput, "You must provide a DescribeAlarmsInput")
 	local headers = {
@@ -3493,19 +3505,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAlarmsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAlarmsSync(DescribeAlarmsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAlarmsAsync(DescribeAlarmsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAlarmsAsync(DescribeAlarmsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDashboard asynchronously, invoking a callback when done
 -- @param GetDashboardInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDashboardAsync(GetDashboardInput, cb)
 	assert(GetDashboardInput, "You must provide a GetDashboardInput")
 	local headers = {
@@ -3528,19 +3541,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDashboardInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDashboardSync(GetDashboardInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDashboardAsync(GetDashboardInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDashboardAsync(GetDashboardInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAlarmsForMetric asynchronously, invoking a callback when done
 -- @param DescribeAlarmsForMetricInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAlarmsForMetricAsync(DescribeAlarmsForMetricInput, cb)
 	assert(DescribeAlarmsForMetricInput, "You must provide a DescribeAlarmsForMetricInput")
 	local headers = {
@@ -3563,19 +3577,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAlarmsForMetricInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAlarmsForMetricSync(DescribeAlarmsForMetricInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAlarmsForMetricAsync(DescribeAlarmsForMetricInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAlarmsForMetricAsync(DescribeAlarmsForMetricInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAlarmHistory asynchronously, invoking a callback when done
 -- @param DescribeAlarmHistoryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAlarmHistoryAsync(DescribeAlarmHistoryInput, cb)
 	assert(DescribeAlarmHistoryInput, "You must provide a DescribeAlarmHistoryInput")
 	local headers = {
@@ -3598,19 +3613,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAlarmHistoryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAlarmHistorySync(DescribeAlarmHistoryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAlarmHistoryAsync(DescribeAlarmHistoryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAlarmHistoryAsync(DescribeAlarmHistoryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMetricWidgetImage asynchronously, invoking a callback when done
 -- @param GetMetricWidgetImageInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMetricWidgetImageAsync(GetMetricWidgetImageInput, cb)
 	assert(GetMetricWidgetImageInput, "You must provide a GetMetricWidgetImageInput")
 	local headers = {
@@ -3633,12 +3649,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMetricWidgetImageInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMetricWidgetImageSync(GetMetricWidgetImageInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMetricWidgetImageAsync(GetMetricWidgetImageInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMetricWidgetImageAsync(GetMetricWidgetImageInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mq.lua
+++ b/aws-sdk/mq.lua
@@ -2548,7 +2548,7 @@ end
 --
 --- Call UpdateUser asynchronously, invoking a callback when done
 -- @param UpdateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserAsync(UpdateUserRequest, cb)
 	assert(UpdateUserRequest, "You must provide a UpdateUserRequest")
 	local headers = {
@@ -2571,19 +2571,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserSync(UpdateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserAsync(UpdateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserAsync(UpdateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBrokers asynchronously, invoking a callback when done
 -- @param ListBrokersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBrokersAsync(ListBrokersRequest, cb)
 	assert(ListBrokersRequest, "You must provide a ListBrokersRequest")
 	local headers = {
@@ -2606,19 +2607,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBrokersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBrokersSync(ListBrokersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBrokersAsync(ListBrokersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBrokersAsync(ListBrokersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -2641,19 +2643,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBroker asynchronously, invoking a callback when done
 -- @param DescribeBrokerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBrokerAsync(DescribeBrokerRequest, cb)
 	assert(DescribeBrokerRequest, "You must provide a DescribeBrokerRequest")
 	local headers = {
@@ -2676,19 +2679,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBrokerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBrokerSync(DescribeBrokerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBrokerAsync(DescribeBrokerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBrokerAsync(DescribeBrokerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateBroker asynchronously, invoking a callback when done
 -- @param UpdateBrokerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateBrokerAsync(UpdateBrokerRequest, cb)
 	assert(UpdateBrokerRequest, "You must provide a UpdateBrokerRequest")
 	local headers = {
@@ -2711,19 +2715,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateBrokerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateBrokerSync(UpdateBrokerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateBrokerAsync(UpdateBrokerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateBrokerAsync(UpdateBrokerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListConfigurations asynchronously, invoking a callback when done
 -- @param ListConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListConfigurationsAsync(ListConfigurationsRequest, cb)
 	assert(ListConfigurationsRequest, "You must provide a ListConfigurationsRequest")
 	local headers = {
@@ -2746,19 +2751,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListConfigurationsSync(ListConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListConfigurationsAsync(ListConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListConfigurationsAsync(ListConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConfiguration asynchronously, invoking a callback when done
 -- @param UpdateConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConfigurationAsync(UpdateConfigurationRequest, cb)
 	assert(UpdateConfigurationRequest, "You must provide a UpdateConfigurationRequest")
 	local headers = {
@@ -2781,19 +2787,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConfigurationSync(UpdateConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConfigurationAsync(UpdateConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConfigurationAsync(UpdateConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUser asynchronously, invoking a callback when done
 -- @param DescribeUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserAsync(DescribeUserRequest, cb)
 	assert(DescribeUserRequest, "You must provide a DescribeUserRequest")
 	local headers = {
@@ -2816,19 +2823,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserSync(DescribeUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserAsync(DescribeUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserAsync(DescribeUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUsers asynchronously, invoking a callback when done
 -- @param ListUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUsersAsync(ListUsersRequest, cb)
 	assert(ListUsersRequest, "You must provide a ListUsersRequest")
 	local headers = {
@@ -2851,19 +2859,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUsersSync(ListUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUsersAsync(ListUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUsersAsync(ListUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfiguration asynchronously, invoking a callback when done
 -- @param DescribeConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationAsync(DescribeConfigurationRequest, cb)
 	assert(DescribeConfigurationRequest, "You must provide a DescribeConfigurationRequest")
 	local headers = {
@@ -2886,19 +2895,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationSync(DescribeConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationAsync(DescribeConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationAsync(DescribeConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConfigurationRevision asynchronously, invoking a callback when done
 -- @param DescribeConfigurationRevisionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConfigurationRevisionAsync(DescribeConfigurationRevisionRequest, cb)
 	assert(DescribeConfigurationRevisionRequest, "You must provide a DescribeConfigurationRevisionRequest")
 	local headers = {
@@ -2921,19 +2931,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConfigurationRevisionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConfigurationRevisionSync(DescribeConfigurationRevisionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConfigurationRevisionAsync(DescribeConfigurationRevisionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConfigurationRevisionAsync(DescribeConfigurationRevisionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUser asynchronously, invoking a callback when done
 -- @param CreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserAsync(CreateUserRequest, cb)
 	assert(CreateUserRequest, "You must provide a CreateUserRequest")
 	local headers = {
@@ -2956,19 +2967,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserSync(CreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserAsync(CreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserAsync(CreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConfiguration asynchronously, invoking a callback when done
 -- @param CreateConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConfigurationAsync(CreateConfigurationRequest, cb)
 	assert(CreateConfigurationRequest, "You must provide a CreateConfigurationRequest")
 	local headers = {
@@ -2991,19 +3003,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConfigurationSync(CreateConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConfigurationAsync(CreateConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConfigurationAsync(CreateConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListConfigurationRevisions asynchronously, invoking a callback when done
 -- @param ListConfigurationRevisionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListConfigurationRevisionsAsync(ListConfigurationRevisionsRequest, cb)
 	assert(ListConfigurationRevisionsRequest, "You must provide a ListConfigurationRevisionsRequest")
 	local headers = {
@@ -3026,19 +3039,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListConfigurationRevisionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListConfigurationRevisionsSync(ListConfigurationRevisionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListConfigurationRevisionsAsync(ListConfigurationRevisionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListConfigurationRevisionsAsync(ListConfigurationRevisionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBroker asynchronously, invoking a callback when done
 -- @param CreateBrokerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBrokerAsync(CreateBrokerRequest, cb)
 	assert(CreateBrokerRequest, "You must provide a CreateBrokerRequest")
 	local headers = {
@@ -3061,19 +3075,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBrokerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBrokerSync(CreateBrokerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBrokerAsync(CreateBrokerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBrokerAsync(CreateBrokerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootBroker asynchronously, invoking a callback when done
 -- @param RebootBrokerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootBrokerAsync(RebootBrokerRequest, cb)
 	assert(RebootBrokerRequest, "You must provide a RebootBrokerRequest")
 	local headers = {
@@ -3096,19 +3111,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootBrokerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootBrokerSync(RebootBrokerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootBrokerAsync(RebootBrokerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootBrokerAsync(RebootBrokerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBroker asynchronously, invoking a callback when done
 -- @param DeleteBrokerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBrokerAsync(DeleteBrokerRequest, cb)
 	assert(DeleteBrokerRequest, "You must provide a DeleteBrokerRequest")
 	local headers = {
@@ -3131,12 +3147,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBrokerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBrokerSync(DeleteBrokerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBrokerAsync(DeleteBrokerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBrokerAsync(DeleteBrokerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/mturk-requester.lua
+++ b/aws-sdk/mturk-requester.lua
@@ -5044,7 +5044,7 @@ end
 --
 --- Call SendBonus asynchronously, invoking a callback when done
 -- @param SendBonusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendBonusAsync(SendBonusRequest, cb)
 	assert(SendBonusRequest, "You must provide a SendBonusRequest")
 	local headers = {
@@ -5067,19 +5067,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendBonusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendBonusSync(SendBonusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendBonusAsync(SendBonusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendBonusAsync(SendBonusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateQualificationWithWorker asynchronously, invoking a callback when done
 -- @param AssociateQualificationWithWorkerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateQualificationWithWorkerAsync(AssociateQualificationWithWorkerRequest, cb)
 	assert(AssociateQualificationWithWorkerRequest, "You must provide a AssociateQualificationWithWorkerRequest")
 	local headers = {
@@ -5102,19 +5103,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateQualificationWithWorkerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateQualificationWithWorkerSync(AssociateQualificationWithWorkerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateQualificationWithWorkerAsync(AssociateQualificationWithWorkerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateQualificationWithWorkerAsync(AssociateQualificationWithWorkerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateHITTypeOfHIT asynchronously, invoking a callback when done
 -- @param UpdateHITTypeOfHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateHITTypeOfHITAsync(UpdateHITTypeOfHITRequest, cb)
 	assert(UpdateHITTypeOfHITRequest, "You must provide a UpdateHITTypeOfHITRequest")
 	local headers = {
@@ -5137,19 +5139,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateHITTypeOfHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateHITTypeOfHITSync(UpdateHITTypeOfHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateHITTypeOfHITAsync(UpdateHITTypeOfHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateHITTypeOfHITAsync(UpdateHITTypeOfHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateNotificationSettings asynchronously, invoking a callback when done
 -- @param UpdateNotificationSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateNotificationSettingsAsync(UpdateNotificationSettingsRequest, cb)
 	assert(UpdateNotificationSettingsRequest, "You must provide a UpdateNotificationSettingsRequest")
 	local headers = {
@@ -5172,19 +5175,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateNotificationSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateNotificationSettingsSync(UpdateNotificationSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateNotificationSettingsAsync(UpdateNotificationSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateNotificationSettingsAsync(UpdateNotificationSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListWorkerBlocks asynchronously, invoking a callback when done
 -- @param ListWorkerBlocksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListWorkerBlocksAsync(ListWorkerBlocksRequest, cb)
 	assert(ListWorkerBlocksRequest, "You must provide a ListWorkerBlocksRequest")
 	local headers = {
@@ -5207,19 +5211,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListWorkerBlocksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListWorkerBlocksSync(ListWorkerBlocksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListWorkerBlocksAsync(ListWorkerBlocksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListWorkerBlocksAsync(ListWorkerBlocksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListReviewableHITs asynchronously, invoking a callback when done
 -- @param ListReviewableHITsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListReviewableHITsAsync(ListReviewableHITsRequest, cb)
 	assert(ListReviewableHITsRequest, "You must provide a ListReviewableHITsRequest")
 	local headers = {
@@ -5242,19 +5247,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListReviewableHITsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListReviewableHITsSync(ListReviewableHITsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListReviewableHITsAsync(ListReviewableHITsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListReviewableHITsAsync(ListReviewableHITsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssignmentsForHIT asynchronously, invoking a callback when done
 -- @param ListAssignmentsForHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssignmentsForHITAsync(ListAssignmentsForHITRequest, cb)
 	assert(ListAssignmentsForHITRequest, "You must provide a ListAssignmentsForHITRequest")
 	local headers = {
@@ -5277,19 +5283,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssignmentsForHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssignmentsForHITSync(ListAssignmentsForHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssignmentsForHITAsync(ListAssignmentsForHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssignmentsForHITAsync(ListAssignmentsForHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateQualificationFromWorker asynchronously, invoking a callback when done
 -- @param DisassociateQualificationFromWorkerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateQualificationFromWorkerAsync(DisassociateQualificationFromWorkerRequest, cb)
 	assert(DisassociateQualificationFromWorkerRequest, "You must provide a DisassociateQualificationFromWorkerRequest")
 	local headers = {
@@ -5312,19 +5319,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateQualificationFromWorkerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateQualificationFromWorkerSync(DisassociateQualificationFromWorkerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateQualificationFromWorkerAsync(DisassociateQualificationFromWorkerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateQualificationFromWorkerAsync(DisassociateQualificationFromWorkerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectQualificationRequest asynchronously, invoking a callback when done
 -- @param RejectQualificationRequestRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectQualificationRequestAsync(RejectQualificationRequestRequest, cb)
 	assert(RejectQualificationRequestRequest, "You must provide a RejectQualificationRequestRequest")
 	local headers = {
@@ -5347,19 +5355,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectQualificationRequestRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectQualificationRequestSync(RejectQualificationRequestRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectQualificationRequestAsync(RejectQualificationRequestRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectQualificationRequestAsync(RejectQualificationRequestRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHITType asynchronously, invoking a callback when done
 -- @param CreateHITTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHITTypeAsync(CreateHITTypeRequest, cb)
 	assert(CreateHITTypeRequest, "You must provide a CreateHITTypeRequest")
 	local headers = {
@@ -5382,19 +5391,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHITTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHITTypeSync(CreateHITTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHITTypeAsync(CreateHITTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHITTypeAsync(CreateHITTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFileUploadURL asynchronously, invoking a callback when done
 -- @param GetFileUploadURLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFileUploadURLAsync(GetFileUploadURLRequest, cb)
 	assert(GetFileUploadURLRequest, "You must provide a GetFileUploadURLRequest")
 	local headers = {
@@ -5417,19 +5427,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFileUploadURLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFileUploadURLSync(GetFileUploadURLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFileUploadURLAsync(GetFileUploadURLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFileUploadURLAsync(GetFileUploadURLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListReviewPolicyResultsForHIT asynchronously, invoking a callback when done
 -- @param ListReviewPolicyResultsForHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListReviewPolicyResultsForHITAsync(ListReviewPolicyResultsForHITRequest, cb)
 	assert(ListReviewPolicyResultsForHITRequest, "You must provide a ListReviewPolicyResultsForHITRequest")
 	local headers = {
@@ -5452,19 +5463,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListReviewPolicyResultsForHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListReviewPolicyResultsForHITSync(ListReviewPolicyResultsForHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListReviewPolicyResultsForHITAsync(ListReviewPolicyResultsForHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListReviewPolicyResultsForHITAsync(ListReviewPolicyResultsForHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateExpirationForHIT asynchronously, invoking a callback when done
 -- @param UpdateExpirationForHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateExpirationForHITAsync(UpdateExpirationForHITRequest, cb)
 	assert(UpdateExpirationForHITRequest, "You must provide a UpdateExpirationForHITRequest")
 	local headers = {
@@ -5487,19 +5499,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateExpirationForHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateExpirationForHITSync(UpdateExpirationForHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateExpirationForHITAsync(UpdateExpirationForHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateExpirationForHITAsync(UpdateExpirationForHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateQualificationType asynchronously, invoking a callback when done
 -- @param UpdateQualificationTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateQualificationTypeAsync(UpdateQualificationTypeRequest, cb)
 	assert(UpdateQualificationTypeRequest, "You must provide a UpdateQualificationTypeRequest")
 	local headers = {
@@ -5522,19 +5535,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateQualificationTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateQualificationTypeSync(UpdateQualificationTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateQualificationTypeAsync(UpdateQualificationTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateQualificationTypeAsync(UpdateQualificationTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call NotifyWorkers asynchronously, invoking a callback when done
 -- @param NotifyWorkersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.NotifyWorkersAsync(NotifyWorkersRequest, cb)
 	assert(NotifyWorkersRequest, "You must provide a NotifyWorkersRequest")
 	local headers = {
@@ -5557,19 +5571,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param NotifyWorkersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.NotifyWorkersSync(NotifyWorkersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.NotifyWorkersAsync(NotifyWorkersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.NotifyWorkersAsync(NotifyWorkersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListQualificationTypes asynchronously, invoking a callback when done
 -- @param ListQualificationTypesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListQualificationTypesAsync(ListQualificationTypesRequest, cb)
 	assert(ListQualificationTypesRequest, "You must provide a ListQualificationTypesRequest")
 	local headers = {
@@ -5592,19 +5607,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListQualificationTypesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListQualificationTypesSync(ListQualificationTypesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListQualificationTypesAsync(ListQualificationTypesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListQualificationTypesAsync(ListQualificationTypesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHIT asynchronously, invoking a callback when done
 -- @param CreateHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHITAsync(CreateHITRequest, cb)
 	assert(CreateHITRequest, "You must provide a CreateHITRequest")
 	local headers = {
@@ -5627,19 +5643,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHITSync(CreateHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHITAsync(CreateHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHITAsync(CreateHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHITsForQualificationType asynchronously, invoking a callback when done
 -- @param ListHITsForQualificationTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHITsForQualificationTypeAsync(ListHITsForQualificationTypeRequest, cb)
 	assert(ListHITsForQualificationTypeRequest, "You must provide a ListHITsForQualificationTypeRequest")
 	local headers = {
@@ -5662,19 +5679,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHITsForQualificationTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHITsForQualificationTypeSync(ListHITsForQualificationTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHITsForQualificationTypeAsync(ListHITsForQualificationTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHITsForQualificationTypeAsync(ListHITsForQualificationTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptQualificationRequest asynchronously, invoking a callback when done
 -- @param AcceptQualificationRequestRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptQualificationRequestAsync(AcceptQualificationRequestRequest, cb)
 	assert(AcceptQualificationRequestRequest, "You must provide a AcceptQualificationRequestRequest")
 	local headers = {
@@ -5697,19 +5715,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptQualificationRequestRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptQualificationRequestSync(AcceptQualificationRequestRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptQualificationRequestAsync(AcceptQualificationRequestRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptQualificationRequestAsync(AcceptQualificationRequestRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListQualificationRequests asynchronously, invoking a callback when done
 -- @param ListQualificationRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListQualificationRequestsAsync(ListQualificationRequestsRequest, cb)
 	assert(ListQualificationRequestsRequest, "You must provide a ListQualificationRequestsRequest")
 	local headers = {
@@ -5732,19 +5751,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListQualificationRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListQualificationRequestsSync(ListQualificationRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListQualificationRequestsAsync(ListQualificationRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListQualificationRequestsAsync(ListQualificationRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateHITReviewStatus asynchronously, invoking a callback when done
 -- @param UpdateHITReviewStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateHITReviewStatusAsync(UpdateHITReviewStatusRequest, cb)
 	assert(UpdateHITReviewStatusRequest, "You must provide a UpdateHITReviewStatusRequest")
 	local headers = {
@@ -5767,19 +5787,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateHITReviewStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateHITReviewStatusSync(UpdateHITReviewStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateHITReviewStatusAsync(UpdateHITReviewStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateHITReviewStatusAsync(UpdateHITReviewStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHITs asynchronously, invoking a callback when done
 -- @param ListHITsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHITsAsync(ListHITsRequest, cb)
 	assert(ListHITsRequest, "You must provide a ListHITsRequest")
 	local headers = {
@@ -5802,19 +5823,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHITsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHITsSync(ListHITsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHITsAsync(ListHITsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHITsAsync(ListHITsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListWorkersWithQualificationType asynchronously, invoking a callback when done
 -- @param ListWorkersWithQualificationTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListWorkersWithQualificationTypeAsync(ListWorkersWithQualificationTypeRequest, cb)
 	assert(ListWorkersWithQualificationTypeRequest, "You must provide a ListWorkersWithQualificationTypeRequest")
 	local headers = {
@@ -5837,19 +5859,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListWorkersWithQualificationTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListWorkersWithQualificationTypeSync(ListWorkersWithQualificationTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListWorkersWithQualificationTypeAsync(ListWorkersWithQualificationTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListWorkersWithQualificationTypeAsync(ListWorkersWithQualificationTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountBalance asynchronously, invoking a callback when done
 -- @param GetAccountBalanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountBalanceAsync(GetAccountBalanceRequest, cb)
 	assert(GetAccountBalanceRequest, "You must provide a GetAccountBalanceRequest")
 	local headers = {
@@ -5872,19 +5895,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountBalanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountBalanceSync(GetAccountBalanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountBalanceAsync(GetAccountBalanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountBalanceAsync(GetAccountBalanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteQualificationType asynchronously, invoking a callback when done
 -- @param DeleteQualificationTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteQualificationTypeAsync(DeleteQualificationTypeRequest, cb)
 	assert(DeleteQualificationTypeRequest, "You must provide a DeleteQualificationTypeRequest")
 	local headers = {
@@ -5907,19 +5931,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteQualificationTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteQualificationTypeSync(DeleteQualificationTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteQualificationTypeAsync(DeleteQualificationTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteQualificationTypeAsync(DeleteQualificationTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendTestEventNotification asynchronously, invoking a callback when done
 -- @param SendTestEventNotificationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendTestEventNotificationAsync(SendTestEventNotificationRequest, cb)
 	assert(SendTestEventNotificationRequest, "You must provide a SendTestEventNotificationRequest")
 	local headers = {
@@ -5942,19 +5967,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendTestEventNotificationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendTestEventNotificationSync(SendTestEventNotificationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendTestEventNotificationAsync(SendTestEventNotificationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendTestEventNotificationAsync(SendTestEventNotificationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHITWithHITType asynchronously, invoking a callback when done
 -- @param CreateHITWithHITTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHITWithHITTypeAsync(CreateHITWithHITTypeRequest, cb)
 	assert(CreateHITWithHITTypeRequest, "You must provide a CreateHITWithHITTypeRequest")
 	local headers = {
@@ -5977,19 +6003,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHITWithHITTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHITWithHITTypeSync(CreateHITWithHITTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHITWithHITTypeAsync(CreateHITWithHITTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHITWithHITTypeAsync(CreateHITWithHITTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateWorkerBlock asynchronously, invoking a callback when done
 -- @param CreateWorkerBlockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateWorkerBlockAsync(CreateWorkerBlockRequest, cb)
 	assert(CreateWorkerBlockRequest, "You must provide a CreateWorkerBlockRequest")
 	local headers = {
@@ -6012,19 +6039,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateWorkerBlockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateWorkerBlockSync(CreateWorkerBlockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateWorkerBlockAsync(CreateWorkerBlockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateWorkerBlockAsync(CreateWorkerBlockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ApproveAssignment asynchronously, invoking a callback when done
 -- @param ApproveAssignmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ApproveAssignmentAsync(ApproveAssignmentRequest, cb)
 	assert(ApproveAssignmentRequest, "You must provide a ApproveAssignmentRequest")
 	local headers = {
@@ -6047,19 +6075,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ApproveAssignmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ApproveAssignmentSync(ApproveAssignmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ApproveAssignmentAsync(ApproveAssignmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ApproveAssignmentAsync(ApproveAssignmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBonusPayments asynchronously, invoking a callback when done
 -- @param ListBonusPaymentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBonusPaymentsAsync(ListBonusPaymentsRequest, cb)
 	assert(ListBonusPaymentsRequest, "You must provide a ListBonusPaymentsRequest")
 	local headers = {
@@ -6082,19 +6111,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBonusPaymentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBonusPaymentsSync(ListBonusPaymentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBonusPaymentsAsync(ListBonusPaymentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBonusPaymentsAsync(ListBonusPaymentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHIT asynchronously, invoking a callback when done
 -- @param DeleteHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHITAsync(DeleteHITRequest, cb)
 	assert(DeleteHITRequest, "You must provide a DeleteHITRequest")
 	local headers = {
@@ -6117,19 +6147,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHITSync(DeleteHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHITAsync(DeleteHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHITAsync(DeleteHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQualificationScore asynchronously, invoking a callback when done
 -- @param GetQualificationScoreRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQualificationScoreAsync(GetQualificationScoreRequest, cb)
 	assert(GetQualificationScoreRequest, "You must provide a GetQualificationScoreRequest")
 	local headers = {
@@ -6152,19 +6183,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQualificationScoreRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQualificationScoreSync(GetQualificationScoreRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQualificationScoreAsync(GetQualificationScoreRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQualificationScoreAsync(GetQualificationScoreRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteWorkerBlock asynchronously, invoking a callback when done
 -- @param DeleteWorkerBlockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteWorkerBlockAsync(DeleteWorkerBlockRequest, cb)
 	assert(DeleteWorkerBlockRequest, "You must provide a DeleteWorkerBlockRequest")
 	local headers = {
@@ -6187,19 +6219,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteWorkerBlockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteWorkerBlockSync(DeleteWorkerBlockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteWorkerBlockAsync(DeleteWorkerBlockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteWorkerBlockAsync(DeleteWorkerBlockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQualificationType asynchronously, invoking a callback when done
 -- @param GetQualificationTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQualificationTypeAsync(GetQualificationTypeRequest, cb)
 	assert(GetQualificationTypeRequest, "You must provide a GetQualificationTypeRequest")
 	local headers = {
@@ -6222,19 +6255,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQualificationTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQualificationTypeSync(GetQualificationTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQualificationTypeAsync(GetQualificationTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQualificationTypeAsync(GetQualificationTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectAssignment asynchronously, invoking a callback when done
 -- @param RejectAssignmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectAssignmentAsync(RejectAssignmentRequest, cb)
 	assert(RejectAssignmentRequest, "You must provide a RejectAssignmentRequest")
 	local headers = {
@@ -6257,19 +6291,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectAssignmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectAssignmentSync(RejectAssignmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectAssignmentAsync(RejectAssignmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectAssignmentAsync(RejectAssignmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateQualificationType asynchronously, invoking a callback when done
 -- @param CreateQualificationTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateQualificationTypeAsync(CreateQualificationTypeRequest, cb)
 	assert(CreateQualificationTypeRequest, "You must provide a CreateQualificationTypeRequest")
 	local headers = {
@@ -6292,19 +6327,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateQualificationTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateQualificationTypeSync(CreateQualificationTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateQualificationTypeAsync(CreateQualificationTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateQualificationTypeAsync(CreateQualificationTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAssignment asynchronously, invoking a callback when done
 -- @param GetAssignmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAssignmentAsync(GetAssignmentRequest, cb)
 	assert(GetAssignmentRequest, "You must provide a GetAssignmentRequest")
 	local headers = {
@@ -6327,19 +6363,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAssignmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAssignmentSync(GetAssignmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAssignmentAsync(GetAssignmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAssignmentAsync(GetAssignmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHIT asynchronously, invoking a callback when done
 -- @param GetHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHITAsync(GetHITRequest, cb)
 	assert(GetHITRequest, "You must provide a GetHITRequest")
 	local headers = {
@@ -6362,19 +6399,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHITSync(GetHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHITAsync(GetHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHITAsync(GetHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAdditionalAssignmentsForHIT asynchronously, invoking a callback when done
 -- @param CreateAdditionalAssignmentsForHITRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAdditionalAssignmentsForHITAsync(CreateAdditionalAssignmentsForHITRequest, cb)
 	assert(CreateAdditionalAssignmentsForHITRequest, "You must provide a CreateAdditionalAssignmentsForHITRequest")
 	local headers = {
@@ -6397,12 +6435,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAdditionalAssignmentsForHITRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAdditionalAssignmentsForHITSync(CreateAdditionalAssignmentsForHITRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAdditionalAssignmentsForHITAsync(CreateAdditionalAssignmentsForHITRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAdditionalAssignmentsForHITAsync(CreateAdditionalAssignmentsForHITRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/opsworks-cm.lua
+++ b/aws-sdk/opsworks-cm.lua
@@ -2119,7 +2119,7 @@ end
 --
 --- Call DescribeServers asynchronously, invoking a callback when done
 -- @param DescribeServersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeServersAsync(DescribeServersRequest, cb)
 	assert(DescribeServersRequest, "You must provide a DescribeServersRequest")
 	local headers = {
@@ -2142,19 +2142,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeServersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeServersSync(DescribeServersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeServersAsync(DescribeServersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeServersAsync(DescribeServersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNodeAssociationStatus asynchronously, invoking a callback when done
 -- @param DescribeNodeAssociationStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNodeAssociationStatusAsync(DescribeNodeAssociationStatusRequest, cb)
 	assert(DescribeNodeAssociationStatusRequest, "You must provide a DescribeNodeAssociationStatusRequest")
 	local headers = {
@@ -2177,19 +2178,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNodeAssociationStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNodeAssociationStatusSync(DescribeNodeAssociationStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNodeAssociationStatusAsync(DescribeNodeAssociationStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNodeAssociationStatusAsync(DescribeNodeAssociationStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteServer asynchronously, invoking a callback when done
 -- @param DeleteServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServerAsync(DeleteServerRequest, cb)
 	assert(DeleteServerRequest, "You must provide a DeleteServerRequest")
 	local headers = {
@@ -2212,19 +2214,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServerSync(DeleteServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServerAsync(DeleteServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServerAsync(DeleteServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBackups asynchronously, invoking a callback when done
 -- @param DescribeBackupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBackupsAsync(DescribeBackupsRequest, cb)
 	assert(DescribeBackupsRequest, "You must provide a DescribeBackupsRequest")
 	local headers = {
@@ -2247,19 +2250,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBackupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBackupsSync(DescribeBackupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBackupsAsync(DescribeBackupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBackupsAsync(DescribeBackupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreServer asynchronously, invoking a callback when done
 -- @param RestoreServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreServerAsync(RestoreServerRequest, cb)
 	assert(RestoreServerRequest, "You must provide a RestoreServerRequest")
 	local headers = {
@@ -2282,19 +2286,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreServerSync(RestoreServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreServerAsync(RestoreServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreServerAsync(RestoreServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateServerEngineAttributes asynchronously, invoking a callback when done
 -- @param UpdateServerEngineAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServerEngineAttributesAsync(UpdateServerEngineAttributesRequest, cb)
 	assert(UpdateServerEngineAttributesRequest, "You must provide a UpdateServerEngineAttributesRequest")
 	local headers = {
@@ -2317,19 +2322,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServerEngineAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServerEngineAttributesSync(UpdateServerEngineAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServerEngineAttributesAsync(UpdateServerEngineAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServerEngineAttributesAsync(UpdateServerEngineAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ExportServerEngineAttribute asynchronously, invoking a callback when done
 -- @param ExportServerEngineAttributeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExportServerEngineAttributeAsync(ExportServerEngineAttributeRequest, cb)
 	assert(ExportServerEngineAttributeRequest, "You must provide a ExportServerEngineAttributeRequest")
 	local headers = {
@@ -2352,19 +2358,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExportServerEngineAttributeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExportServerEngineAttributeSync(ExportServerEngineAttributeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExportServerEngineAttributeAsync(ExportServerEngineAttributeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExportServerEngineAttributeAsync(ExportServerEngineAttributeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountAttributes asynchronously, invoking a callback when done
 -- @param DescribeAccountAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountAttributesAsync(DescribeAccountAttributesRequest, cb)
 	assert(DescribeAccountAttributesRequest, "You must provide a DescribeAccountAttributesRequest")
 	local headers = {
@@ -2387,19 +2394,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountAttributesSync(DescribeAccountAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountAttributesAsync(DescribeAccountAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountAttributesAsync(DescribeAccountAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsRequest, cb)
 	assert(DescribeEventsRequest, "You must provide a DescribeEventsRequest")
 	local headers = {
@@ -2422,19 +2430,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBackup asynchronously, invoking a callback when done
 -- @param DeleteBackupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBackupAsync(DeleteBackupRequest, cb)
 	assert(DeleteBackupRequest, "You must provide a DeleteBackupRequest")
 	local headers = {
@@ -2457,19 +2466,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBackupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBackupSync(DeleteBackupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBackupAsync(DeleteBackupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBackupAsync(DeleteBackupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateServer asynchronously, invoking a callback when done
 -- @param CreateServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateServerAsync(CreateServerRequest, cb)
 	assert(CreateServerRequest, "You must provide a CreateServerRequest")
 	local headers = {
@@ -2492,19 +2502,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateServerSync(CreateServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateServerAsync(CreateServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateServerAsync(CreateServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBackup asynchronously, invoking a callback when done
 -- @param CreateBackupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBackupAsync(CreateBackupRequest, cb)
 	assert(CreateBackupRequest, "You must provide a CreateBackupRequest")
 	local headers = {
@@ -2527,19 +2538,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBackupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBackupSync(CreateBackupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBackupAsync(CreateBackupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBackupAsync(CreateBackupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartMaintenance asynchronously, invoking a callback when done
 -- @param StartMaintenanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartMaintenanceAsync(StartMaintenanceRequest, cb)
 	assert(StartMaintenanceRequest, "You must provide a StartMaintenanceRequest")
 	local headers = {
@@ -2562,19 +2574,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartMaintenanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartMaintenanceSync(StartMaintenanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartMaintenanceAsync(StartMaintenanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartMaintenanceAsync(StartMaintenanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateServer asynchronously, invoking a callback when done
 -- @param UpdateServerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServerAsync(UpdateServerRequest, cb)
 	assert(UpdateServerRequest, "You must provide a UpdateServerRequest")
 	local headers = {
@@ -2597,19 +2610,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServerSync(UpdateServerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServerAsync(UpdateServerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServerAsync(UpdateServerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateNode asynchronously, invoking a callback when done
 -- @param AssociateNodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateNodeAsync(AssociateNodeRequest, cb)
 	assert(AssociateNodeRequest, "You must provide a AssociateNodeRequest")
 	local headers = {
@@ -2632,19 +2646,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateNodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateNodeSync(AssociateNodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateNodeAsync(AssociateNodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateNodeAsync(AssociateNodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateNode asynchronously, invoking a callback when done
 -- @param DisassociateNodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateNodeAsync(DisassociateNodeRequest, cb)
 	assert(DisassociateNodeRequest, "You must provide a DisassociateNodeRequest")
 	local headers = {
@@ -2667,12 +2682,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateNodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateNodeSync(DisassociateNodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateNodeAsync(DisassociateNodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateNodeAsync(DisassociateNodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/opsworks.lua
+++ b/aws-sdk/opsworks.lua
@@ -8204,7 +8204,7 @@ end
 --
 --- Call DeregisterVolume asynchronously, invoking a callback when done
 -- @param DeregisterVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterVolumeAsync(DeregisterVolumeRequest, cb)
 	assert(DeregisterVolumeRequest, "You must provide a DeregisterVolumeRequest")
 	local headers = {
@@ -8227,19 +8227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterVolumeSync(DeregisterVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterVolumeAsync(DeregisterVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterVolumeAsync(DeregisterVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterInstance asynchronously, invoking a callback when done
 -- @param DeregisterInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterInstanceAsync(DeregisterInstanceRequest, cb)
 	assert(DeregisterInstanceRequest, "You must provide a DeregisterInstanceRequest")
 	local headers = {
@@ -8262,19 +8263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterInstanceSync(DeregisterInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterInstanceAsync(DeregisterInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterInstanceAsync(DeregisterInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTimeBasedAutoScaling asynchronously, invoking a callback when done
 -- @param DescribeTimeBasedAutoScalingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTimeBasedAutoScalingAsync(DescribeTimeBasedAutoScalingRequest, cb)
 	assert(DescribeTimeBasedAutoScalingRequest, "You must provide a DescribeTimeBasedAutoScalingRequest")
 	local headers = {
@@ -8297,19 +8299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTimeBasedAutoScalingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTimeBasedAutoScalingSync(DescribeTimeBasedAutoScalingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTimeBasedAutoScalingAsync(DescribeTimeBasedAutoScalingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTimeBasedAutoScalingAsync(DescribeTimeBasedAutoScalingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootInstance asynchronously, invoking a callback when done
 -- @param RebootInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootInstanceAsync(RebootInstanceRequest, cb)
 	assert(RebootInstanceRequest, "You must provide a RebootInstanceRequest")
 	local headers = {
@@ -8332,19 +8335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootInstanceSync(RebootInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootInstanceAsync(RebootInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootInstanceAsync(RebootInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartStack asynchronously, invoking a callback when done
 -- @param StartStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartStackAsync(StartStackRequest, cb)
 	assert(StartStackRequest, "You must provide a StartStackRequest")
 	local headers = {
@@ -8367,19 +8371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartStackSync(StartStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartStackAsync(StartStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartStackAsync(StartStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnassignInstance asynchronously, invoking a callback when done
 -- @param UnassignInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnassignInstanceAsync(UnassignInstanceRequest, cb)
 	assert(UnassignInstanceRequest, "You must provide a UnassignInstanceRequest")
 	local headers = {
@@ -8402,19 +8407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnassignInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnassignInstanceSync(UnassignInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnassignInstanceAsync(UnassignInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnassignInstanceAsync(UnassignInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateElasticIp asynchronously, invoking a callback when done
 -- @param DisassociateElasticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateElasticIpAsync(DisassociateElasticIpRequest, cb)
 	assert(DisassociateElasticIpRequest, "You must provide a DisassociateElasticIpRequest")
 	local headers = {
@@ -8437,19 +8443,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateElasticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateElasticIpSync(DisassociateElasticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateElasticIpAsync(DisassociateElasticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateElasticIpAsync(DisassociateElasticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUserProfile asynchronously, invoking a callback when done
 -- @param CreateUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserProfileAsync(CreateUserProfileRequest, cb)
 	assert(CreateUserProfileRequest, "You must provide a CreateUserProfileRequest")
 	local headers = {
@@ -8472,19 +8479,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserProfileSync(CreateUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserProfileAsync(CreateUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserProfileAsync(CreateUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachElasticLoadBalancer asynchronously, invoking a callback when done
 -- @param AttachElasticLoadBalancerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachElasticLoadBalancerAsync(AttachElasticLoadBalancerRequest, cb)
 	assert(AttachElasticLoadBalancerRequest, "You must provide a AttachElasticLoadBalancerRequest")
 	local headers = {
@@ -8507,19 +8515,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachElasticLoadBalancerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachElasticLoadBalancerSync(AttachElasticLoadBalancerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachElasticLoadBalancerAsync(AttachElasticLoadBalancerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachElasticLoadBalancerAsync(AttachElasticLoadBalancerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterEcsCluster asynchronously, invoking a callback when done
 -- @param RegisterEcsClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterEcsClusterAsync(RegisterEcsClusterRequest, cb)
 	assert(RegisterEcsClusterRequest, "You must provide a RegisterEcsClusterRequest")
 	local headers = {
@@ -8542,19 +8551,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterEcsClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterEcsClusterSync(RegisterEcsClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterEcsClusterAsync(RegisterEcsClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterEcsClusterAsync(RegisterEcsClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLayers asynchronously, invoking a callback when done
 -- @param DescribeLayersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLayersAsync(DescribeLayersRequest, cb)
 	assert(DescribeLayersRequest, "You must provide a DescribeLayersRequest")
 	local headers = {
@@ -8577,19 +8587,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLayersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLayersSync(DescribeLayersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLayersAsync(DescribeLayersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLayersAsync(DescribeLayersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateElasticIp asynchronously, invoking a callback when done
 -- @param UpdateElasticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateElasticIpAsync(UpdateElasticIpRequest, cb)
 	assert(UpdateElasticIpRequest, "You must provide a UpdateElasticIpRequest")
 	local headers = {
@@ -8612,19 +8623,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateElasticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateElasticIpSync(UpdateElasticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateElasticIpAsync(UpdateElasticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateElasticIpAsync(UpdateElasticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInstance asynchronously, invoking a callback when done
 -- @param DeleteInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInstanceAsync(DeleteInstanceRequest, cb)
 	assert(DeleteInstanceRequest, "You must provide a DeleteInstanceRequest")
 	local headers = {
@@ -8647,19 +8659,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInstanceSync(DeleteInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInstanceAsync(DeleteInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInstanceAsync(DeleteInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachElasticLoadBalancer asynchronously, invoking a callback when done
 -- @param DetachElasticLoadBalancerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachElasticLoadBalancerAsync(DetachElasticLoadBalancerRequest, cb)
 	assert(DetachElasticLoadBalancerRequest, "You must provide a DetachElasticLoadBalancerRequest")
 	local headers = {
@@ -8682,19 +8695,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachElasticLoadBalancerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachElasticLoadBalancerSync(DetachElasticLoadBalancerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachElasticLoadBalancerAsync(DetachElasticLoadBalancerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachElasticLoadBalancerAsync(DetachElasticLoadBalancerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDeployment asynchronously, invoking a callback when done
 -- @param CreateDeploymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDeploymentAsync(CreateDeploymentRequest, cb)
 	assert(CreateDeploymentRequest, "You must provide a CreateDeploymentRequest")
 	local headers = {
@@ -8717,19 +8731,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDeploymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDeploymentSync(CreateDeploymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDeploymentAsync(CreateDeploymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDeploymentAsync(CreateDeploymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UnassignVolume asynchronously, invoking a callback when done
 -- @param UnassignVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnassignVolumeAsync(UnassignVolumeRequest, cb)
 	assert(UnassignVolumeRequest, "You must provide a UnassignVolumeRequest")
 	local headers = {
@@ -8752,19 +8767,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnassignVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnassignVolumeSync(UnassignVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnassignVolumeAsync(UnassignVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnassignVolumeAsync(UnassignVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserProfile asynchronously, invoking a callback when done
 -- @param DeleteUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserProfileAsync(DeleteUserProfileRequest, cb)
 	assert(DeleteUserProfileRequest, "You must provide a DeleteUserProfileRequest")
 	local headers = {
@@ -8787,19 +8803,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserProfileSync(DeleteUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserProfileAsync(DeleteUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserProfileAsync(DeleteUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStack asynchronously, invoking a callback when done
 -- @param CreateStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStackAsync(CreateStackRequest, cb)
 	assert(CreateStackRequest, "You must provide a CreateStackRequest")
 	local headers = {
@@ -8822,19 +8839,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStackSync(CreateStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStackAsync(CreateStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStackAsync(CreateStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRdsDbInstance asynchronously, invoking a callback when done
 -- @param UpdateRdsDbInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRdsDbInstanceAsync(UpdateRdsDbInstanceRequest, cb)
 	assert(UpdateRdsDbInstanceRequest, "You must provide a UpdateRdsDbInstanceRequest")
 	local headers = {
@@ -8857,19 +8875,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRdsDbInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRdsDbInstanceSync(UpdateRdsDbInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRdsDbInstanceAsync(UpdateRdsDbInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRdsDbInstanceAsync(UpdateRdsDbInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHostnameSuggestion asynchronously, invoking a callback when done
 -- @param GetHostnameSuggestionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHostnameSuggestionAsync(GetHostnameSuggestionRequest, cb)
 	assert(GetHostnameSuggestionRequest, "You must provide a GetHostnameSuggestionRequest")
 	local headers = {
@@ -8892,19 +8911,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHostnameSuggestionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHostnameSuggestionSync(GetHostnameSuggestionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHostnameSuggestionAsync(GetHostnameSuggestionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHostnameSuggestionAsync(GetHostnameSuggestionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstances asynchronously, invoking a callback when done
 -- @param DescribeInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstancesAsync(DescribeInstancesRequest, cb)
 	assert(DescribeInstancesRequest, "You must provide a DescribeInstancesRequest")
 	local headers = {
@@ -8927,19 +8947,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstancesSync(DescribeInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstancesAsync(DescribeInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstancesAsync(DescribeInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCommands asynchronously, invoking a callback when done
 -- @param DescribeCommandsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCommandsAsync(DescribeCommandsRequest, cb)
 	assert(DescribeCommandsRequest, "You must provide a DescribeCommandsRequest")
 	local headers = {
@@ -8962,18 +8983,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCommandsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCommandsSync(DescribeCommandsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCommandsAsync(DescribeCommandsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCommandsAsync(DescribeCommandsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMyUserProfile asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMyUserProfileAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -8992,19 +9014,20 @@ end
 --- Call DescribeMyUserProfile synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMyUserProfileSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMyUserProfileAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMyUserProfileAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterElasticIp asynchronously, invoking a callback when done
 -- @param DeregisterElasticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterElasticIpAsync(DeregisterElasticIpRequest, cb)
 	assert(DeregisterElasticIpRequest, "You must provide a DeregisterElasticIpRequest")
 	local headers = {
@@ -9027,19 +9050,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterElasticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterElasticIpSync(DeregisterElasticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterElasticIpAsync(DeregisterElasticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterElasticIpAsync(DeregisterElasticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAgentVersions asynchronously, invoking a callback when done
 -- @param DescribeAgentVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAgentVersionsAsync(DescribeAgentVersionsRequest, cb)
 	assert(DescribeAgentVersionsRequest, "You must provide a DescribeAgentVersionsRequest")
 	local headers = {
@@ -9062,19 +9086,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAgentVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAgentVersionsSync(DescribeAgentVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAgentVersionsAsync(DescribeAgentVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAgentVersionsAsync(DescribeAgentVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopStack asynchronously, invoking a callback when done
 -- @param StopStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopStackAsync(StopStackRequest, cb)
 	assert(StopStackRequest, "You must provide a StopStackRequest")
 	local headers = {
@@ -9097,19 +9122,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopStackSync(StopStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopStackAsync(StopStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopStackAsync(StopStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeApps asynchronously, invoking a callback when done
 -- @param DescribeAppsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAppsAsync(DescribeAppsRequest, cb)
 	assert(DescribeAppsRequest, "You must provide a DescribeAppsRequest")
 	local headers = {
@@ -9132,19 +9158,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAppsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAppsSync(DescribeAppsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAppsAsync(DescribeAppsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAppsAsync(DescribeAppsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeElasticIps asynchronously, invoking a callback when done
 -- @param DescribeElasticIpsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeElasticIpsAsync(DescribeElasticIpsRequest, cb)
 	assert(DescribeElasticIpsRequest, "You must provide a DescribeElasticIpsRequest")
 	local headers = {
@@ -9167,19 +9194,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeElasticIpsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeElasticIpsSync(DescribeElasticIpsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeElasticIpsAsync(DescribeElasticIpsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeElasticIpsAsync(DescribeElasticIpsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateVolume asynchronously, invoking a callback when done
 -- @param UpdateVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateVolumeAsync(UpdateVolumeRequest, cb)
 	assert(UpdateVolumeRequest, "You must provide a UpdateVolumeRequest")
 	local headers = {
@@ -9202,19 +9230,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateVolumeSync(UpdateVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateVolumeAsync(UpdateVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateVolumeAsync(UpdateVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartInstance asynchronously, invoking a callback when done
 -- @param StartInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartInstanceAsync(StartInstanceRequest, cb)
 	assert(StartInstanceRequest, "You must provide a StartInstanceRequest")
 	local headers = {
@@ -9237,19 +9266,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartInstanceSync(StartInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartInstanceAsync(StartInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartInstanceAsync(StartInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMyUserProfile asynchronously, invoking a callback when done
 -- @param UpdateMyUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMyUserProfileAsync(UpdateMyUserProfileRequest, cb)
 	assert(UpdateMyUserProfileRequest, "You must provide a UpdateMyUserProfileRequest")
 	local headers = {
@@ -9272,19 +9302,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMyUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMyUserProfileSync(UpdateMyUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMyUserProfileAsync(UpdateMyUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMyUserProfileAsync(UpdateMyUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApp asynchronously, invoking a callback when done
 -- @param DeleteAppRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAppAsync(DeleteAppRequest, cb)
 	assert(DeleteAppRequest, "You must provide a DeleteAppRequest")
 	local headers = {
@@ -9307,19 +9338,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAppRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAppSync(DeleteAppRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAppAsync(DeleteAppRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAppAsync(DeleteAppRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateInstance asynchronously, invoking a callback when done
 -- @param UpdateInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateInstanceAsync(UpdateInstanceRequest, cb)
 	assert(UpdateInstanceRequest, "You must provide a UpdateInstanceRequest")
 	local headers = {
@@ -9342,19 +9374,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateInstanceSync(UpdateInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateInstanceAsync(UpdateInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateInstanceAsync(UpdateInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterElasticIp asynchronously, invoking a callback when done
 -- @param RegisterElasticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterElasticIpAsync(RegisterElasticIpRequest, cb)
 	assert(RegisterElasticIpRequest, "You must provide a RegisterElasticIpRequest")
 	local headers = {
@@ -9377,19 +9410,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterElasticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterElasticIpSync(RegisterElasticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterElasticIpAsync(RegisterElasticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterElasticIpAsync(RegisterElasticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -9412,19 +9446,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterRdsDbInstance asynchronously, invoking a callback when done
 -- @param DeregisterRdsDbInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterRdsDbInstanceAsync(DeregisterRdsDbInstanceRequest, cb)
 	assert(DeregisterRdsDbInstanceRequest, "You must provide a DeregisterRdsDbInstanceRequest")
 	local headers = {
@@ -9447,19 +9482,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterRdsDbInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterRdsDbInstanceSync(DeregisterRdsDbInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterRdsDbInstanceAsync(DeregisterRdsDbInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterRdsDbInstanceAsync(DeregisterRdsDbInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRaidArrays asynchronously, invoking a callback when done
 -- @param DescribeRaidArraysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRaidArraysAsync(DescribeRaidArraysRequest, cb)
 	assert(DescribeRaidArraysRequest, "You must provide a DescribeRaidArraysRequest")
 	local headers = {
@@ -9482,19 +9518,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRaidArraysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRaidArraysSync(DescribeRaidArraysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRaidArraysAsync(DescribeRaidArraysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRaidArraysAsync(DescribeRaidArraysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterVolume asynchronously, invoking a callback when done
 -- @param RegisterVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterVolumeAsync(RegisterVolumeRequest, cb)
 	assert(RegisterVolumeRequest, "You must provide a RegisterVolumeRequest")
 	local headers = {
@@ -9517,19 +9554,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterVolumeSync(RegisterVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterVolumeAsync(RegisterVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterVolumeAsync(RegisterVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetPermission asynchronously, invoking a callback when done
 -- @param SetPermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetPermissionAsync(SetPermissionRequest, cb)
 	assert(SetPermissionRequest, "You must provide a SetPermissionRequest")
 	local headers = {
@@ -9552,19 +9590,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetPermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetPermissionSync(SetPermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetPermissionAsync(SetPermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetPermissionAsync(SetPermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDeployments asynchronously, invoking a callback when done
 -- @param DescribeDeploymentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDeploymentsAsync(DescribeDeploymentsRequest, cb)
 	assert(DescribeDeploymentsRequest, "You must provide a DescribeDeploymentsRequest")
 	local headers = {
@@ -9587,19 +9626,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDeploymentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDeploymentsSync(DescribeDeploymentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDeploymentsAsync(DescribeDeploymentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDeploymentsAsync(DescribeDeploymentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTags asynchronously, invoking a callback when done
 -- @param ListTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsAsync(ListTagsRequest, cb)
 	assert(ListTagsRequest, "You must provide a ListTagsRequest")
 	local headers = {
@@ -9622,19 +9662,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsSync(ListTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsAsync(ListTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsAsync(ListTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CloneStack asynchronously, invoking a callback when done
 -- @param CloneStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CloneStackAsync(CloneStackRequest, cb)
 	assert(CloneStackRequest, "You must provide a CloneStackRequest")
 	local headers = {
@@ -9657,19 +9698,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CloneStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CloneStackSync(CloneStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CloneStackAsync(CloneStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CloneStackAsync(CloneStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeServiceErrors asynchronously, invoking a callback when done
 -- @param DescribeServiceErrorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeServiceErrorsAsync(DescribeServiceErrorsRequest, cb)
 	assert(DescribeServiceErrorsRequest, "You must provide a DescribeServiceErrorsRequest")
 	local headers = {
@@ -9692,19 +9734,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeServiceErrorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeServiceErrorsSync(DescribeServiceErrorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeServiceErrorsAsync(DescribeServiceErrorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeServiceErrorsAsync(DescribeServiceErrorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateElasticIp asynchronously, invoking a callback when done
 -- @param AssociateElasticIpRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateElasticIpAsync(AssociateElasticIpRequest, cb)
 	assert(AssociateElasticIpRequest, "You must provide a AssociateElasticIpRequest")
 	local headers = {
@@ -9727,19 +9770,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateElasticIpRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateElasticIpSync(AssociateElasticIpRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateElasticIpAsync(AssociateElasticIpRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateElasticIpAsync(AssociateElasticIpRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateInstance asynchronously, invoking a callback when done
 -- @param CreateInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateInstanceAsync(CreateInstanceRequest, cb)
 	assert(CreateInstanceRequest, "You must provide a CreateInstanceRequest")
 	local headers = {
@@ -9762,19 +9806,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateInstanceSync(CreateInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateInstanceAsync(CreateInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateInstanceAsync(CreateInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeElasticLoadBalancers asynchronously, invoking a callback when done
 -- @param DescribeElasticLoadBalancersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeElasticLoadBalancersAsync(DescribeElasticLoadBalancersRequest, cb)
 	assert(DescribeElasticLoadBalancersRequest, "You must provide a DescribeElasticLoadBalancersRequest")
 	local headers = {
@@ -9797,18 +9842,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeElasticLoadBalancersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeElasticLoadBalancersSync(DescribeElasticLoadBalancersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeElasticLoadBalancersAsync(DescribeElasticLoadBalancersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeElasticLoadBalancersAsync(DescribeElasticLoadBalancersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOperatingSystems asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOperatingSystemsAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -9827,19 +9873,20 @@ end
 --- Call DescribeOperatingSystems synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOperatingSystemsSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOperatingSystemsAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOperatingSystemsAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterEcsCluster asynchronously, invoking a callback when done
 -- @param DeregisterEcsClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterEcsClusterAsync(DeregisterEcsClusterRequest, cb)
 	assert(DeregisterEcsClusterRequest, "You must provide a DeregisterEcsClusterRequest")
 	local headers = {
@@ -9862,19 +9909,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterEcsClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterEcsClusterSync(DeregisterEcsClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterEcsClusterAsync(DeregisterEcsClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterEcsClusterAsync(DeregisterEcsClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEcsClusters asynchronously, invoking a callback when done
 -- @param DescribeEcsClustersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEcsClustersAsync(DescribeEcsClustersRequest, cb)
 	assert(DescribeEcsClustersRequest, "You must provide a DescribeEcsClustersRequest")
 	local headers = {
@@ -9897,19 +9945,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEcsClustersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEcsClustersSync(DescribeEcsClustersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEcsClustersAsync(DescribeEcsClustersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEcsClustersAsync(DescribeEcsClustersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterRdsDbInstance asynchronously, invoking a callback when done
 -- @param RegisterRdsDbInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterRdsDbInstanceAsync(RegisterRdsDbInstanceRequest, cb)
 	assert(RegisterRdsDbInstanceRequest, "You must provide a RegisterRdsDbInstanceRequest")
 	local headers = {
@@ -9932,19 +9981,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterRdsDbInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterRdsDbInstanceSync(RegisterRdsDbInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterRdsDbInstanceAsync(RegisterRdsDbInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterRdsDbInstanceAsync(RegisterRdsDbInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetTimeBasedAutoScaling asynchronously, invoking a callback when done
 -- @param SetTimeBasedAutoScalingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetTimeBasedAutoScalingAsync(SetTimeBasedAutoScalingRequest, cb)
 	assert(SetTimeBasedAutoScalingRequest, "You must provide a SetTimeBasedAutoScalingRequest")
 	local headers = {
@@ -9967,19 +10017,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetTimeBasedAutoScalingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetTimeBasedAutoScalingSync(SetTimeBasedAutoScalingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetTimeBasedAutoScalingAsync(SetTimeBasedAutoScalingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetTimeBasedAutoScalingAsync(SetTimeBasedAutoScalingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLoadBasedAutoScaling asynchronously, invoking a callback when done
 -- @param DescribeLoadBasedAutoScalingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLoadBasedAutoScalingAsync(DescribeLoadBasedAutoScalingRequest, cb)
 	assert(DescribeLoadBasedAutoScalingRequest, "You must provide a DescribeLoadBasedAutoScalingRequest")
 	local headers = {
@@ -10002,19 +10053,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLoadBasedAutoScalingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLoadBasedAutoScalingSync(DescribeLoadBasedAutoScalingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLoadBasedAutoScalingAsync(DescribeLoadBasedAutoScalingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLoadBasedAutoScalingAsync(DescribeLoadBasedAutoScalingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssignInstance asynchronously, invoking a callback when done
 -- @param AssignInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssignInstanceAsync(AssignInstanceRequest, cb)
 	assert(AssignInstanceRequest, "You must provide a AssignInstanceRequest")
 	local headers = {
@@ -10037,19 +10089,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssignInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssignInstanceSync(AssignInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssignInstanceAsync(AssignInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssignInstanceAsync(AssignInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetLoadBasedAutoScaling asynchronously, invoking a callback when done
 -- @param SetLoadBasedAutoScalingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetLoadBasedAutoScalingAsync(SetLoadBasedAutoScalingRequest, cb)
 	assert(SetLoadBasedAutoScalingRequest, "You must provide a SetLoadBasedAutoScalingRequest")
 	local headers = {
@@ -10072,19 +10125,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetLoadBasedAutoScalingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetLoadBasedAutoScalingSync(SetLoadBasedAutoScalingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetLoadBasedAutoScalingAsync(SetLoadBasedAutoScalingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetLoadBasedAutoScalingAsync(SetLoadBasedAutoScalingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStackSummary asynchronously, invoking a callback when done
 -- @param DescribeStackSummaryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackSummaryAsync(DescribeStackSummaryRequest, cb)
 	assert(DescribeStackSummaryRequest, "You must provide a DescribeStackSummaryRequest")
 	local headers = {
@@ -10107,19 +10161,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackSummaryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackSummarySync(DescribeStackSummaryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackSummaryAsync(DescribeStackSummaryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackSummaryAsync(DescribeStackSummaryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopInstance asynchronously, invoking a callback when done
 -- @param StopInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopInstanceAsync(StopInstanceRequest, cb)
 	assert(StopInstanceRequest, "You must provide a StopInstanceRequest")
 	local headers = {
@@ -10142,19 +10197,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopInstanceSync(StopInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopInstanceAsync(StopInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopInstanceAsync(StopInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStacks asynchronously, invoking a callback when done
 -- @param DescribeStacksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStacksAsync(DescribeStacksRequest, cb)
 	assert(DescribeStacksRequest, "You must provide a DescribeStacksRequest")
 	local headers = {
@@ -10177,19 +10233,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStacksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStacksSync(DescribeStacksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStacksAsync(DescribeStacksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStacksAsync(DescribeStacksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLayer asynchronously, invoking a callback when done
 -- @param CreateLayerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLayerAsync(CreateLayerRequest, cb)
 	assert(CreateLayerRequest, "You must provide a CreateLayerRequest")
 	local headers = {
@@ -10212,19 +10269,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLayerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLayerSync(CreateLayerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLayerAsync(CreateLayerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLayerAsync(CreateLayerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStack asynchronously, invoking a callback when done
 -- @param UpdateStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStackAsync(UpdateStackRequest, cb)
 	assert(UpdateStackRequest, "You must provide a UpdateStackRequest")
 	local headers = {
@@ -10247,19 +10305,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStackSync(UpdateStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStackAsync(UpdateStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStackAsync(UpdateStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GrantAccess asynchronously, invoking a callback when done
 -- @param GrantAccessRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GrantAccessAsync(GrantAccessRequest, cb)
 	assert(GrantAccessRequest, "You must provide a GrantAccessRequest")
 	local headers = {
@@ -10282,19 +10341,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GrantAccessRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GrantAccessSync(GrantAccessRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GrantAccessAsync(GrantAccessRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GrantAccessAsync(GrantAccessRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApp asynchronously, invoking a callback when done
 -- @param CreateAppRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAppAsync(CreateAppRequest, cb)
 	assert(CreateAppRequest, "You must provide a CreateAppRequest")
 	local headers = {
@@ -10317,19 +10377,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAppRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAppSync(CreateAppRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAppAsync(CreateAppRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAppAsync(CreateAppRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -10352,19 +10413,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePermissions asynchronously, invoking a callback when done
 -- @param DescribePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePermissionsAsync(DescribePermissionsRequest, cb)
 	assert(DescribePermissionsRequest, "You must provide a DescribePermissionsRequest")
 	local headers = {
@@ -10387,19 +10449,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePermissionsSync(DescribePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePermissionsAsync(DescribePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePermissionsAsync(DescribePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLayer asynchronously, invoking a callback when done
 -- @param DeleteLayerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLayerAsync(DeleteLayerRequest, cb)
 	assert(DeleteLayerRequest, "You must provide a DeleteLayerRequest")
 	local headers = {
@@ -10422,19 +10485,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLayerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLayerSync(DeleteLayerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLayerAsync(DeleteLayerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLayerAsync(DeleteLayerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVolumes asynchronously, invoking a callback when done
 -- @param DescribeVolumesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVolumesAsync(DescribeVolumesRequest, cb)
 	assert(DescribeVolumesRequest, "You must provide a DescribeVolumesRequest")
 	local headers = {
@@ -10457,19 +10521,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVolumesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVolumesSync(DescribeVolumesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVolumesAsync(DescribeVolumesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVolumesAsync(DescribeVolumesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStackProvisioningParameters asynchronously, invoking a callback when done
 -- @param DescribeStackProvisioningParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStackProvisioningParametersAsync(DescribeStackProvisioningParametersRequest, cb)
 	assert(DescribeStackProvisioningParametersRequest, "You must provide a DescribeStackProvisioningParametersRequest")
 	local headers = {
@@ -10492,19 +10557,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStackProvisioningParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStackProvisioningParametersSync(DescribeStackProvisioningParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStackProvisioningParametersAsync(DescribeStackProvisioningParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStackProvisioningParametersAsync(DescribeStackProvisioningParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterInstance asynchronously, invoking a callback when done
 -- @param RegisterInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterInstanceAsync(RegisterInstanceRequest, cb)
 	assert(RegisterInstanceRequest, "You must provide a RegisterInstanceRequest")
 	local headers = {
@@ -10527,19 +10593,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterInstanceSync(RegisterInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterInstanceAsync(RegisterInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterInstanceAsync(RegisterInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStack asynchronously, invoking a callback when done
 -- @param DeleteStackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStackAsync(DeleteStackRequest, cb)
 	assert(DeleteStackRequest, "You must provide a DeleteStackRequest")
 	local headers = {
@@ -10562,19 +10629,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStackSync(DeleteStackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStackAsync(DeleteStackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStackAsync(DeleteStackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssignVolume asynchronously, invoking a callback when done
 -- @param AssignVolumeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssignVolumeAsync(AssignVolumeRequest, cb)
 	assert(AssignVolumeRequest, "You must provide a AssignVolumeRequest")
 	local headers = {
@@ -10597,19 +10665,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssignVolumeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssignVolumeSync(AssignVolumeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssignVolumeAsync(AssignVolumeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssignVolumeAsync(AssignVolumeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApp asynchronously, invoking a callback when done
 -- @param UpdateAppRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAppAsync(UpdateAppRequest, cb)
 	assert(UpdateAppRequest, "You must provide a UpdateAppRequest")
 	local headers = {
@@ -10632,19 +10701,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAppRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAppSync(UpdateAppRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAppAsync(UpdateAppRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAppAsync(UpdateAppRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRdsDbInstances asynchronously, invoking a callback when done
 -- @param DescribeRdsDbInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRdsDbInstancesAsync(DescribeRdsDbInstancesRequest, cb)
 	assert(DescribeRdsDbInstancesRequest, "You must provide a DescribeRdsDbInstancesRequest")
 	local headers = {
@@ -10667,19 +10737,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRdsDbInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRdsDbInstancesSync(DescribeRdsDbInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRdsDbInstancesAsync(DescribeRdsDbInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRdsDbInstancesAsync(DescribeRdsDbInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUserProfile asynchronously, invoking a callback when done
 -- @param UpdateUserProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserProfileAsync(UpdateUserProfileRequest, cb)
 	assert(UpdateUserProfileRequest, "You must provide a UpdateUserProfileRequest")
 	local headers = {
@@ -10702,19 +10773,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserProfileSync(UpdateUserProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserProfileAsync(UpdateUserProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserProfileAsync(UpdateUserProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUserProfiles asynchronously, invoking a callback when done
 -- @param DescribeUserProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserProfilesAsync(DescribeUserProfilesRequest, cb)
 	assert(DescribeUserProfilesRequest, "You must provide a DescribeUserProfilesRequest")
 	local headers = {
@@ -10737,19 +10809,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserProfilesSync(DescribeUserProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserProfilesAsync(DescribeUserProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserProfilesAsync(DescribeUserProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateLayer asynchronously, invoking a callback when done
 -- @param UpdateLayerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateLayerAsync(UpdateLayerRequest, cb)
 	assert(UpdateLayerRequest, "You must provide a UpdateLayerRequest")
 	local headers = {
@@ -10772,12 +10845,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateLayerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateLayerSync(UpdateLayerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateLayerAsync(UpdateLayerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateLayerAsync(UpdateLayerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/organizations.lua
+++ b/aws-sdk/organizations.lua
@@ -4452,7 +4452,7 @@ end
 --
 --- Call DeclineHandshake asynchronously, invoking a callback when done
 -- @param DeclineHandshakeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeclineHandshakeAsync(DeclineHandshakeRequest, cb)
 	assert(DeclineHandshakeRequest, "You must provide a DeclineHandshakeRequest")
 	local headers = {
@@ -4475,19 +4475,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeclineHandshakeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeclineHandshakeSync(DeclineHandshakeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeclineHandshakeAsync(DeclineHandshakeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeclineHandshakeAsync(DeclineHandshakeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisablePolicyType asynchronously, invoking a callback when done
 -- @param DisablePolicyTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisablePolicyTypeAsync(DisablePolicyTypeRequest, cb)
 	assert(DisablePolicyTypeRequest, "You must provide a DisablePolicyTypeRequest")
 	local headers = {
@@ -4510,19 +4511,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisablePolicyTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisablePolicyTypeSync(DisablePolicyTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisablePolicyTypeAsync(DisablePolicyTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisablePolicyTypeAsync(DisablePolicyTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCreateAccountStatus asynchronously, invoking a callback when done
 -- @param DescribeCreateAccountStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCreateAccountStatusAsync(DescribeCreateAccountStatusRequest, cb)
 	assert(DescribeCreateAccountStatusRequest, "You must provide a DescribeCreateAccountStatusRequest")
 	local headers = {
@@ -4545,19 +4547,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCreateAccountStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCreateAccountStatusSync(DescribeCreateAccountStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCreateAccountStatusAsync(DescribeCreateAccountStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCreateAccountStatusAsync(DescribeCreateAccountStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOrganizationalUnitsForParent asynchronously, invoking a callback when done
 -- @param ListOrganizationalUnitsForParentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOrganizationalUnitsForParentAsync(ListOrganizationalUnitsForParentRequest, cb)
 	assert(ListOrganizationalUnitsForParentRequest, "You must provide a ListOrganizationalUnitsForParentRequest")
 	local headers = {
@@ -4580,19 +4583,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOrganizationalUnitsForParentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOrganizationalUnitsForParentSync(ListOrganizationalUnitsForParentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOrganizationalUnitsForParentAsync(ListOrganizationalUnitsForParentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOrganizationalUnitsForParentAsync(ListOrganizationalUnitsForParentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOrganizationalUnit asynchronously, invoking a callback when done
 -- @param DescribeOrganizationalUnitRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOrganizationalUnitAsync(DescribeOrganizationalUnitRequest, cb)
 	assert(DescribeOrganizationalUnitRequest, "You must provide a DescribeOrganizationalUnitRequest")
 	local headers = {
@@ -4615,19 +4619,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOrganizationalUnitRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOrganizationalUnitSync(DescribeOrganizationalUnitRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOrganizationalUnitAsync(DescribeOrganizationalUnitRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOrganizationalUnitAsync(DescribeOrganizationalUnitRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptHandshake asynchronously, invoking a callback when done
 -- @param AcceptHandshakeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptHandshakeAsync(AcceptHandshakeRequest, cb)
 	assert(AcceptHandshakeRequest, "You must provide a AcceptHandshakeRequest")
 	local headers = {
@@ -4650,19 +4655,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptHandshakeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptHandshakeSync(AcceptHandshakeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptHandshakeAsync(AcceptHandshakeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptHandshakeAsync(AcceptHandshakeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteOrganizationalUnit asynchronously, invoking a callback when done
 -- @param DeleteOrganizationalUnitRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteOrganizationalUnitAsync(DeleteOrganizationalUnitRequest, cb)
 	assert(DeleteOrganizationalUnitRequest, "You must provide a DeleteOrganizationalUnitRequest")
 	local headers = {
@@ -4685,19 +4691,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteOrganizationalUnitRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteOrganizationalUnitSync(DeleteOrganizationalUnitRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteOrganizationalUnitAsync(DeleteOrganizationalUnitRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteOrganizationalUnitAsync(DeleteOrganizationalUnitRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePolicy asynchronously, invoking a callback when done
 -- @param DeletePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePolicyAsync(DeletePolicyRequest, cb)
 	assert(DeletePolicyRequest, "You must provide a DeletePolicyRequest")
 	local headers = {
@@ -4720,19 +4727,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePolicySync(DeletePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePolicyAsync(DeletePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableAWSServiceAccess asynchronously, invoking a callback when done
 -- @param EnableAWSServiceAccessRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableAWSServiceAccessAsync(EnableAWSServiceAccessRequest, cb)
 	assert(EnableAWSServiceAccessRequest, "You must provide a EnableAWSServiceAccessRequest")
 	local headers = {
@@ -4755,19 +4763,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableAWSServiceAccessRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableAWSServiceAccessSync(EnableAWSServiceAccessRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableAWSServiceAccessAsync(EnableAWSServiceAccessRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableAWSServiceAccessAsync(EnableAWSServiceAccessRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetachPolicy asynchronously, invoking a callback when done
 -- @param DetachPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetachPolicyAsync(DetachPolicyRequest, cb)
 	assert(DetachPolicyRequest, "You must provide a DetachPolicyRequest")
 	local headers = {
@@ -4790,19 +4799,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetachPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetachPolicySync(DetachPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetachPolicyAsync(DetachPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetachPolicyAsync(DetachPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHandshakesForAccount asynchronously, invoking a callback when done
 -- @param ListHandshakesForAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHandshakesForAccountAsync(ListHandshakesForAccountRequest, cb)
 	assert(ListHandshakesForAccountRequest, "You must provide a ListHandshakesForAccountRequest")
 	local headers = {
@@ -4825,19 +4835,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHandshakesForAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHandshakesForAccountSync(ListHandshakesForAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHandshakesForAccountAsync(ListHandshakesForAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHandshakesForAccountAsync(ListHandshakesForAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveAccountFromOrganization asynchronously, invoking a callback when done
 -- @param RemoveAccountFromOrganizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveAccountFromOrganizationAsync(RemoveAccountFromOrganizationRequest, cb)
 	assert(RemoveAccountFromOrganizationRequest, "You must provide a RemoveAccountFromOrganizationRequest")
 	local headers = {
@@ -4860,19 +4871,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveAccountFromOrganizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveAccountFromOrganizationSync(RemoveAccountFromOrganizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveAccountFromOrganizationAsync(RemoveAccountFromOrganizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveAccountFromOrganizationAsync(RemoveAccountFromOrganizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableAllFeatures asynchronously, invoking a callback when done
 -- @param EnableAllFeaturesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableAllFeaturesAsync(EnableAllFeaturesRequest, cb)
 	assert(EnableAllFeaturesRequest, "You must provide a EnableAllFeaturesRequest")
 	local headers = {
@@ -4895,18 +4907,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableAllFeaturesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableAllFeaturesSync(EnableAllFeaturesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableAllFeaturesAsync(EnableAllFeaturesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableAllFeaturesAsync(EnableAllFeaturesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteOrganization asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteOrganizationAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -4925,19 +4938,20 @@ end
 --- Call DeleteOrganization synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteOrganizationSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteOrganizationAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteOrganizationAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPoliciesForTarget asynchronously, invoking a callback when done
 -- @param ListPoliciesForTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPoliciesForTargetAsync(ListPoliciesForTargetRequest, cb)
 	assert(ListPoliciesForTargetRequest, "You must provide a ListPoliciesForTargetRequest")
 	local headers = {
@@ -4960,19 +4974,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPoliciesForTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPoliciesForTargetSync(ListPoliciesForTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPoliciesForTargetAsync(ListPoliciesForTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPoliciesForTargetAsync(ListPoliciesForTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePolicy asynchronously, invoking a callback when done
 -- @param DescribePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePolicyAsync(DescribePolicyRequest, cb)
 	assert(DescribePolicyRequest, "You must provide a DescribePolicyRequest")
 	local headers = {
@@ -4995,19 +5010,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePolicySync(DescribePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePolicyAsync(DescribePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePolicyAsync(DescribePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCreateAccountStatus asynchronously, invoking a callback when done
 -- @param ListCreateAccountStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCreateAccountStatusAsync(ListCreateAccountStatusRequest, cb)
 	assert(ListCreateAccountStatusRequest, "You must provide a ListCreateAccountStatusRequest")
 	local headers = {
@@ -5030,19 +5046,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCreateAccountStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCreateAccountStatusSync(ListCreateAccountStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCreateAccountStatusAsync(ListCreateAccountStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCreateAccountStatusAsync(ListCreateAccountStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAccount asynchronously, invoking a callback when done
 -- @param CreateAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAccountAsync(CreateAccountRequest, cb)
 	assert(CreateAccountRequest, "You must provide a CreateAccountRequest")
 	local headers = {
@@ -5065,19 +5082,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAccountSync(CreateAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAccountAsync(CreateAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAccountAsync(CreateAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelHandshake asynchronously, invoking a callback when done
 -- @param CancelHandshakeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelHandshakeAsync(CancelHandshakeRequest, cb)
 	assert(CancelHandshakeRequest, "You must provide a CancelHandshakeRequest")
 	local headers = {
@@ -5100,19 +5118,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelHandshakeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelHandshakeSync(CancelHandshakeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelHandshakeAsync(CancelHandshakeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelHandshakeAsync(CancelHandshakeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAccounts asynchronously, invoking a callback when done
 -- @param ListAccountsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAccountsAsync(ListAccountsRequest, cb)
 	assert(ListAccountsRequest, "You must provide a ListAccountsRequest")
 	local headers = {
@@ -5135,19 +5154,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAccountsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAccountsSync(ListAccountsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAccountsAsync(ListAccountsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAccountsAsync(ListAccountsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AttachPolicy asynchronously, invoking a callback when done
 -- @param AttachPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AttachPolicyAsync(AttachPolicyRequest, cb)
 	assert(AttachPolicyRequest, "You must provide a AttachPolicyRequest")
 	local headers = {
@@ -5170,19 +5190,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AttachPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AttachPolicySync(AttachPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AttachPolicyAsync(AttachPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AttachPolicyAsync(AttachPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call MoveAccount asynchronously, invoking a callback when done
 -- @param MoveAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.MoveAccountAsync(MoveAccountRequest, cb)
 	assert(MoveAccountRequest, "You must provide a MoveAccountRequest")
 	local headers = {
@@ -5205,18 +5226,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param MoveAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.MoveAccountSync(MoveAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.MoveAccountAsync(MoveAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.MoveAccountAsync(MoveAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOrganization asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOrganizationAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -5235,19 +5257,20 @@ end
 --- Call DescribeOrganization synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOrganizationSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOrganizationAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOrganizationAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListChildren asynchronously, invoking a callback when done
 -- @param ListChildrenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListChildrenAsync(ListChildrenRequest, cb)
 	assert(ListChildrenRequest, "You must provide a ListChildrenRequest")
 	local headers = {
@@ -5270,19 +5293,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListChildrenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListChildrenSync(ListChildrenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListChildrenAsync(ListChildrenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListChildrenAsync(ListChildrenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateOrganization asynchronously, invoking a callback when done
 -- @param CreateOrganizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateOrganizationAsync(CreateOrganizationRequest, cb)
 	assert(CreateOrganizationRequest, "You must provide a CreateOrganizationRequest")
 	local headers = {
@@ -5305,19 +5329,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateOrganizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateOrganizationSync(CreateOrganizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateOrganizationAsync(CreateOrganizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateOrganizationAsync(CreateOrganizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePolicy asynchronously, invoking a callback when done
 -- @param UpdatePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePolicyAsync(UpdatePolicyRequest, cb)
 	assert(UpdatePolicyRequest, "You must provide a UpdatePolicyRequest")
 	local headers = {
@@ -5340,19 +5365,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePolicySync(UpdatePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePolicyAsync(UpdatePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePolicyAsync(UpdatePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableAWSServiceAccess asynchronously, invoking a callback when done
 -- @param DisableAWSServiceAccessRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableAWSServiceAccessAsync(DisableAWSServiceAccessRequest, cb)
 	assert(DisableAWSServiceAccessRequest, "You must provide a DisableAWSServiceAccessRequest")
 	local headers = {
@@ -5375,18 +5401,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableAWSServiceAccessRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableAWSServiceAccessSync(DisableAWSServiceAccessRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableAWSServiceAccessAsync(DisableAWSServiceAccessRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableAWSServiceAccessAsync(DisableAWSServiceAccessRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call LeaveOrganization asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.LeaveOrganizationAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -5405,19 +5432,20 @@ end
 --- Call LeaveOrganization synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.LeaveOrganizationSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.LeaveOrganizationAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.LeaveOrganizationAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateOrganizationalUnit asynchronously, invoking a callback when done
 -- @param CreateOrganizationalUnitRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateOrganizationalUnitAsync(CreateOrganizationalUnitRequest, cb)
 	assert(CreateOrganizationalUnitRequest, "You must provide a CreateOrganizationalUnitRequest")
 	local headers = {
@@ -5440,19 +5468,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateOrganizationalUnitRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateOrganizationalUnitSync(CreateOrganizationalUnitRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateOrganizationalUnitAsync(CreateOrganizationalUnitRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateOrganizationalUnitAsync(CreateOrganizationalUnitRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnablePolicyType asynchronously, invoking a callback when done
 -- @param EnablePolicyTypeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnablePolicyTypeAsync(EnablePolicyTypeRequest, cb)
 	assert(EnablePolicyTypeRequest, "You must provide a EnablePolicyTypeRequest")
 	local headers = {
@@ -5475,19 +5504,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnablePolicyTypeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnablePolicyTypeSync(EnablePolicyTypeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnablePolicyTypeAsync(EnablePolicyTypeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnablePolicyTypeAsync(EnablePolicyTypeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccount asynchronously, invoking a callback when done
 -- @param DescribeAccountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountAsync(DescribeAccountRequest, cb)
 	assert(DescribeAccountRequest, "You must provide a DescribeAccountRequest")
 	local headers = {
@@ -5510,19 +5540,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountSync(DescribeAccountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountAsync(DescribeAccountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountAsync(DescribeAccountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InviteAccountToOrganization asynchronously, invoking a callback when done
 -- @param InviteAccountToOrganizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InviteAccountToOrganizationAsync(InviteAccountToOrganizationRequest, cb)
 	assert(InviteAccountToOrganizationRequest, "You must provide a InviteAccountToOrganizationRequest")
 	local headers = {
@@ -5545,19 +5576,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InviteAccountToOrganizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InviteAccountToOrganizationSync(InviteAccountToOrganizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InviteAccountToOrganizationAsync(InviteAccountToOrganizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InviteAccountToOrganizationAsync(InviteAccountToOrganizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPolicies asynchronously, invoking a callback when done
 -- @param ListPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPoliciesAsync(ListPoliciesRequest, cb)
 	assert(ListPoliciesRequest, "You must provide a ListPoliciesRequest")
 	local headers = {
@@ -5580,19 +5612,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPoliciesSync(ListPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPoliciesAsync(ListPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAccountsForParent asynchronously, invoking a callback when done
 -- @param ListAccountsForParentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAccountsForParentAsync(ListAccountsForParentRequest, cb)
 	assert(ListAccountsForParentRequest, "You must provide a ListAccountsForParentRequest")
 	local headers = {
@@ -5615,19 +5648,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAccountsForParentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAccountsForParentSync(ListAccountsForParentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAccountsForParentAsync(ListAccountsForParentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAccountsForParentAsync(ListAccountsForParentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHandshake asynchronously, invoking a callback when done
 -- @param DescribeHandshakeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHandshakeAsync(DescribeHandshakeRequest, cb)
 	assert(DescribeHandshakeRequest, "You must provide a DescribeHandshakeRequest")
 	local headers = {
@@ -5650,19 +5684,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHandshakeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHandshakeSync(DescribeHandshakeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHandshakeAsync(DescribeHandshakeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHandshakeAsync(DescribeHandshakeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListParents asynchronously, invoking a callback when done
 -- @param ListParentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListParentsAsync(ListParentsRequest, cb)
 	assert(ListParentsRequest, "You must provide a ListParentsRequest")
 	local headers = {
@@ -5685,19 +5720,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListParentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListParentsSync(ListParentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListParentsAsync(ListParentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListParentsAsync(ListParentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateOrganizationalUnit asynchronously, invoking a callback when done
 -- @param UpdateOrganizationalUnitRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateOrganizationalUnitAsync(UpdateOrganizationalUnitRequest, cb)
 	assert(UpdateOrganizationalUnitRequest, "You must provide a UpdateOrganizationalUnitRequest")
 	local headers = {
@@ -5720,19 +5756,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateOrganizationalUnitRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateOrganizationalUnitSync(UpdateOrganizationalUnitRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateOrganizationalUnitAsync(UpdateOrganizationalUnitRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateOrganizationalUnitAsync(UpdateOrganizationalUnitRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHandshakesForOrganization asynchronously, invoking a callback when done
 -- @param ListHandshakesForOrganizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHandshakesForOrganizationAsync(ListHandshakesForOrganizationRequest, cb)
 	assert(ListHandshakesForOrganizationRequest, "You must provide a ListHandshakesForOrganizationRequest")
 	local headers = {
@@ -5755,19 +5792,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHandshakesForOrganizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHandshakesForOrganizationSync(ListHandshakesForOrganizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHandshakesForOrganizationAsync(ListHandshakesForOrganizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHandshakesForOrganizationAsync(ListHandshakesForOrganizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePolicy asynchronously, invoking a callback when done
 -- @param CreatePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePolicyAsync(CreatePolicyRequest, cb)
 	assert(CreatePolicyRequest, "You must provide a CreatePolicyRequest")
 	local headers = {
@@ -5790,19 +5828,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePolicySync(CreatePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePolicyAsync(CreatePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePolicyAsync(CreatePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTargetsForPolicy asynchronously, invoking a callback when done
 -- @param ListTargetsForPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTargetsForPolicyAsync(ListTargetsForPolicyRequest, cb)
 	assert(ListTargetsForPolicyRequest, "You must provide a ListTargetsForPolicyRequest")
 	local headers = {
@@ -5825,19 +5864,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTargetsForPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTargetsForPolicySync(ListTargetsForPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTargetsForPolicyAsync(ListTargetsForPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTargetsForPolicyAsync(ListTargetsForPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRoots asynchronously, invoking a callback when done
 -- @param ListRootsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRootsAsync(ListRootsRequest, cb)
 	assert(ListRootsRequest, "You must provide a ListRootsRequest")
 	local headers = {
@@ -5860,19 +5900,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRootsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRootsSync(ListRootsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRootsAsync(ListRootsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRootsAsync(ListRootsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAWSServiceAccessForOrganization asynchronously, invoking a callback when done
 -- @param ListAWSServiceAccessForOrganizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAWSServiceAccessForOrganizationAsync(ListAWSServiceAccessForOrganizationRequest, cb)
 	assert(ListAWSServiceAccessForOrganizationRequest, "You must provide a ListAWSServiceAccessForOrganizationRequest")
 	local headers = {
@@ -5895,12 +5936,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAWSServiceAccessForOrganizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAWSServiceAccessForOrganizationSync(ListAWSServiceAccessForOrganizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAWSServiceAccessForOrganizationAsync(ListAWSServiceAccessForOrganizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAWSServiceAccessForOrganizationAsync(ListAWSServiceAccessForOrganizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/pi.lua
+++ b/aws-sdk/pi.lua
@@ -935,7 +935,7 @@ end
 --
 --- Call DescribeDimensionKeys asynchronously, invoking a callback when done
 -- @param DescribeDimensionKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDimensionKeysAsync(DescribeDimensionKeysRequest, cb)
 	assert(DescribeDimensionKeysRequest, "You must provide a DescribeDimensionKeysRequest")
 	local headers = {
@@ -958,19 +958,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDimensionKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDimensionKeysSync(DescribeDimensionKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDimensionKeysAsync(DescribeDimensionKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDimensionKeysAsync(DescribeDimensionKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResourceMetrics asynchronously, invoking a callback when done
 -- @param GetResourceMetricsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourceMetricsAsync(GetResourceMetricsRequest, cb)
 	assert(GetResourceMetricsRequest, "You must provide a GetResourceMetricsRequest")
 	local headers = {
@@ -993,12 +994,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourceMetricsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourceMetricsSync(GetResourceMetricsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourceMetricsAsync(GetResourceMetricsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourceMetricsAsync(GetResourceMetricsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/pinpoint.lua
+++ b/aws-sdk/pinpoint.lua
@@ -12440,7 +12440,7 @@ end
 --
 --- Call UpdateSegment asynchronously, invoking a callback when done
 -- @param UpdateSegmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSegmentAsync(UpdateSegmentRequest, cb)
 	assert(UpdateSegmentRequest, "You must provide a UpdateSegmentRequest")
 	local headers = {
@@ -12463,19 +12463,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSegmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSegmentSync(UpdateSegmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSegmentAsync(UpdateSegmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSegmentAsync(UpdateSegmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSegment asynchronously, invoking a callback when done
 -- @param CreateSegmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSegmentAsync(CreateSegmentRequest, cb)
 	assert(CreateSegmentRequest, "You must provide a CreateSegmentRequest")
 	local headers = {
@@ -12498,19 +12499,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSegmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSegmentSync(CreateSegmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSegmentAsync(CreateSegmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSegmentAsync(CreateSegmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetExportJob asynchronously, invoking a callback when done
 -- @param GetExportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetExportJobAsync(GetExportJobRequest, cb)
 	assert(GetExportJobRequest, "You must provide a GetExportJobRequest")
 	local headers = {
@@ -12533,19 +12535,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetExportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetExportJobSync(GetExportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetExportJobAsync(GetExportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetExportJobAsync(GetExportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApnsVoipSandboxChannel asynchronously, invoking a callback when done
 -- @param UpdateApnsVoipSandboxChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApnsVoipSandboxChannelAsync(UpdateApnsVoipSandboxChannelRequest, cb)
 	assert(UpdateApnsVoipSandboxChannelRequest, "You must provide a UpdateApnsVoipSandboxChannelRequest")
 	local headers = {
@@ -12568,19 +12571,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApnsVoipSandboxChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApnsVoipSandboxChannelSync(UpdateApnsVoipSandboxChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApnsVoipSandboxChannelAsync(UpdateApnsVoipSandboxChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApnsVoipSandboxChannelAsync(UpdateApnsVoipSandboxChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCampaign asynchronously, invoking a callback when done
 -- @param UpdateCampaignRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateCampaignAsync(UpdateCampaignRequest, cb)
 	assert(UpdateCampaignRequest, "You must provide a UpdateCampaignRequest")
 	local headers = {
@@ -12603,19 +12607,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateCampaignRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateCampaignSync(UpdateCampaignRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateCampaignAsync(UpdateCampaignRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateCampaignAsync(UpdateCampaignRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetImportJobs asynchronously, invoking a callback when done
 -- @param GetImportJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetImportJobsAsync(GetImportJobsRequest, cb)
 	assert(GetImportJobsRequest, "You must provide a GetImportJobsRequest")
 	local headers = {
@@ -12638,19 +12643,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetImportJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetImportJobsSync(GetImportJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetImportJobsAsync(GetImportJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetImportJobsAsync(GetImportJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApps asynchronously, invoking a callback when done
 -- @param GetAppsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAppsAsync(GetAppsRequest, cb)
 	assert(GetAppsRequest, "You must provide a GetAppsRequest")
 	local headers = {
@@ -12673,19 +12679,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAppsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAppsSync(GetAppsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAppsAsync(GetAppsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAppsAsync(GetAppsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSegmentVersion asynchronously, invoking a callback when done
 -- @param GetSegmentVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSegmentVersionAsync(GetSegmentVersionRequest, cb)
 	assert(GetSegmentVersionRequest, "You must provide a GetSegmentVersionRequest")
 	local headers = {
@@ -12708,19 +12715,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSegmentVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSegmentVersionSync(GetSegmentVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSegmentVersionAsync(GetSegmentVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSegmentVersionAsync(GetSegmentVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApnsSandboxChannel asynchronously, invoking a callback when done
 -- @param DeleteApnsSandboxChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApnsSandboxChannelAsync(DeleteApnsSandboxChannelRequest, cb)
 	assert(DeleteApnsSandboxChannelRequest, "You must provide a DeleteApnsSandboxChannelRequest")
 	local headers = {
@@ -12743,19 +12751,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApnsSandboxChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApnsSandboxChannelSync(DeleteApnsSandboxChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApnsSandboxChannelAsync(DeleteApnsSandboxChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApnsSandboxChannelAsync(DeleteApnsSandboxChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSmsChannel asynchronously, invoking a callback when done
 -- @param GetSmsChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSmsChannelAsync(GetSmsChannelRequest, cb)
 	assert(GetSmsChannelRequest, "You must provide a GetSmsChannelRequest")
 	local headers = {
@@ -12778,19 +12787,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSmsChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSmsChannelSync(GetSmsChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSmsChannelAsync(GetSmsChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSmsChannelAsync(GetSmsChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApnsVoipSandboxChannel asynchronously, invoking a callback when done
 -- @param DeleteApnsVoipSandboxChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApnsVoipSandboxChannelAsync(DeleteApnsVoipSandboxChannelRequest, cb)
 	assert(DeleteApnsVoipSandboxChannelRequest, "You must provide a DeleteApnsVoipSandboxChannelRequest")
 	local headers = {
@@ -12813,19 +12823,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApnsVoipSandboxChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApnsVoipSandboxChannelSync(DeleteApnsVoipSandboxChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApnsVoipSandboxChannelAsync(DeleteApnsVoipSandboxChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApnsVoipSandboxChannelAsync(DeleteApnsVoipSandboxChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGcmChannel asynchronously, invoking a callback when done
 -- @param DeleteGcmChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGcmChannelAsync(DeleteGcmChannelRequest, cb)
 	assert(DeleteGcmChannelRequest, "You must provide a DeleteGcmChannelRequest")
 	local headers = {
@@ -12848,19 +12859,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGcmChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGcmChannelSync(DeleteGcmChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGcmChannelAsync(DeleteGcmChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGcmChannelAsync(DeleteGcmChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApp asynchronously, invoking a callback when done
 -- @param GetAppRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAppAsync(GetAppRequest, cb)
 	assert(GetAppRequest, "You must provide a GetAppRequest")
 	local headers = {
@@ -12883,19 +12895,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAppRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAppSync(GetAppRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAppAsync(GetAppRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAppAsync(GetAppRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetChannels asynchronously, invoking a callback when done
 -- @param GetChannelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetChannelsAsync(GetChannelsRequest, cb)
 	assert(GetChannelsRequest, "You must provide a GetChannelsRequest")
 	local headers = {
@@ -12918,19 +12931,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetChannelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetChannelsSync(GetChannelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetChannelsAsync(GetChannelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetChannelsAsync(GetChannelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCampaign asynchronously, invoking a callback when done
 -- @param DeleteCampaignRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCampaignAsync(DeleteCampaignRequest, cb)
 	assert(DeleteCampaignRequest, "You must provide a DeleteCampaignRequest")
 	local headers = {
@@ -12953,19 +12967,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCampaignRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCampaignSync(DeleteCampaignRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCampaignAsync(DeleteCampaignRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCampaignAsync(DeleteCampaignRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetImportJob asynchronously, invoking a callback when done
 -- @param GetImportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetImportJobAsync(GetImportJobRequest, cb)
 	assert(GetImportJobRequest, "You must provide a GetImportJobRequest")
 	local headers = {
@@ -12988,19 +13003,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetImportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetImportJobSync(GetImportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetImportJobAsync(GetImportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetImportJobAsync(GetImportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCampaign asynchronously, invoking a callback when done
 -- @param CreateCampaignRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCampaignAsync(CreateCampaignRequest, cb)
 	assert(CreateCampaignRequest, "You must provide a CreateCampaignRequest")
 	local headers = {
@@ -13023,19 +13039,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCampaignRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCampaignSync(CreateCampaignRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCampaignAsync(CreateCampaignRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCampaignAsync(CreateCampaignRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEndpoint asynchronously, invoking a callback when done
 -- @param DeleteEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEndpointAsync(DeleteEndpointRequest, cb)
 	assert(DeleteEndpointRequest, "You must provide a DeleteEndpointRequest")
 	local headers = {
@@ -13058,19 +13075,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEndpointSync(DeleteEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEndpointAsync(DeleteEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEndpointAsync(DeleteEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateImportJob asynchronously, invoking a callback when done
 -- @param CreateImportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateImportJobAsync(CreateImportJobRequest, cb)
 	assert(CreateImportJobRequest, "You must provide a CreateImportJobRequest")
 	local headers = {
@@ -13093,19 +13111,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateImportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateImportJobSync(CreateImportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateImportJobAsync(CreateImportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateImportJobAsync(CreateImportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutEvents asynchronously, invoking a callback when done
 -- @param PutEventsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutEventsAsync(PutEventsRequest, cb)
 	assert(PutEventsRequest, "You must provide a PutEventsRequest")
 	local headers = {
@@ -13128,19 +13147,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutEventsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutEventsSync(PutEventsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutEventsAsync(PutEventsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutEventsAsync(PutEventsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveAttributes asynchronously, invoking a callback when done
 -- @param RemoveAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveAttributesAsync(RemoveAttributesRequest, cb)
 	assert(RemoveAttributesRequest, "You must provide a RemoveAttributesRequest")
 	local headers = {
@@ -13163,19 +13183,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveAttributesSync(RemoveAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveAttributesAsync(RemoveAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveAttributesAsync(RemoveAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCampaignVersion asynchronously, invoking a callback when done
 -- @param GetCampaignVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCampaignVersionAsync(GetCampaignVersionRequest, cb)
 	assert(GetCampaignVersionRequest, "You must provide a GetCampaignVersionRequest")
 	local headers = {
@@ -13198,19 +13219,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCampaignVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCampaignVersionSync(GetCampaignVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCampaignVersionAsync(GetCampaignVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCampaignVersionAsync(GetCampaignVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGcmChannel asynchronously, invoking a callback when done
 -- @param GetGcmChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGcmChannelAsync(GetGcmChannelRequest, cb)
 	assert(GetGcmChannelRequest, "You must provide a GetGcmChannelRequest")
 	local headers = {
@@ -13233,19 +13255,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGcmChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGcmChannelSync(GetGcmChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGcmChannelAsync(GetGcmChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGcmChannelAsync(GetGcmChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApnsChannel asynchronously, invoking a callback when done
 -- @param UpdateApnsChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApnsChannelAsync(UpdateApnsChannelRequest, cb)
 	assert(UpdateApnsChannelRequest, "You must provide a UpdateApnsChannelRequest")
 	local headers = {
@@ -13268,19 +13291,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApnsChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApnsChannelSync(UpdateApnsChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApnsChannelAsync(UpdateApnsChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApnsChannelAsync(UpdateApnsChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGcmChannel asynchronously, invoking a callback when done
 -- @param UpdateGcmChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGcmChannelAsync(UpdateGcmChannelRequest, cb)
 	assert(UpdateGcmChannelRequest, "You must provide a UpdateGcmChannelRequest")
 	local headers = {
@@ -13303,19 +13327,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGcmChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGcmChannelSync(UpdateGcmChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGcmChannelAsync(UpdateGcmChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGcmChannelAsync(UpdateGcmChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSegment asynchronously, invoking a callback when done
 -- @param GetSegmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSegmentAsync(GetSegmentRequest, cb)
 	assert(GetSegmentRequest, "You must provide a GetSegmentRequest")
 	local headers = {
@@ -13338,19 +13363,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSegmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSegmentSync(GetSegmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSegmentAsync(GetSegmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSegmentAsync(GetSegmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCampaign asynchronously, invoking a callback when done
 -- @param GetCampaignRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCampaignAsync(GetCampaignRequest, cb)
 	assert(GetCampaignRequest, "You must provide a GetCampaignRequest")
 	local headers = {
@@ -13373,19 +13399,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCampaignRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCampaignSync(GetCampaignRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCampaignAsync(GetCampaignRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCampaignAsync(GetCampaignRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEmailChannel asynchronously, invoking a callback when done
 -- @param GetEmailChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEmailChannelAsync(GetEmailChannelRequest, cb)
 	assert(GetEmailChannelRequest, "You must provide a GetEmailChannelRequest")
 	local headers = {
@@ -13408,19 +13435,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEmailChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEmailChannelSync(GetEmailChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEmailChannelAsync(GetEmailChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEmailChannelAsync(GetEmailChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApp asynchronously, invoking a callback when done
 -- @param DeleteAppRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAppAsync(DeleteAppRequest, cb)
 	assert(DeleteAppRequest, "You must provide a DeleteAppRequest")
 	local headers = {
@@ -13443,19 +13471,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAppRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAppSync(DeleteAppRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAppAsync(DeleteAppRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAppAsync(DeleteAppRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApplicationSettings asynchronously, invoking a callback when done
 -- @param UpdateApplicationSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationSettingsAsync(UpdateApplicationSettingsRequest, cb)
 	assert(UpdateApplicationSettingsRequest, "You must provide a UpdateApplicationSettingsRequest")
 	local headers = {
@@ -13478,19 +13507,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationSettingsSync(UpdateApplicationSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationSettingsAsync(UpdateApplicationSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationSettingsAsync(UpdateApplicationSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApnsSandboxChannel asynchronously, invoking a callback when done
 -- @param UpdateApnsSandboxChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApnsSandboxChannelAsync(UpdateApnsSandboxChannelRequest, cb)
 	assert(UpdateApnsSandboxChannelRequest, "You must provide a UpdateApnsSandboxChannelRequest")
 	local headers = {
@@ -13513,19 +13543,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApnsSandboxChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApnsSandboxChannelSync(UpdateApnsSandboxChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApnsSandboxChannelAsync(UpdateApnsSandboxChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApnsSandboxChannelAsync(UpdateApnsSandboxChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSegmentExportJobs asynchronously, invoking a callback when done
 -- @param GetSegmentExportJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSegmentExportJobsAsync(GetSegmentExportJobsRequest, cb)
 	assert(GetSegmentExportJobsRequest, "You must provide a GetSegmentExportJobsRequest")
 	local headers = {
@@ -13548,19 +13579,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSegmentExportJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSegmentExportJobsSync(GetSegmentExportJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSegmentExportJobsAsync(GetSegmentExportJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSegmentExportJobsAsync(GetSegmentExportJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutEventStream asynchronously, invoking a callback when done
 -- @param PutEventStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutEventStreamAsync(PutEventStreamRequest, cb)
 	assert(PutEventStreamRequest, "You must provide a PutEventStreamRequest")
 	local headers = {
@@ -13583,19 +13615,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutEventStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutEventStreamSync(PutEventStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutEventStreamAsync(PutEventStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutEventStreamAsync(PutEventStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSegment asynchronously, invoking a callback when done
 -- @param DeleteSegmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSegmentAsync(DeleteSegmentRequest, cb)
 	assert(DeleteSegmentRequest, "You must provide a DeleteSegmentRequest")
 	local headers = {
@@ -13618,19 +13651,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSegmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSegmentSync(DeleteSegmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSegmentAsync(DeleteSegmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSegmentAsync(DeleteSegmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCampaignVersions asynchronously, invoking a callback when done
 -- @param GetCampaignVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCampaignVersionsAsync(GetCampaignVersionsRequest, cb)
 	assert(GetCampaignVersionsRequest, "You must provide a GetCampaignVersionsRequest")
 	local headers = {
@@ -13653,19 +13687,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCampaignVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCampaignVersionsSync(GetCampaignVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCampaignVersionsAsync(GetCampaignVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCampaignVersionsAsync(GetCampaignVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateApnsVoipChannel asynchronously, invoking a callback when done
 -- @param UpdateApnsVoipChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApnsVoipChannelAsync(UpdateApnsVoipChannelRequest, cb)
 	assert(UpdateApnsVoipChannelRequest, "You must provide a UpdateApnsVoipChannelRequest")
 	local headers = {
@@ -13688,19 +13723,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApnsVoipChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApnsVoipChannelSync(UpdateApnsVoipChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApnsVoipChannelAsync(UpdateApnsVoipChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApnsVoipChannelAsync(UpdateApnsVoipChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApnsVoipSandboxChannel asynchronously, invoking a callback when done
 -- @param GetApnsVoipSandboxChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApnsVoipSandboxChannelAsync(GetApnsVoipSandboxChannelRequest, cb)
 	assert(GetApnsVoipSandboxChannelRequest, "You must provide a GetApnsVoipSandboxChannelRequest")
 	local headers = {
@@ -13723,19 +13759,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApnsVoipSandboxChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApnsVoipSandboxChannelSync(GetApnsVoipSandboxChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApnsVoipSandboxChannelAsync(GetApnsVoipSandboxChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApnsVoipSandboxChannelAsync(GetApnsVoipSandboxChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAdmChannel asynchronously, invoking a callback when done
 -- @param GetAdmChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAdmChannelAsync(GetAdmChannelRequest, cb)
 	assert(GetAdmChannelRequest, "You must provide a GetAdmChannelRequest")
 	local headers = {
@@ -13758,19 +13795,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAdmChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAdmChannelSync(GetAdmChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAdmChannelAsync(GetAdmChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAdmChannelAsync(GetAdmChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApnsSandboxChannel asynchronously, invoking a callback when done
 -- @param GetApnsSandboxChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApnsSandboxChannelAsync(GetApnsSandboxChannelRequest, cb)
 	assert(GetApnsSandboxChannelRequest, "You must provide a GetApnsSandboxChannelRequest")
 	local headers = {
@@ -13793,19 +13831,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApnsSandboxChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApnsSandboxChannelSync(GetApnsSandboxChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApnsSandboxChannelAsync(GetApnsSandboxChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApnsSandboxChannelAsync(GetApnsSandboxChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSegmentImportJobs asynchronously, invoking a callback when done
 -- @param GetSegmentImportJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSegmentImportJobsAsync(GetSegmentImportJobsRequest, cb)
 	assert(GetSegmentImportJobsRequest, "You must provide a GetSegmentImportJobsRequest")
 	local headers = {
@@ -13828,19 +13867,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSegmentImportJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSegmentImportJobsSync(GetSegmentImportJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSegmentImportJobsAsync(GetSegmentImportJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSegmentImportJobsAsync(GetSegmentImportJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCampaigns asynchronously, invoking a callback when done
 -- @param GetCampaignsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCampaignsAsync(GetCampaignsRequest, cb)
 	assert(GetCampaignsRequest, "You must provide a GetCampaignsRequest")
 	local headers = {
@@ -13863,19 +13903,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCampaignsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCampaignsSync(GetCampaignsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCampaignsAsync(GetCampaignsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCampaignsAsync(GetCampaignsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEmailChannel asynchronously, invoking a callback when done
 -- @param DeleteEmailChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEmailChannelAsync(DeleteEmailChannelRequest, cb)
 	assert(DeleteEmailChannelRequest, "You must provide a DeleteEmailChannelRequest")
 	local headers = {
@@ -13898,19 +13939,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEmailChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEmailChannelSync(DeleteEmailChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEmailChannelAsync(DeleteEmailChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEmailChannelAsync(DeleteEmailChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApnsVoipChannel asynchronously, invoking a callback when done
 -- @param DeleteApnsVoipChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApnsVoipChannelAsync(DeleteApnsVoipChannelRequest, cb)
 	assert(DeleteApnsVoipChannelRequest, "You must provide a DeleteApnsVoipChannelRequest")
 	local headers = {
@@ -13933,19 +13975,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApnsVoipChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApnsVoipChannelSync(DeleteApnsVoipChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApnsVoipChannelAsync(DeleteApnsVoipChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApnsVoipChannelAsync(DeleteApnsVoipChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCampaignActivities asynchronously, invoking a callback when done
 -- @param GetCampaignActivitiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCampaignActivitiesAsync(GetCampaignActivitiesRequest, cb)
 	assert(GetCampaignActivitiesRequest, "You must provide a GetCampaignActivitiesRequest")
 	local headers = {
@@ -13968,19 +14011,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCampaignActivitiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCampaignActivitiesSync(GetCampaignActivitiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCampaignActivitiesAsync(GetCampaignActivitiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCampaignActivitiesAsync(GetCampaignActivitiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBaiduChannel asynchronously, invoking a callback when done
 -- @param DeleteBaiduChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBaiduChannelAsync(DeleteBaiduChannelRequest, cb)
 	assert(DeleteBaiduChannelRequest, "You must provide a DeleteBaiduChannelRequest")
 	local headers = {
@@ -14003,19 +14047,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBaiduChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBaiduChannelSync(DeleteBaiduChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBaiduChannelAsync(DeleteBaiduChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBaiduChannelAsync(DeleteBaiduChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEndpoint asynchronously, invoking a callback when done
 -- @param UpdateEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEndpointAsync(UpdateEndpointRequest, cb)
 	assert(UpdateEndpointRequest, "You must provide a UpdateEndpointRequest")
 	local headers = {
@@ -14038,19 +14083,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEndpointSync(UpdateEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEndpointAsync(UpdateEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEndpointAsync(UpdateEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendUsersMessages asynchronously, invoking a callback when done
 -- @param SendUsersMessagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendUsersMessagesAsync(SendUsersMessagesRequest, cb)
 	assert(SendUsersMessagesRequest, "You must provide a SendUsersMessagesRequest")
 	local headers = {
@@ -14073,19 +14119,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendUsersMessagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendUsersMessagesSync(SendUsersMessagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendUsersMessagesAsync(SendUsersMessagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendUsersMessagesAsync(SendUsersMessagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUserEndpoints asynchronously, invoking a callback when done
 -- @param DeleteUserEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserEndpointsAsync(DeleteUserEndpointsRequest, cb)
 	assert(DeleteUserEndpointsRequest, "You must provide a DeleteUserEndpointsRequest")
 	local headers = {
@@ -14108,19 +14155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserEndpointsSync(DeleteUserEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserEndpointsAsync(DeleteUserEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserEndpointsAsync(DeleteUserEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEventStream asynchronously, invoking a callback when done
 -- @param GetEventStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEventStreamAsync(GetEventStreamRequest, cb)
 	assert(GetEventStreamRequest, "You must provide a GetEventStreamRequest")
 	local headers = {
@@ -14143,19 +14191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEventStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEventStreamSync(GetEventStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEventStreamAsync(GetEventStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEventStreamAsync(GetEventStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSmsChannel asynchronously, invoking a callback when done
 -- @param DeleteSmsChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSmsChannelAsync(DeleteSmsChannelRequest, cb)
 	assert(DeleteSmsChannelRequest, "You must provide a DeleteSmsChannelRequest")
 	local headers = {
@@ -14178,19 +14227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSmsChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSmsChannelSync(DeleteSmsChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSmsChannelAsync(DeleteSmsChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSmsChannelAsync(DeleteSmsChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEndpoint asynchronously, invoking a callback when done
 -- @param GetEndpointRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEndpointAsync(GetEndpointRequest, cb)
 	assert(GetEndpointRequest, "You must provide a GetEndpointRequest")
 	local headers = {
@@ -14213,19 +14263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEndpointRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEndpointSync(GetEndpointRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEndpointAsync(GetEndpointRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEndpointAsync(GetEndpointRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAdmChannel asynchronously, invoking a callback when done
 -- @param DeleteAdmChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAdmChannelAsync(DeleteAdmChannelRequest, cb)
 	assert(DeleteAdmChannelRequest, "You must provide a DeleteAdmChannelRequest")
 	local headers = {
@@ -14248,19 +14299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAdmChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAdmChannelSync(DeleteAdmChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAdmChannelAsync(DeleteAdmChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAdmChannelAsync(DeleteAdmChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendMessages asynchronously, invoking a callback when done
 -- @param SendMessagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendMessagesAsync(SendMessagesRequest, cb)
 	assert(SendMessagesRequest, "You must provide a SendMessagesRequest")
 	local headers = {
@@ -14283,19 +14335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendMessagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendMessagesSync(SendMessagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendMessagesAsync(SendMessagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendMessagesAsync(SendMessagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateBaiduChannel asynchronously, invoking a callback when done
 -- @param UpdateBaiduChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateBaiduChannelAsync(UpdateBaiduChannelRequest, cb)
 	assert(UpdateBaiduChannelRequest, "You must provide a UpdateBaiduChannelRequest")
 	local headers = {
@@ -14318,19 +14371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateBaiduChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateBaiduChannelSync(UpdateBaiduChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateBaiduChannelAsync(UpdateBaiduChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateBaiduChannelAsync(UpdateBaiduChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApp asynchronously, invoking a callback when done
 -- @param CreateAppRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAppAsync(CreateAppRequest, cb)
 	assert(CreateAppRequest, "You must provide a CreateAppRequest")
 	local headers = {
@@ -14353,19 +14407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAppRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAppSync(CreateAppRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAppAsync(CreateAppRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAppAsync(CreateAppRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApnsChannel asynchronously, invoking a callback when done
 -- @param DeleteApnsChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApnsChannelAsync(DeleteApnsChannelRequest, cb)
 	assert(DeleteApnsChannelRequest, "You must provide a DeleteApnsChannelRequest")
 	local headers = {
@@ -14388,19 +14443,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApnsChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApnsChannelSync(DeleteApnsChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApnsChannelAsync(DeleteApnsChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApnsChannelAsync(DeleteApnsChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetUserEndpoints asynchronously, invoking a callback when done
 -- @param GetUserEndpointsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetUserEndpointsAsync(GetUserEndpointsRequest, cb)
 	assert(GetUserEndpointsRequest, "You must provide a GetUserEndpointsRequest")
 	local headers = {
@@ -14423,19 +14479,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetUserEndpointsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetUserEndpointsSync(GetUserEndpointsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetUserEndpointsAsync(GetUserEndpointsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetUserEndpointsAsync(GetUserEndpointsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateExportJob asynchronously, invoking a callback when done
 -- @param CreateExportJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateExportJobAsync(CreateExportJobRequest, cb)
 	assert(CreateExportJobRequest, "You must provide a CreateExportJobRequest")
 	local headers = {
@@ -14458,19 +14515,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateExportJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateExportJobSync(CreateExportJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateExportJobAsync(CreateExportJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateExportJobAsync(CreateExportJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEventStream asynchronously, invoking a callback when done
 -- @param DeleteEventStreamRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEventStreamAsync(DeleteEventStreamRequest, cb)
 	assert(DeleteEventStreamRequest, "You must provide a DeleteEventStreamRequest")
 	local headers = {
@@ -14493,19 +14551,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEventStreamRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEventStreamSync(DeleteEventStreamRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEventStreamAsync(DeleteEventStreamRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEventStreamAsync(DeleteEventStreamRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApplicationSettings asynchronously, invoking a callback when done
 -- @param GetApplicationSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApplicationSettingsAsync(GetApplicationSettingsRequest, cb)
 	assert(GetApplicationSettingsRequest, "You must provide a GetApplicationSettingsRequest")
 	local headers = {
@@ -14528,19 +14587,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApplicationSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApplicationSettingsSync(GetApplicationSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApplicationSettingsAsync(GetApplicationSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApplicationSettingsAsync(GetApplicationSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEmailChannel asynchronously, invoking a callback when done
 -- @param UpdateEmailChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEmailChannelAsync(UpdateEmailChannelRequest, cb)
 	assert(UpdateEmailChannelRequest, "You must provide a UpdateEmailChannelRequest")
 	local headers = {
@@ -14563,19 +14623,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEmailChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEmailChannelSync(UpdateEmailChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEmailChannelAsync(UpdateEmailChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEmailChannelAsync(UpdateEmailChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAdmChannel asynchronously, invoking a callback when done
 -- @param UpdateAdmChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAdmChannelAsync(UpdateAdmChannelRequest, cb)
 	assert(UpdateAdmChannelRequest, "You must provide a UpdateAdmChannelRequest")
 	local headers = {
@@ -14598,19 +14659,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAdmChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAdmChannelSync(UpdateAdmChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAdmChannelAsync(UpdateAdmChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAdmChannelAsync(UpdateAdmChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSegments asynchronously, invoking a callback when done
 -- @param GetSegmentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSegmentsAsync(GetSegmentsRequest, cb)
 	assert(GetSegmentsRequest, "You must provide a GetSegmentsRequest")
 	local headers = {
@@ -14633,19 +14695,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSegmentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSegmentsSync(GetSegmentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSegmentsAsync(GetSegmentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSegmentsAsync(GetSegmentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBaiduChannel asynchronously, invoking a callback when done
 -- @param GetBaiduChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBaiduChannelAsync(GetBaiduChannelRequest, cb)
 	assert(GetBaiduChannelRequest, "You must provide a GetBaiduChannelRequest")
 	local headers = {
@@ -14668,19 +14731,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBaiduChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBaiduChannelSync(GetBaiduChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBaiduChannelAsync(GetBaiduChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBaiduChannelAsync(GetBaiduChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PhoneNumberValidate asynchronously, invoking a callback when done
 -- @param PhoneNumberValidateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PhoneNumberValidateAsync(PhoneNumberValidateRequest, cb)
 	assert(PhoneNumberValidateRequest, "You must provide a PhoneNumberValidateRequest")
 	local headers = {
@@ -14703,19 +14767,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PhoneNumberValidateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PhoneNumberValidateSync(PhoneNumberValidateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PhoneNumberValidateAsync(PhoneNumberValidateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PhoneNumberValidateAsync(PhoneNumberValidateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetExportJobs asynchronously, invoking a callback when done
 -- @param GetExportJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetExportJobsAsync(GetExportJobsRequest, cb)
 	assert(GetExportJobsRequest, "You must provide a GetExportJobsRequest")
 	local headers = {
@@ -14738,19 +14803,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetExportJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetExportJobsSync(GetExportJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetExportJobsAsync(GetExportJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetExportJobsAsync(GetExportJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSegmentVersions asynchronously, invoking a callback when done
 -- @param GetSegmentVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSegmentVersionsAsync(GetSegmentVersionsRequest, cb)
 	assert(GetSegmentVersionsRequest, "You must provide a GetSegmentVersionsRequest")
 	local headers = {
@@ -14773,19 +14839,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSegmentVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSegmentVersionsSync(GetSegmentVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSegmentVersionsAsync(GetSegmentVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSegmentVersionsAsync(GetSegmentVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEndpointsBatch asynchronously, invoking a callback when done
 -- @param UpdateEndpointsBatchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEndpointsBatchAsync(UpdateEndpointsBatchRequest, cb)
 	assert(UpdateEndpointsBatchRequest, "You must provide a UpdateEndpointsBatchRequest")
 	local headers = {
@@ -14808,19 +14875,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEndpointsBatchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEndpointsBatchSync(UpdateEndpointsBatchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEndpointsBatchAsync(UpdateEndpointsBatchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEndpointsBatchAsync(UpdateEndpointsBatchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSmsChannel asynchronously, invoking a callback when done
 -- @param UpdateSmsChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSmsChannelAsync(UpdateSmsChannelRequest, cb)
 	assert(UpdateSmsChannelRequest, "You must provide a UpdateSmsChannelRequest")
 	local headers = {
@@ -14843,19 +14911,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSmsChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSmsChannelSync(UpdateSmsChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSmsChannelAsync(UpdateSmsChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSmsChannelAsync(UpdateSmsChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApnsVoipChannel asynchronously, invoking a callback when done
 -- @param GetApnsVoipChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApnsVoipChannelAsync(GetApnsVoipChannelRequest, cb)
 	assert(GetApnsVoipChannelRequest, "You must provide a GetApnsVoipChannelRequest")
 	local headers = {
@@ -14878,19 +14947,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApnsVoipChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApnsVoipChannelSync(GetApnsVoipChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApnsVoipChannelAsync(GetApnsVoipChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApnsVoipChannelAsync(GetApnsVoipChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApnsChannel asynchronously, invoking a callback when done
 -- @param GetApnsChannelRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApnsChannelAsync(GetApnsChannelRequest, cb)
 	assert(GetApnsChannelRequest, "You must provide a GetApnsChannelRequest")
 	local headers = {
@@ -14913,12 +14983,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApnsChannelRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApnsChannelSync(GetApnsChannelRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApnsChannelAsync(GetApnsChannelRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApnsChannelAsync(GetApnsChannelRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/polly.lua
+++ b/aws-sdk/polly.lua
@@ -1540,7 +1540,7 @@ end
 --
 --- Call DescribeVoices asynchronously, invoking a callback when done
 -- @param DescribeVoicesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVoicesAsync(DescribeVoicesInput, cb)
 	assert(DescribeVoicesInput, "You must provide a DescribeVoicesInput")
 	local headers = {
@@ -1563,19 +1563,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVoicesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVoicesSync(DescribeVoicesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVoicesAsync(DescribeVoicesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVoicesAsync(DescribeVoicesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSpeechSynthesisTasks asynchronously, invoking a callback when done
 -- @param ListSpeechSynthesisTasksInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSpeechSynthesisTasksAsync(ListSpeechSynthesisTasksInput, cb)
 	assert(ListSpeechSynthesisTasksInput, "You must provide a ListSpeechSynthesisTasksInput")
 	local headers = {
@@ -1598,19 +1599,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSpeechSynthesisTasksInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSpeechSynthesisTasksSync(ListSpeechSynthesisTasksInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSpeechSynthesisTasksAsync(ListSpeechSynthesisTasksInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSpeechSynthesisTasksAsync(ListSpeechSynthesisTasksInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLexicon asynchronously, invoking a callback when done
 -- @param GetLexiconInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLexiconAsync(GetLexiconInput, cb)
 	assert(GetLexiconInput, "You must provide a GetLexiconInput")
 	local headers = {
@@ -1633,19 +1635,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLexiconInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLexiconSync(GetLexiconInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLexiconAsync(GetLexiconInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLexiconAsync(GetLexiconInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSpeechSynthesisTask asynchronously, invoking a callback when done
 -- @param StartSpeechSynthesisTaskInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSpeechSynthesisTaskAsync(StartSpeechSynthesisTaskInput, cb)
 	assert(StartSpeechSynthesisTaskInput, "You must provide a StartSpeechSynthesisTaskInput")
 	local headers = {
@@ -1668,19 +1671,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSpeechSynthesisTaskInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSpeechSynthesisTaskSync(StartSpeechSynthesisTaskInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSpeechSynthesisTaskAsync(StartSpeechSynthesisTaskInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSpeechSynthesisTaskAsync(StartSpeechSynthesisTaskInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSpeechSynthesisTask asynchronously, invoking a callback when done
 -- @param GetSpeechSynthesisTaskInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSpeechSynthesisTaskAsync(GetSpeechSynthesisTaskInput, cb)
 	assert(GetSpeechSynthesisTaskInput, "You must provide a GetSpeechSynthesisTaskInput")
 	local headers = {
@@ -1703,19 +1707,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSpeechSynthesisTaskInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSpeechSynthesisTaskSync(GetSpeechSynthesisTaskInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSpeechSynthesisTaskAsync(GetSpeechSynthesisTaskInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSpeechSynthesisTaskAsync(GetSpeechSynthesisTaskInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutLexicon asynchronously, invoking a callback when done
 -- @param PutLexiconInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutLexiconAsync(PutLexiconInput, cb)
 	assert(PutLexiconInput, "You must provide a PutLexiconInput")
 	local headers = {
@@ -1738,19 +1743,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutLexiconInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutLexiconSync(PutLexiconInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutLexiconAsync(PutLexiconInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutLexiconAsync(PutLexiconInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLexicons asynchronously, invoking a callback when done
 -- @param ListLexiconsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLexiconsAsync(ListLexiconsInput, cb)
 	assert(ListLexiconsInput, "You must provide a ListLexiconsInput")
 	local headers = {
@@ -1773,19 +1779,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLexiconsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLexiconsSync(ListLexiconsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLexiconsAsync(ListLexiconsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLexiconsAsync(ListLexiconsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SynthesizeSpeech asynchronously, invoking a callback when done
 -- @param SynthesizeSpeechInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SynthesizeSpeechAsync(SynthesizeSpeechInput, cb)
 	assert(SynthesizeSpeechInput, "You must provide a SynthesizeSpeechInput")
 	local headers = {
@@ -1808,19 +1815,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SynthesizeSpeechInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SynthesizeSpeechSync(SynthesizeSpeechInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SynthesizeSpeechAsync(SynthesizeSpeechInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SynthesizeSpeechAsync(SynthesizeSpeechInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLexicon asynchronously, invoking a callback when done
 -- @param DeleteLexiconInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLexiconAsync(DeleteLexiconInput, cb)
 	assert(DeleteLexiconInput, "You must provide a DeleteLexiconInput")
 	local headers = {
@@ -1843,12 +1851,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLexiconInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLexiconSync(DeleteLexiconInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLexiconAsync(DeleteLexiconInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLexiconAsync(DeleteLexiconInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/projects_iot1click.lua
+++ b/aws-sdk/projects_iot1click.lua
@@ -1957,7 +1957,7 @@ end
 --
 --- Call DisassociateDeviceFromPlacement asynchronously, invoking a callback when done
 -- @param DisassociateDeviceFromPlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateDeviceFromPlacementAsync(DisassociateDeviceFromPlacementRequest, cb)
 	assert(DisassociateDeviceFromPlacementRequest, "You must provide a DisassociateDeviceFromPlacementRequest")
 	local headers = {
@@ -1980,19 +1980,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateDeviceFromPlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateDeviceFromPlacementSync(DisassociateDeviceFromPlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateDeviceFromPlacementAsync(DisassociateDeviceFromPlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateDeviceFromPlacementAsync(DisassociateDeviceFromPlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePlacement asynchronously, invoking a callback when done
 -- @param UpdatePlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePlacementAsync(UpdatePlacementRequest, cb)
 	assert(UpdatePlacementRequest, "You must provide a UpdatePlacementRequest")
 	local headers = {
@@ -2015,19 +2016,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePlacementSync(UpdatePlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePlacementAsync(UpdatePlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePlacementAsync(UpdatePlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePlacement asynchronously, invoking a callback when done
 -- @param DeletePlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePlacementAsync(DeletePlacementRequest, cb)
 	assert(DeletePlacementRequest, "You must provide a DeletePlacementRequest")
 	local headers = {
@@ -2050,19 +2052,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePlacementSync(DeletePlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePlacementAsync(DeletePlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePlacementAsync(DeletePlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPlacements asynchronously, invoking a callback when done
 -- @param ListPlacementsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPlacementsAsync(ListPlacementsRequest, cb)
 	assert(ListPlacementsRequest, "You must provide a ListPlacementsRequest")
 	local headers = {
@@ -2085,19 +2088,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPlacementsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPlacementsSync(ListPlacementsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPlacementsAsync(ListPlacementsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPlacementsAsync(ListPlacementsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProject asynchronously, invoking a callback when done
 -- @param CreateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProjectAsync(CreateProjectRequest, cb)
 	assert(CreateProjectRequest, "You must provide a CreateProjectRequest")
 	local headers = {
@@ -2120,19 +2124,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProjectSync(CreateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProjectAsync(CreateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProjectAsync(CreateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProjects asynchronously, invoking a callback when done
 -- @param ListProjectsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProjectsAsync(ListProjectsRequest, cb)
 	assert(ListProjectsRequest, "You must provide a ListProjectsRequest")
 	local headers = {
@@ -2155,19 +2160,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProjectsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProjectsSync(ListProjectsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProjectsAsync(ListProjectsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProjectsAsync(ListProjectsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProject asynchronously, invoking a callback when done
 -- @param UpdateProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProjectAsync(UpdateProjectRequest, cb)
 	assert(UpdateProjectRequest, "You must provide a UpdateProjectRequest")
 	local headers = {
@@ -2190,19 +2196,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProjectSync(UpdateProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProjectAsync(UpdateProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDevicesInPlacement asynchronously, invoking a callback when done
 -- @param GetDevicesInPlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDevicesInPlacementAsync(GetDevicesInPlacementRequest, cb)
 	assert(GetDevicesInPlacementRequest, "You must provide a GetDevicesInPlacementRequest")
 	local headers = {
@@ -2225,19 +2232,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDevicesInPlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDevicesInPlacementSync(GetDevicesInPlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDevicesInPlacementAsync(GetDevicesInPlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDevicesInPlacementAsync(GetDevicesInPlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePlacement asynchronously, invoking a callback when done
 -- @param DescribePlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePlacementAsync(DescribePlacementRequest, cb)
 	assert(DescribePlacementRequest, "You must provide a DescribePlacementRequest")
 	local headers = {
@@ -2260,19 +2268,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePlacementSync(DescribePlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePlacementAsync(DescribePlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePlacementAsync(DescribePlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProject asynchronously, invoking a callback when done
 -- @param DescribeProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProjectAsync(DescribeProjectRequest, cb)
 	assert(DescribeProjectRequest, "You must provide a DescribeProjectRequest")
 	local headers = {
@@ -2295,19 +2304,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProjectSync(DescribeProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProjectAsync(DescribeProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProjectAsync(DescribeProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateDeviceWithPlacement asynchronously, invoking a callback when done
 -- @param AssociateDeviceWithPlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateDeviceWithPlacementAsync(AssociateDeviceWithPlacementRequest, cb)
 	assert(AssociateDeviceWithPlacementRequest, "You must provide a AssociateDeviceWithPlacementRequest")
 	local headers = {
@@ -2330,19 +2340,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateDeviceWithPlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateDeviceWithPlacementSync(AssociateDeviceWithPlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateDeviceWithPlacementAsync(AssociateDeviceWithPlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateDeviceWithPlacementAsync(AssociateDeviceWithPlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePlacement asynchronously, invoking a callback when done
 -- @param CreatePlacementRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePlacementAsync(CreatePlacementRequest, cb)
 	assert(CreatePlacementRequest, "You must provide a CreatePlacementRequest")
 	local headers = {
@@ -2365,19 +2376,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePlacementRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePlacementSync(CreatePlacementRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePlacementAsync(CreatePlacementRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePlacementAsync(CreatePlacementRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProject asynchronously, invoking a callback when done
 -- @param DeleteProjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProjectAsync(DeleteProjectRequest, cb)
 	assert(DeleteProjectRequest, "You must provide a DeleteProjectRequest")
 	local headers = {
@@ -2400,12 +2412,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProjectSync(DeleteProjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProjectAsync(DeleteProjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/rds.lua
+++ b/aws-sdk/rds.lua
@@ -13569,7 +13569,7 @@ end
 --
 --- Call DescribeCertificates asynchronously, invoking a callback when done
 -- @param DescribeCertificatesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCertificatesAsync(DescribeCertificatesMessage, cb)
 	assert(DescribeCertificatesMessage, "You must provide a DescribeCertificatesMessage")
 	local headers = {
@@ -13592,19 +13592,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCertificatesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCertificatesSync(DescribeCertificatesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCertificatesAsync(DescribeCertificatesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCertificatesAsync(DescribeCertificatesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreDBClusterToPointInTime asynchronously, invoking a callback when done
 -- @param RestoreDBClusterToPointInTimeMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreDBClusterToPointInTimeAsync(RestoreDBClusterToPointInTimeMessage, cb)
 	assert(RestoreDBClusterToPointInTimeMessage, "You must provide a RestoreDBClusterToPointInTimeMessage")
 	local headers = {
@@ -13627,19 +13628,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreDBClusterToPointInTimeMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreDBClusterToPointInTimeSync(RestoreDBClusterToPointInTimeMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreDBClusterToPointInTimeAsync(RestoreDBClusterToPointInTimeMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreDBClusterToPointInTimeAsync(RestoreDBClusterToPointInTimeMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEngineDefaultParameters asynchronously, invoking a callback when done
 -- @param DescribeEngineDefaultParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEngineDefaultParametersAsync(DescribeEngineDefaultParametersMessage, cb)
 	assert(DescribeEngineDefaultParametersMessage, "You must provide a DescribeEngineDefaultParametersMessage")
 	local headers = {
@@ -13662,19 +13664,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEngineDefaultParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEngineDefaultParametersSync(DescribeEngineDefaultParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEngineDefaultParametersAsync(DescribeEngineDefaultParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEngineDefaultParametersAsync(DescribeEngineDefaultParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBClusterSnapshot asynchronously, invoking a callback when done
 -- @param DeleteDBClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBClusterSnapshotAsync(DeleteDBClusterSnapshotMessage, cb)
 	assert(DeleteDBClusterSnapshotMessage, "You must provide a DeleteDBClusterSnapshotMessage")
 	local headers = {
@@ -13697,19 +13700,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBClusterSnapshotSync(DeleteDBClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBClusterSnapshotAsync(DeleteDBClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBClusterSnapshotAsync(DeleteDBClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBParameterGroup asynchronously, invoking a callback when done
 -- @param CreateDBParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBParameterGroupAsync(CreateDBParameterGroupMessage, cb)
 	assert(CreateDBParameterGroupMessage, "You must provide a CreateDBParameterGroupMessage")
 	local headers = {
@@ -13732,19 +13736,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBParameterGroupSync(CreateDBParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBParameterGroupAsync(CreateDBParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBParameterGroupAsync(CreateDBParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AuthorizeDBSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param AuthorizeDBSecurityGroupIngressMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AuthorizeDBSecurityGroupIngressAsync(AuthorizeDBSecurityGroupIngressMessage, cb)
 	assert(AuthorizeDBSecurityGroupIngressMessage, "You must provide a AuthorizeDBSecurityGroupIngressMessage")
 	local headers = {
@@ -13767,19 +13772,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AuthorizeDBSecurityGroupIngressMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AuthorizeDBSecurityGroupIngressSync(AuthorizeDBSecurityGroupIngressMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AuthorizeDBSecurityGroupIngressAsync(AuthorizeDBSecurityGroupIngressMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AuthorizeDBSecurityGroupIngressAsync(AuthorizeDBSecurityGroupIngressMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBSubnetGroups asynchronously, invoking a callback when done
 -- @param DescribeDBSubnetGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBSubnetGroupsAsync(DescribeDBSubnetGroupsMessage, cb)
 	assert(DescribeDBSubnetGroupsMessage, "You must provide a DescribeDBSubnetGroupsMessage")
 	local headers = {
@@ -13802,19 +13808,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBSubnetGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBSubnetGroupsSync(DescribeDBSubnetGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBSubnetGroupsAsync(DescribeDBSubnetGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBSubnetGroupsAsync(DescribeDBSubnetGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBEngineVersions asynchronously, invoking a callback when done
 -- @param DescribeDBEngineVersionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBEngineVersionsAsync(DescribeDBEngineVersionsMessage, cb)
 	assert(DescribeDBEngineVersionsMessage, "You must provide a DescribeDBEngineVersionsMessage")
 	local headers = {
@@ -13837,19 +13844,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBEngineVersionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBEngineVersionsSync(DescribeDBEngineVersionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBEngineVersionsAsync(DescribeDBEngineVersionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBEngineVersionsAsync(DescribeDBEngineVersionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyDBSnapshot asynchronously, invoking a callback when done
 -- @param CopyDBSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyDBSnapshotAsync(CopyDBSnapshotMessage, cb)
 	assert(CopyDBSnapshotMessage, "You must provide a CopyDBSnapshotMessage")
 	local headers = {
@@ -13872,19 +13880,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyDBSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyDBSnapshotSync(CopyDBSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyDBSnapshotAsync(CopyDBSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyDBSnapshotAsync(CopyDBSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopDBCluster asynchronously, invoking a callback when done
 -- @param StopDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopDBClusterAsync(StopDBClusterMessage, cb)
 	assert(StopDBClusterMessage, "You must provide a StopDBClusterMessage")
 	local headers = {
@@ -13907,19 +13916,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopDBClusterSync(StopDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopDBClusterAsync(StopDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopDBClusterAsync(StopDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEventSubscription asynchronously, invoking a callback when done
 -- @param DeleteEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, cb)
 	assert(DeleteEventSubscriptionMessage, "You must provide a DeleteEventSubscriptionMessage")
 	local headers = {
@@ -13942,19 +13952,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEventSubscriptionSync(DeleteEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBInstanceReadReplica asynchronously, invoking a callback when done
 -- @param CreateDBInstanceReadReplicaMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBInstanceReadReplicaAsync(CreateDBInstanceReadReplicaMessage, cb)
 	assert(CreateDBInstanceReadReplicaMessage, "You must provide a CreateDBInstanceReadReplicaMessage")
 	local headers = {
@@ -13977,19 +13988,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBInstanceReadReplicaMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBInstanceReadReplicaSync(CreateDBInstanceReadReplicaMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBInstanceReadReplicaAsync(CreateDBInstanceReadReplicaMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBInstanceReadReplicaAsync(CreateDBInstanceReadReplicaMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBClusterSnapshot asynchronously, invoking a callback when done
 -- @param CreateDBClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBClusterSnapshotAsync(CreateDBClusterSnapshotMessage, cb)
 	assert(CreateDBClusterSnapshotMessage, "You must provide a CreateDBClusterSnapshotMessage")
 	local headers = {
@@ -14012,19 +14024,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBClusterSnapshotSync(CreateDBClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBClusterSnapshotAsync(CreateDBClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBClusterSnapshotAsync(CreateDBClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedDBInstancesOfferings asynchronously, invoking a callback when done
 -- @param DescribeReservedDBInstancesOfferingsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedDBInstancesOfferingsAsync(DescribeReservedDBInstancesOfferingsMessage, cb)
 	assert(DescribeReservedDBInstancesOfferingsMessage, "You must provide a DescribeReservedDBInstancesOfferingsMessage")
 	local headers = {
@@ -14047,19 +14060,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedDBInstancesOfferingsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedDBInstancesOfferingsSync(DescribeReservedDBInstancesOfferingsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedDBInstancesOfferingsAsync(DescribeReservedDBInstancesOfferingsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedDBInstancesOfferingsAsync(DescribeReservedDBInstancesOfferingsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBCluster asynchronously, invoking a callback when done
 -- @param DeleteDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBClusterAsync(DeleteDBClusterMessage, cb)
 	assert(DeleteDBClusterMessage, "You must provide a DeleteDBClusterMessage")
 	local headers = {
@@ -14082,19 +14096,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBClusterSync(DeleteDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBClusterAsync(DeleteDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBClusterAsync(DeleteDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetDBClusterParameterGroup asynchronously, invoking a callback when done
 -- @param ResetDBClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetDBClusterParameterGroupAsync(ResetDBClusterParameterGroupMessage, cb)
 	assert(ResetDBClusterParameterGroupMessage, "You must provide a ResetDBClusterParameterGroupMessage")
 	local headers = {
@@ -14117,19 +14132,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetDBClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetDBClusterParameterGroupSync(ResetDBClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetDBClusterParameterGroupAsync(ResetDBClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetDBClusterParameterGroupAsync(ResetDBClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceMessage, cb)
 	assert(ListTagsForResourceMessage, "You must provide a ListTagsForResourceMessage")
 	local headers = {
@@ -14152,19 +14168,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBSnapshot asynchronously, invoking a callback when done
 -- @param ModifyDBSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBSnapshotAsync(ModifyDBSnapshotMessage, cb)
 	assert(ModifyDBSnapshotMessage, "You must provide a ModifyDBSnapshotMessage")
 	local headers = {
@@ -14187,19 +14204,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBSnapshotSync(ModifyDBSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBSnapshotAsync(ModifyDBSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBSnapshotAsync(ModifyDBSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBSubnetGroup asynchronously, invoking a callback when done
 -- @param DeleteDBSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBSubnetGroupAsync(DeleteDBSubnetGroupMessage, cb)
 	assert(DeleteDBSubnetGroupMessage, "You must provide a DeleteDBSubnetGroupMessage")
 	local headers = {
@@ -14222,19 +14240,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBSubnetGroupSync(DeleteDBSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBSubnetGroupAsync(DeleteDBSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBSubnetGroupAsync(DeleteDBSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreDBInstanceFromDBSnapshot asynchronously, invoking a callback when done
 -- @param RestoreDBInstanceFromDBSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreDBInstanceFromDBSnapshotAsync(RestoreDBInstanceFromDBSnapshotMessage, cb)
 	assert(RestoreDBInstanceFromDBSnapshotMessage, "You must provide a RestoreDBInstanceFromDBSnapshotMessage")
 	local headers = {
@@ -14257,19 +14276,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreDBInstanceFromDBSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreDBInstanceFromDBSnapshotSync(RestoreDBInstanceFromDBSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreDBInstanceFromDBSnapshotAsync(RestoreDBInstanceFromDBSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreDBInstanceFromDBSnapshotAsync(RestoreDBInstanceFromDBSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOptionGroups asynchronously, invoking a callback when done
 -- @param DescribeOptionGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOptionGroupsAsync(DescribeOptionGroupsMessage, cb)
 	assert(DescribeOptionGroupsMessage, "You must provide a DescribeOptionGroupsMessage")
 	local headers = {
@@ -14292,19 +14312,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOptionGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOptionGroupsSync(DescribeOptionGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOptionGroupsAsync(DescribeOptionGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOptionGroupsAsync(DescribeOptionGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreDBClusterFromS3 asynchronously, invoking a callback when done
 -- @param RestoreDBClusterFromS3Message
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreDBClusterFromS3Async(RestoreDBClusterFromS3Message, cb)
 	assert(RestoreDBClusterFromS3Message, "You must provide a RestoreDBClusterFromS3Message")
 	local headers = {
@@ -14327,19 +14348,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreDBClusterFromS3Message
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreDBClusterFromS3Sync(RestoreDBClusterFromS3Message, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreDBClusterFromS3Async(RestoreDBClusterFromS3Message, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreDBClusterFromS3Async(RestoreDBClusterFromS3Message, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBInstance asynchronously, invoking a callback when done
 -- @param DeleteDBInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBInstanceAsync(DeleteDBInstanceMessage, cb)
 	assert(DeleteDBInstanceMessage, "You must provide a DeleteDBInstanceMessage")
 	local headers = {
@@ -14362,19 +14384,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBInstanceSync(DeleteDBInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBInstanceAsync(DeleteDBInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBInstanceAsync(DeleteDBInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBClusterParameterGroup asynchronously, invoking a callback when done
 -- @param CreateDBClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBClusterParameterGroupAsync(CreateDBClusterParameterGroupMessage, cb)
 	assert(CreateDBClusterParameterGroupMessage, "You must provide a CreateDBClusterParameterGroupMessage")
 	local headers = {
@@ -14397,19 +14420,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBClusterParameterGroupSync(CreateDBClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBClusterParameterGroupAsync(CreateDBClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBClusterParameterGroupAsync(CreateDBClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBParameterGroup asynchronously, invoking a callback when done
 -- @param DeleteDBParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBParameterGroupAsync(DeleteDBParameterGroupMessage, cb)
 	assert(DeleteDBParameterGroupMessage, "You must provide a DeleteDBParameterGroupMessage")
 	local headers = {
@@ -14432,19 +14456,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBParameterGroupSync(DeleteDBParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBParameterGroupAsync(DeleteDBParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBParameterGroupAsync(DeleteDBParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventCategories asynchronously, invoking a callback when done
 -- @param DescribeEventCategoriesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, cb)
 	assert(DescribeEventCategoriesMessage, "You must provide a DescribeEventCategoriesMessage")
 	local headers = {
@@ -14467,19 +14492,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventCategoriesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventCategoriesSync(DescribeEventCategoriesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBClusterBacktracks asynchronously, invoking a callback when done
 -- @param DescribeDBClusterBacktracksMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBClusterBacktracksAsync(DescribeDBClusterBacktracksMessage, cb)
 	assert(DescribeDBClusterBacktracksMessage, "You must provide a DescribeDBClusterBacktracksMessage")
 	local headers = {
@@ -14502,19 +14528,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBClusterBacktracksMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBClusterBacktracksSync(DescribeDBClusterBacktracksMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBClusterBacktracksAsync(DescribeDBClusterBacktracksMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBClusterBacktracksAsync(DescribeDBClusterBacktracksMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToResource asynchronously, invoking a callback when done
 -- @param AddTagsToResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToResourceAsync(AddTagsToResourceMessage, cb)
 	assert(AddTagsToResourceMessage, "You must provide a AddTagsToResourceMessage")
 	local headers = {
@@ -14537,19 +14564,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToResourceSync(AddTagsToResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToResourceAsync(AddTagsToResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToResourceAsync(AddTagsToResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyOptionGroup asynchronously, invoking a callback when done
 -- @param ModifyOptionGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyOptionGroupAsync(ModifyOptionGroupMessage, cb)
 	assert(ModifyOptionGroupMessage, "You must provide a ModifyOptionGroupMessage")
 	local headers = {
@@ -14572,19 +14600,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyOptionGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyOptionGroupSync(ModifyOptionGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyOptionGroupAsync(ModifyOptionGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyOptionGroupAsync(ModifyOptionGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBLogFiles asynchronously, invoking a callback when done
 -- @param DescribeDBLogFilesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBLogFilesAsync(DescribeDBLogFilesMessage, cb)
 	assert(DescribeDBLogFilesMessage, "You must provide a DescribeDBLogFilesMessage")
 	local headers = {
@@ -14607,19 +14636,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBLogFilesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBLogFilesSync(DescribeDBLogFilesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBLogFilesAsync(DescribeDBLogFilesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBLogFilesAsync(DescribeDBLogFilesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BacktrackDBCluster asynchronously, invoking a callback when done
 -- @param BacktrackDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BacktrackDBClusterAsync(BacktrackDBClusterMessage, cb)
 	assert(BacktrackDBClusterMessage, "You must provide a BacktrackDBClusterMessage")
 	local headers = {
@@ -14642,19 +14672,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BacktrackDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BacktrackDBClusterSync(BacktrackDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BacktrackDBClusterAsync(BacktrackDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BacktrackDBClusterAsync(BacktrackDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromResource asynchronously, invoking a callback when done
 -- @param RemoveTagsFromResourceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, cb)
 	assert(RemoveTagsFromResourceMessage, "You must provide a RemoveTagsFromResourceMessage")
 	local headers = {
@@ -14677,19 +14708,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromResourceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromResourceSync(RemoveTagsFromResourceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedDBInstances asynchronously, invoking a callback when done
 -- @param DescribeReservedDBInstancesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedDBInstancesAsync(DescribeReservedDBInstancesMessage, cb)
 	assert(DescribeReservedDBInstancesMessage, "You must provide a DescribeReservedDBInstancesMessage")
 	local headers = {
@@ -14712,19 +14744,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedDBInstancesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedDBInstancesSync(DescribeReservedDBInstancesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedDBInstancesAsync(DescribeReservedDBInstancesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedDBInstancesAsync(DescribeReservedDBInstancesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyOptionGroup asynchronously, invoking a callback when done
 -- @param CopyOptionGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyOptionGroupAsync(CopyOptionGroupMessage, cb)
 	assert(CopyOptionGroupMessage, "You must provide a CopyOptionGroupMessage")
 	local headers = {
@@ -14747,19 +14780,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyOptionGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyOptionGroupSync(CopyOptionGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyOptionGroupAsync(CopyOptionGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyOptionGroupAsync(CopyOptionGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBInstance asynchronously, invoking a callback when done
 -- @param CreateDBInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBInstanceAsync(CreateDBInstanceMessage, cb)
 	assert(CreateDBInstanceMessage, "You must provide a CreateDBInstanceMessage")
 	local headers = {
@@ -14782,19 +14816,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBInstanceSync(CreateDBInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBInstanceAsync(CreateDBInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBInstanceAsync(CreateDBInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyEventSubscription asynchronously, invoking a callback when done
 -- @param ModifyEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, cb)
 	assert(ModifyEventSubscriptionMessage, "You must provide a ModifyEventSubscriptionMessage")
 	local headers = {
@@ -14817,19 +14852,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyEventSubscriptionSync(ModifyEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBSubnetGroup asynchronously, invoking a callback when done
 -- @param ModifyDBSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBSubnetGroupAsync(ModifyDBSubnetGroupMessage, cb)
 	assert(ModifyDBSubnetGroupMessage, "You must provide a ModifyDBSubnetGroupMessage")
 	local headers = {
@@ -14852,19 +14888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBSubnetGroupSync(ModifyDBSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBSubnetGroupAsync(ModifyDBSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBSubnetGroupAsync(ModifyDBSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBSecurityGroup asynchronously, invoking a callback when done
 -- @param DeleteDBSecurityGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBSecurityGroupAsync(DeleteDBSecurityGroupMessage, cb)
 	assert(DeleteDBSecurityGroupMessage, "You must provide a DeleteDBSecurityGroupMessage")
 	local headers = {
@@ -14887,19 +14924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBSecurityGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBSecurityGroupSync(DeleteDBSecurityGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBSecurityGroupAsync(DeleteDBSecurityGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBSecurityGroupAsync(DeleteDBSecurityGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreDBInstanceToPointInTime asynchronously, invoking a callback when done
 -- @param RestoreDBInstanceToPointInTimeMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreDBInstanceToPointInTimeAsync(RestoreDBInstanceToPointInTimeMessage, cb)
 	assert(RestoreDBInstanceToPointInTimeMessage, "You must provide a RestoreDBInstanceToPointInTimeMessage")
 	local headers = {
@@ -14922,19 +14960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreDBInstanceToPointInTimeMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreDBInstanceToPointInTimeSync(RestoreDBInstanceToPointInTimeMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreDBInstanceToPointInTimeAsync(RestoreDBInstanceToPointInTimeMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreDBInstanceToPointInTimeAsync(RestoreDBInstanceToPointInTimeMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddSourceIdentifierToSubscription asynchronously, invoking a callback when done
 -- @param AddSourceIdentifierToSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddSourceIdentifierToSubscriptionAsync(AddSourceIdentifierToSubscriptionMessage, cb)
 	assert(AddSourceIdentifierToSubscriptionMessage, "You must provide a AddSourceIdentifierToSubscriptionMessage")
 	local headers = {
@@ -14957,19 +14996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddSourceIdentifierToSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddSourceIdentifierToSubscriptionSync(AddSourceIdentifierToSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddSourceIdentifierToSubscriptionAsync(AddSourceIdentifierToSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddSourceIdentifierToSubscriptionAsync(AddSourceIdentifierToSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyDBClusterParameterGroup asynchronously, invoking a callback when done
 -- @param CopyDBClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyDBClusterParameterGroupAsync(CopyDBClusterParameterGroupMessage, cb)
 	assert(CopyDBClusterParameterGroupMessage, "You must provide a CopyDBClusterParameterGroupMessage")
 	local headers = {
@@ -14992,19 +15032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyDBClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyDBClusterParameterGroupSync(CopyDBClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyDBClusterParameterGroupAsync(CopyDBClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyDBClusterParameterGroupAsync(CopyDBClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartDBInstance asynchronously, invoking a callback when done
 -- @param StartDBInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartDBInstanceAsync(StartDBInstanceMessage, cb)
 	assert(StartDBInstanceMessage, "You must provide a StartDBInstanceMessage")
 	local headers = {
@@ -15027,19 +15068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartDBInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartDBInstanceSync(StartDBInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartDBInstanceAsync(StartDBInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartDBInstanceAsync(StartDBInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBClusterSnapshotAttributes asynchronously, invoking a callback when done
 -- @param DescribeDBClusterSnapshotAttributesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBClusterSnapshotAttributesAsync(DescribeDBClusterSnapshotAttributesMessage, cb)
 	assert(DescribeDBClusterSnapshotAttributesMessage, "You must provide a DescribeDBClusterSnapshotAttributesMessage")
 	local headers = {
@@ -15062,19 +15104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBClusterSnapshotAttributesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBClusterSnapshotAttributesSync(DescribeDBClusterSnapshotAttributesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBClusterSnapshotAttributesAsync(DescribeDBClusterSnapshotAttributesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBClusterSnapshotAttributesAsync(DescribeDBClusterSnapshotAttributesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreDBClusterFromSnapshot asynchronously, invoking a callback when done
 -- @param RestoreDBClusterFromSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreDBClusterFromSnapshotAsync(RestoreDBClusterFromSnapshotMessage, cb)
 	assert(RestoreDBClusterFromSnapshotMessage, "You must provide a RestoreDBClusterFromSnapshotMessage")
 	local headers = {
@@ -15097,19 +15140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreDBClusterFromSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreDBClusterFromSnapshotSync(RestoreDBClusterFromSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreDBClusterFromSnapshotAsync(RestoreDBClusterFromSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreDBClusterFromSnapshotAsync(RestoreDBClusterFromSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBParameters asynchronously, invoking a callback when done
 -- @param DescribeDBParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBParametersAsync(DescribeDBParametersMessage, cb)
 	assert(DescribeDBParametersMessage, "You must provide a DescribeDBParametersMessage")
 	local headers = {
@@ -15132,19 +15176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBParametersSync(DescribeDBParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBParametersAsync(DescribeDBParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBParametersAsync(DescribeDBParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PromoteReadReplicaDBCluster asynchronously, invoking a callback when done
 -- @param PromoteReadReplicaDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PromoteReadReplicaDBClusterAsync(PromoteReadReplicaDBClusterMessage, cb)
 	assert(PromoteReadReplicaDBClusterMessage, "You must provide a PromoteReadReplicaDBClusterMessage")
 	local headers = {
@@ -15167,19 +15212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PromoteReadReplicaDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PromoteReadReplicaDBClusterSync(PromoteReadReplicaDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PromoteReadReplicaDBClusterAsync(PromoteReadReplicaDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PromoteReadReplicaDBClusterAsync(PromoteReadReplicaDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBClusterParameters asynchronously, invoking a callback when done
 -- @param DescribeDBClusterParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBClusterParametersAsync(DescribeDBClusterParametersMessage, cb)
 	assert(DescribeDBClusterParametersMessage, "You must provide a DescribeDBClusterParametersMessage")
 	local headers = {
@@ -15202,19 +15248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBClusterParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBClusterParametersSync(DescribeDBClusterParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBClusterParametersAsync(DescribeDBClusterParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBClusterParametersAsync(DescribeDBClusterParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBSnapshot asynchronously, invoking a callback when done
 -- @param DeleteDBSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBSnapshotAsync(DeleteDBSnapshotMessage, cb)
 	assert(DeleteDBSnapshotMessage, "You must provide a DeleteDBSnapshotMessage")
 	local headers = {
@@ -15237,19 +15284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBSnapshotSync(DeleteDBSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBSnapshotAsync(DeleteDBSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBSnapshotAsync(DeleteDBSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsMessage, cb)
 	assert(DescribeEventsMessage, "You must provide a DescribeEventsMessage")
 	local headers = {
@@ -15272,19 +15320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventSubscriptions asynchronously, invoking a callback when done
 -- @param DescribeEventSubscriptionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, cb)
 	assert(DescribeEventSubscriptionsMessage, "You must provide a DescribeEventSubscriptionsMessage")
 	local headers = {
@@ -15307,19 +15356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventSubscriptionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventSubscriptionsSync(DescribeEventSubscriptionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteOptionGroup asynchronously, invoking a callback when done
 -- @param DeleteOptionGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteOptionGroupAsync(DeleteOptionGroupMessage, cb)
 	assert(DeleteOptionGroupMessage, "You must provide a DeleteOptionGroupMessage")
 	local headers = {
@@ -15342,19 +15392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteOptionGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteOptionGroupSync(DeleteOptionGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteOptionGroupAsync(DeleteOptionGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteOptionGroupAsync(DeleteOptionGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PromoteReadReplica asynchronously, invoking a callback when done
 -- @param PromoteReadReplicaMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PromoteReadReplicaAsync(PromoteReadReplicaMessage, cb)
 	assert(PromoteReadReplicaMessage, "You must provide a PromoteReadReplicaMessage")
 	local headers = {
@@ -15377,19 +15428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PromoteReadReplicaMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PromoteReadReplicaSync(PromoteReadReplicaMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PromoteReadReplicaAsync(PromoteReadReplicaMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PromoteReadReplicaAsync(PromoteReadReplicaMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddRoleToDBCluster asynchronously, invoking a callback when done
 -- @param AddRoleToDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddRoleToDBClusterAsync(AddRoleToDBClusterMessage, cb)
 	assert(AddRoleToDBClusterMessage, "You must provide a AddRoleToDBClusterMessage")
 	local headers = {
@@ -15412,19 +15464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddRoleToDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddRoleToDBClusterSync(AddRoleToDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddRoleToDBClusterAsync(AddRoleToDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddRoleToDBClusterAsync(AddRoleToDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBSnapshotAttribute asynchronously, invoking a callback when done
 -- @param ModifyDBSnapshotAttributeMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBSnapshotAttributeAsync(ModifyDBSnapshotAttributeMessage, cb)
 	assert(ModifyDBSnapshotAttributeMessage, "You must provide a ModifyDBSnapshotAttributeMessage")
 	local headers = {
@@ -15447,19 +15500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBSnapshotAttributeMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBSnapshotAttributeSync(ModifyDBSnapshotAttributeMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBSnapshotAttributeAsync(ModifyDBSnapshotAttributeMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBSnapshotAttributeAsync(ModifyDBSnapshotAttributeMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBParameterGroups asynchronously, invoking a callback when done
 -- @param DescribeDBParameterGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBParameterGroupsAsync(DescribeDBParameterGroupsMessage, cb)
 	assert(DescribeDBParameterGroupsMessage, "You must provide a DescribeDBParameterGroupsMessage")
 	local headers = {
@@ -15482,19 +15536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBParameterGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBParameterGroupsSync(DescribeDBParameterGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBParameterGroupsAsync(DescribeDBParameterGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBParameterGroupsAsync(DescribeDBParameterGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBClusterParameterGroup asynchronously, invoking a callback when done
 -- @param ModifyDBClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBClusterParameterGroupAsync(ModifyDBClusterParameterGroupMessage, cb)
 	assert(ModifyDBClusterParameterGroupMessage, "You must provide a ModifyDBClusterParameterGroupMessage")
 	local headers = {
@@ -15517,19 +15572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBClusterParameterGroupSync(ModifyDBClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBClusterParameterGroupAsync(ModifyDBClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBClusterParameterGroupAsync(ModifyDBClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call FailoverDBCluster asynchronously, invoking a callback when done
 -- @param FailoverDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.FailoverDBClusterAsync(FailoverDBClusterMessage, cb)
 	assert(FailoverDBClusterMessage, "You must provide a FailoverDBClusterMessage")
 	local headers = {
@@ -15552,19 +15608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param FailoverDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.FailoverDBClusterSync(FailoverDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.FailoverDBClusterAsync(FailoverDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.FailoverDBClusterAsync(FailoverDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ApplyPendingMaintenanceAction asynchronously, invoking a callback when done
 -- @param ApplyPendingMaintenanceActionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ApplyPendingMaintenanceActionAsync(ApplyPendingMaintenanceActionMessage, cb)
 	assert(ApplyPendingMaintenanceActionMessage, "You must provide a ApplyPendingMaintenanceActionMessage")
 	local headers = {
@@ -15587,19 +15644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ApplyPendingMaintenanceActionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ApplyPendingMaintenanceActionSync(ApplyPendingMaintenanceActionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ApplyPendingMaintenanceActionAsync(ApplyPendingMaintenanceActionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ApplyPendingMaintenanceActionAsync(ApplyPendingMaintenanceActionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBInstances asynchronously, invoking a callback when done
 -- @param DescribeDBInstancesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBInstancesAsync(DescribeDBInstancesMessage, cb)
 	assert(DescribeDBInstancesMessage, "You must provide a DescribeDBInstancesMessage")
 	local headers = {
@@ -15622,19 +15680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBInstancesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBInstancesSync(DescribeDBInstancesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBInstancesAsync(DescribeDBInstancesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBInstancesAsync(DescribeDBInstancesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseReservedDBInstancesOffering asynchronously, invoking a callback when done
 -- @param PurchaseReservedDBInstancesOfferingMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseReservedDBInstancesOfferingAsync(PurchaseReservedDBInstancesOfferingMessage, cb)
 	assert(PurchaseReservedDBInstancesOfferingMessage, "You must provide a PurchaseReservedDBInstancesOfferingMessage")
 	local headers = {
@@ -15657,19 +15716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseReservedDBInstancesOfferingMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseReservedDBInstancesOfferingSync(PurchaseReservedDBInstancesOfferingMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseReservedDBInstancesOfferingAsync(PurchaseReservedDBInstancesOfferingMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseReservedDBInstancesOfferingAsync(PurchaseReservedDBInstancesOfferingMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOrderableDBInstanceOptions asynchronously, invoking a callback when done
 -- @param DescribeOrderableDBInstanceOptionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOrderableDBInstanceOptionsAsync(DescribeOrderableDBInstanceOptionsMessage, cb)
 	assert(DescribeOrderableDBInstanceOptionsMessage, "You must provide a DescribeOrderableDBInstanceOptionsMessage")
 	local headers = {
@@ -15692,19 +15752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOrderableDBInstanceOptionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOrderableDBInstanceOptionsSync(DescribeOrderableDBInstanceOptionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOrderableDBInstanceOptionsAsync(DescribeOrderableDBInstanceOptionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOrderableDBInstanceOptionsAsync(DescribeOrderableDBInstanceOptionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreDBInstanceFromS3 asynchronously, invoking a callback when done
 -- @param RestoreDBInstanceFromS3Message
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreDBInstanceFromS3Async(RestoreDBInstanceFromS3Message, cb)
 	assert(RestoreDBInstanceFromS3Message, "You must provide a RestoreDBInstanceFromS3Message")
 	local headers = {
@@ -15727,19 +15788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreDBInstanceFromS3Message
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreDBInstanceFromS3Sync(RestoreDBInstanceFromS3Message, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreDBInstanceFromS3Async(RestoreDBInstanceFromS3Message, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreDBInstanceFromS3Async(RestoreDBInstanceFromS3Message, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateOptionGroup asynchronously, invoking a callback when done
 -- @param CreateOptionGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateOptionGroupAsync(CreateOptionGroupMessage, cb)
 	assert(CreateOptionGroupMessage, "You must provide a CreateOptionGroupMessage")
 	local headers = {
@@ -15762,19 +15824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateOptionGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateOptionGroupSync(CreateOptionGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateOptionGroupAsync(CreateOptionGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateOptionGroupAsync(CreateOptionGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOptionGroupOptions asynchronously, invoking a callback when done
 -- @param DescribeOptionGroupOptionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOptionGroupOptionsAsync(DescribeOptionGroupOptionsMessage, cb)
 	assert(DescribeOptionGroupOptionsMessage, "You must provide a DescribeOptionGroupOptionsMessage")
 	local headers = {
@@ -15797,19 +15860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOptionGroupOptionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOptionGroupOptionsSync(DescribeOptionGroupOptionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOptionGroupOptionsAsync(DescribeOptionGroupOptionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOptionGroupOptionsAsync(DescribeOptionGroupOptionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetDBParameterGroup asynchronously, invoking a callback when done
 -- @param ResetDBParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetDBParameterGroupAsync(ResetDBParameterGroupMessage, cb)
 	assert(ResetDBParameterGroupMessage, "You must provide a ResetDBParameterGroupMessage")
 	local headers = {
@@ -15832,19 +15896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetDBParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetDBParameterGroupSync(ResetDBParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetDBParameterGroupAsync(ResetDBParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetDBParameterGroupAsync(ResetDBParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEngineDefaultClusterParameters asynchronously, invoking a callback when done
 -- @param DescribeEngineDefaultClusterParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEngineDefaultClusterParametersAsync(DescribeEngineDefaultClusterParametersMessage, cb)
 	assert(DescribeEngineDefaultClusterParametersMessage, "You must provide a DescribeEngineDefaultClusterParametersMessage")
 	local headers = {
@@ -15867,19 +15932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEngineDefaultClusterParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEngineDefaultClusterParametersSync(DescribeEngineDefaultClusterParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEngineDefaultClusterParametersAsync(DescribeEngineDefaultClusterParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEngineDefaultClusterParametersAsync(DescribeEngineDefaultClusterParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBSnapshot asynchronously, invoking a callback when done
 -- @param CreateDBSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBSnapshotAsync(CreateDBSnapshotMessage, cb)
 	assert(CreateDBSnapshotMessage, "You must provide a CreateDBSnapshotMessage")
 	local headers = {
@@ -15902,19 +15968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBSnapshotSync(CreateDBSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBSnapshotAsync(CreateDBSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBSnapshotAsync(CreateDBSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBCluster asynchronously, invoking a callback when done
 -- @param CreateDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBClusterAsync(CreateDBClusterMessage, cb)
 	assert(CreateDBClusterMessage, "You must provide a CreateDBClusterMessage")
 	local headers = {
@@ -15937,19 +16004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBClusterSync(CreateDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBClusterAsync(CreateDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBClusterAsync(CreateDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAccountAttributes asynchronously, invoking a callback when done
 -- @param DescribeAccountAttributesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAccountAttributesAsync(DescribeAccountAttributesMessage, cb)
 	assert(DescribeAccountAttributesMessage, "You must provide a DescribeAccountAttributesMessage")
 	local headers = {
@@ -15972,19 +16040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAccountAttributesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAccountAttributesSync(DescribeAccountAttributesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAccountAttributesAsync(DescribeAccountAttributesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAccountAttributesAsync(DescribeAccountAttributesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBSnapshots asynchronously, invoking a callback when done
 -- @param DescribeDBSnapshotsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBSnapshotsAsync(DescribeDBSnapshotsMessage, cb)
 	assert(DescribeDBSnapshotsMessage, "You must provide a DescribeDBSnapshotsMessage")
 	local headers = {
@@ -16007,19 +16076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBSnapshotsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBSnapshotsSync(DescribeDBSnapshotsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBSnapshotsAsync(DescribeDBSnapshotsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBSnapshotsAsync(DescribeDBSnapshotsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBClusterSnapshotAttribute asynchronously, invoking a callback when done
 -- @param ModifyDBClusterSnapshotAttributeMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBClusterSnapshotAttributeAsync(ModifyDBClusterSnapshotAttributeMessage, cb)
 	assert(ModifyDBClusterSnapshotAttributeMessage, "You must provide a ModifyDBClusterSnapshotAttributeMessage")
 	local headers = {
@@ -16042,19 +16112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBClusterSnapshotAttributeMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBClusterSnapshotAttributeSync(ModifyDBClusterSnapshotAttributeMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBClusterSnapshotAttributeAsync(ModifyDBClusterSnapshotAttributeMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBClusterSnapshotAttributeAsync(ModifyDBClusterSnapshotAttributeMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBSecurityGroup asynchronously, invoking a callback when done
 -- @param CreateDBSecurityGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBSecurityGroupAsync(CreateDBSecurityGroupMessage, cb)
 	assert(CreateDBSecurityGroupMessage, "You must provide a CreateDBSecurityGroupMessage")
 	local headers = {
@@ -16077,19 +16148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBSecurityGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBSecurityGroupSync(CreateDBSecurityGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBSecurityGroupAsync(CreateDBSecurityGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBSecurityGroupAsync(CreateDBSecurityGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyCurrentDBClusterCapacity asynchronously, invoking a callback when done
 -- @param ModifyCurrentDBClusterCapacityMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyCurrentDBClusterCapacityAsync(ModifyCurrentDBClusterCapacityMessage, cb)
 	assert(ModifyCurrentDBClusterCapacityMessage, "You must provide a ModifyCurrentDBClusterCapacityMessage")
 	local headers = {
@@ -16112,19 +16184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyCurrentDBClusterCapacityMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyCurrentDBClusterCapacitySync(ModifyCurrentDBClusterCapacityMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyCurrentDBClusterCapacityAsync(ModifyCurrentDBClusterCapacityMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyCurrentDBClusterCapacityAsync(ModifyCurrentDBClusterCapacityMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeValidDBInstanceModifications asynchronously, invoking a callback when done
 -- @param DescribeValidDBInstanceModificationsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeValidDBInstanceModificationsAsync(DescribeValidDBInstanceModificationsMessage, cb)
 	assert(DescribeValidDBInstanceModificationsMessage, "You must provide a DescribeValidDBInstanceModificationsMessage")
 	local headers = {
@@ -16147,19 +16220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeValidDBInstanceModificationsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeValidDBInstanceModificationsSync(DescribeValidDBInstanceModificationsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeValidDBInstanceModificationsAsync(DescribeValidDBInstanceModificationsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeValidDBInstanceModificationsAsync(DescribeValidDBInstanceModificationsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopDBInstance asynchronously, invoking a callback when done
 -- @param StopDBInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopDBInstanceAsync(StopDBInstanceMessage, cb)
 	assert(StopDBInstanceMessage, "You must provide a StopDBInstanceMessage")
 	local headers = {
@@ -16182,19 +16256,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopDBInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopDBInstanceSync(StopDBInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopDBInstanceAsync(StopDBInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopDBInstanceAsync(StopDBInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveRoleFromDBCluster asynchronously, invoking a callback when done
 -- @param RemoveRoleFromDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveRoleFromDBClusterAsync(RemoveRoleFromDBClusterMessage, cb)
 	assert(RemoveRoleFromDBClusterMessage, "You must provide a RemoveRoleFromDBClusterMessage")
 	local headers = {
@@ -16217,19 +16292,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveRoleFromDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveRoleFromDBClusterSync(RemoveRoleFromDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveRoleFromDBClusterAsync(RemoveRoleFromDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveRoleFromDBClusterAsync(RemoveRoleFromDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeDBSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param RevokeDBSecurityGroupIngressMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeDBSecurityGroupIngressAsync(RevokeDBSecurityGroupIngressMessage, cb)
 	assert(RevokeDBSecurityGroupIngressMessage, "You must provide a RevokeDBSecurityGroupIngressMessage")
 	local headers = {
@@ -16252,19 +16328,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeDBSecurityGroupIngressMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeDBSecurityGroupIngressSync(RevokeDBSecurityGroupIngressMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeDBSecurityGroupIngressAsync(RevokeDBSecurityGroupIngressMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeDBSecurityGroupIngressAsync(RevokeDBSecurityGroupIngressMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEventSubscription asynchronously, invoking a callback when done
 -- @param CreateEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, cb)
 	assert(CreateEventSubscriptionMessage, "You must provide a CreateEventSubscriptionMessage")
 	local headers = {
@@ -16287,19 +16364,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEventSubscriptionSync(CreateEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyDBParameterGroup asynchronously, invoking a callback when done
 -- @param CopyDBParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyDBParameterGroupAsync(CopyDBParameterGroupMessage, cb)
 	assert(CopyDBParameterGroupMessage, "You must provide a CopyDBParameterGroupMessage")
 	local headers = {
@@ -16322,19 +16400,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyDBParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyDBParameterGroupSync(CopyDBParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyDBParameterGroupAsync(CopyDBParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyDBParameterGroupAsync(CopyDBParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootDBInstance asynchronously, invoking a callback when done
 -- @param RebootDBInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootDBInstanceAsync(RebootDBInstanceMessage, cb)
 	assert(RebootDBInstanceMessage, "You must provide a RebootDBInstanceMessage")
 	local headers = {
@@ -16357,19 +16436,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootDBInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootDBInstanceSync(RebootDBInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootDBInstanceAsync(RebootDBInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootDBInstanceAsync(RebootDBInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDBSubnetGroup asynchronously, invoking a callback when done
 -- @param CreateDBSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDBSubnetGroupAsync(CreateDBSubnetGroupMessage, cb)
 	assert(CreateDBSubnetGroupMessage, "You must provide a CreateDBSubnetGroupMessage")
 	local headers = {
@@ -16392,19 +16472,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDBSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDBSubnetGroupSync(CreateDBSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDBSubnetGroupAsync(CreateDBSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDBSubnetGroupAsync(CreateDBSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBCluster asynchronously, invoking a callback when done
 -- @param ModifyDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBClusterAsync(ModifyDBClusterMessage, cb)
 	assert(ModifyDBClusterMessage, "You must provide a ModifyDBClusterMessage")
 	local headers = {
@@ -16427,19 +16508,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBClusterSync(ModifyDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBClusterAsync(ModifyDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBClusterAsync(ModifyDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBSnapshotAttributes asynchronously, invoking a callback when done
 -- @param DescribeDBSnapshotAttributesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBSnapshotAttributesAsync(DescribeDBSnapshotAttributesMessage, cb)
 	assert(DescribeDBSnapshotAttributesMessage, "You must provide a DescribeDBSnapshotAttributesMessage")
 	local headers = {
@@ -16462,19 +16544,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBSnapshotAttributesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBSnapshotAttributesSync(DescribeDBSnapshotAttributesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBSnapshotAttributesAsync(DescribeDBSnapshotAttributesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBSnapshotAttributesAsync(DescribeDBSnapshotAttributesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSourceRegions asynchronously, invoking a callback when done
 -- @param DescribeSourceRegionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSourceRegionsAsync(DescribeSourceRegionsMessage, cb)
 	assert(DescribeSourceRegionsMessage, "You must provide a DescribeSourceRegionsMessage")
 	local headers = {
@@ -16497,19 +16580,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSourceRegionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSourceRegionsSync(DescribeSourceRegionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSourceRegionsAsync(DescribeSourceRegionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSourceRegionsAsync(DescribeSourceRegionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DownloadDBLogFilePortion asynchronously, invoking a callback when done
 -- @param DownloadDBLogFilePortionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DownloadDBLogFilePortionAsync(DownloadDBLogFilePortionMessage, cb)
 	assert(DownloadDBLogFilePortionMessage, "You must provide a DownloadDBLogFilePortionMessage")
 	local headers = {
@@ -16532,19 +16616,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DownloadDBLogFilePortionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DownloadDBLogFilePortionSync(DownloadDBLogFilePortionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DownloadDBLogFilePortionAsync(DownloadDBLogFilePortionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DownloadDBLogFilePortionAsync(DownloadDBLogFilePortionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBClusters asynchronously, invoking a callback when done
 -- @param DescribeDBClustersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBClustersAsync(DescribeDBClustersMessage, cb)
 	assert(DescribeDBClustersMessage, "You must provide a DescribeDBClustersMessage")
 	local headers = {
@@ -16567,19 +16652,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBClustersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBClustersSync(DescribeDBClustersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBClustersAsync(DescribeDBClustersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBClustersAsync(DescribeDBClustersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBClusterSnapshots asynchronously, invoking a callback when done
 -- @param DescribeDBClusterSnapshotsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBClusterSnapshotsAsync(DescribeDBClusterSnapshotsMessage, cb)
 	assert(DescribeDBClusterSnapshotsMessage, "You must provide a DescribeDBClusterSnapshotsMessage")
 	local headers = {
@@ -16602,19 +16688,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBClusterSnapshotsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBClusterSnapshotsSync(DescribeDBClusterSnapshotsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBClusterSnapshotsAsync(DescribeDBClusterSnapshotsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBClusterSnapshotsAsync(DescribeDBClusterSnapshotsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBParameterGroup asynchronously, invoking a callback when done
 -- @param ModifyDBParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBParameterGroupAsync(ModifyDBParameterGroupMessage, cb)
 	assert(ModifyDBParameterGroupMessage, "You must provide a ModifyDBParameterGroupMessage")
 	local headers = {
@@ -16637,19 +16724,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBParameterGroupSync(ModifyDBParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBParameterGroupAsync(ModifyDBParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBParameterGroupAsync(ModifyDBParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartDBCluster asynchronously, invoking a callback when done
 -- @param StartDBClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartDBClusterAsync(StartDBClusterMessage, cb)
 	assert(StartDBClusterMessage, "You must provide a StartDBClusterMessage")
 	local headers = {
@@ -16672,19 +16760,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartDBClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartDBClusterSync(StartDBClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartDBClusterAsync(StartDBClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartDBClusterAsync(StartDBClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBSecurityGroups asynchronously, invoking a callback when done
 -- @param DescribeDBSecurityGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBSecurityGroupsAsync(DescribeDBSecurityGroupsMessage, cb)
 	assert(DescribeDBSecurityGroupsMessage, "You must provide a DescribeDBSecurityGroupsMessage")
 	local headers = {
@@ -16707,19 +16796,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBSecurityGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBSecurityGroupsSync(DescribeDBSecurityGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBSecurityGroupsAsync(DescribeDBSecurityGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBSecurityGroupsAsync(DescribeDBSecurityGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDBClusterParameterGroup asynchronously, invoking a callback when done
 -- @param DeleteDBClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDBClusterParameterGroupAsync(DeleteDBClusterParameterGroupMessage, cb)
 	assert(DeleteDBClusterParameterGroupMessage, "You must provide a DeleteDBClusterParameterGroupMessage")
 	local headers = {
@@ -16742,19 +16832,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDBClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDBClusterParameterGroupSync(DeleteDBClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDBClusterParameterGroupAsync(DeleteDBClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDBClusterParameterGroupAsync(DeleteDBClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePendingMaintenanceActions asynchronously, invoking a callback when done
 -- @param DescribePendingMaintenanceActionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePendingMaintenanceActionsAsync(DescribePendingMaintenanceActionsMessage, cb)
 	assert(DescribePendingMaintenanceActionsMessage, "You must provide a DescribePendingMaintenanceActionsMessage")
 	local headers = {
@@ -16777,19 +16868,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePendingMaintenanceActionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePendingMaintenanceActionsSync(DescribePendingMaintenanceActionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePendingMaintenanceActionsAsync(DescribePendingMaintenanceActionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePendingMaintenanceActionsAsync(DescribePendingMaintenanceActionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDBClusterParameterGroups asynchronously, invoking a callback when done
 -- @param DescribeDBClusterParameterGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDBClusterParameterGroupsAsync(DescribeDBClusterParameterGroupsMessage, cb)
 	assert(DescribeDBClusterParameterGroupsMessage, "You must provide a DescribeDBClusterParameterGroupsMessage")
 	local headers = {
@@ -16812,19 +16904,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDBClusterParameterGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDBClusterParameterGroupsSync(DescribeDBClusterParameterGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDBClusterParameterGroupsAsync(DescribeDBClusterParameterGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDBClusterParameterGroupsAsync(DescribeDBClusterParameterGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyDBClusterSnapshot asynchronously, invoking a callback when done
 -- @param CopyDBClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyDBClusterSnapshotAsync(CopyDBClusterSnapshotMessage, cb)
 	assert(CopyDBClusterSnapshotMessage, "You must provide a CopyDBClusterSnapshotMessage")
 	local headers = {
@@ -16847,19 +16940,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyDBClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyDBClusterSnapshotSync(CopyDBClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyDBClusterSnapshotAsync(CopyDBClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyDBClusterSnapshotAsync(CopyDBClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDBInstance asynchronously, invoking a callback when done
 -- @param ModifyDBInstanceMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDBInstanceAsync(ModifyDBInstanceMessage, cb)
 	assert(ModifyDBInstanceMessage, "You must provide a ModifyDBInstanceMessage")
 	local headers = {
@@ -16882,19 +16976,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDBInstanceMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDBInstanceSync(ModifyDBInstanceMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDBInstanceAsync(ModifyDBInstanceMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDBInstanceAsync(ModifyDBInstanceMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveSourceIdentifierFromSubscription asynchronously, invoking a callback when done
 -- @param RemoveSourceIdentifierFromSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveSourceIdentifierFromSubscriptionAsync(RemoveSourceIdentifierFromSubscriptionMessage, cb)
 	assert(RemoveSourceIdentifierFromSubscriptionMessage, "You must provide a RemoveSourceIdentifierFromSubscriptionMessage")
 	local headers = {
@@ -16917,12 +17012,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveSourceIdentifierFromSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveSourceIdentifierFromSubscriptionSync(RemoveSourceIdentifierFromSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveSourceIdentifierFromSubscriptionAsync(RemoveSourceIdentifierFromSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveSourceIdentifierFromSubscriptionAsync(RemoveSourceIdentifierFromSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/redshift.lua
+++ b/aws-sdk/redshift.lua
@@ -8865,7 +8865,7 @@ end
 --
 --- Call DeleteTags asynchronously, invoking a callback when done
 -- @param DeleteTagsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsAsync(DeleteTagsMessage, cb)
 	assert(DeleteTagsMessage, "You must provide a DeleteTagsMessage")
 	local headers = {
@@ -8888,19 +8888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsSync(DeleteTagsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsAsync(DeleteTagsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsAsync(DeleteTagsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDefaultClusterParameters asynchronously, invoking a callback when done
 -- @param DescribeDefaultClusterParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDefaultClusterParametersAsync(DescribeDefaultClusterParametersMessage, cb)
 	assert(DescribeDefaultClusterParametersMessage, "You must provide a DescribeDefaultClusterParametersMessage")
 	local headers = {
@@ -8923,19 +8924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDefaultClusterParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDefaultClusterParametersSync(DescribeDefaultClusterParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDefaultClusterParametersAsync(DescribeDefaultClusterParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDefaultClusterParametersAsync(DescribeDefaultClusterParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterParameterGroups asynchronously, invoking a callback when done
 -- @param DescribeClusterParameterGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterParameterGroupsAsync(DescribeClusterParameterGroupsMessage, cb)
 	assert(DescribeClusterParameterGroupsMessage, "You must provide a DescribeClusterParameterGroupsMessage")
 	local headers = {
@@ -8958,19 +8960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterParameterGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterParameterGroupsSync(DescribeClusterParameterGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterParameterGroupsAsync(DescribeClusterParameterGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterParameterGroupsAsync(DescribeClusterParameterGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreFromClusterSnapshot asynchronously, invoking a callback when done
 -- @param RestoreFromClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreFromClusterSnapshotAsync(RestoreFromClusterSnapshotMessage, cb)
 	assert(RestoreFromClusterSnapshotMessage, "You must provide a RestoreFromClusterSnapshotMessage")
 	local headers = {
@@ -8993,19 +8996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreFromClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreFromClusterSnapshotSync(RestoreFromClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreFromClusterSnapshotAsync(RestoreFromClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreFromClusterSnapshotAsync(RestoreFromClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCluster asynchronously, invoking a callback when done
 -- @param CreateClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterAsync(CreateClusterMessage, cb)
 	assert(CreateClusterMessage, "You must provide a CreateClusterMessage")
 	local headers = {
@@ -9028,19 +9032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSync(CreateClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterAsync(CreateClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterAsync(CreateClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyClusterSnapshot asynchronously, invoking a callback when done
 -- @param CopyClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyClusterSnapshotAsync(CopyClusterSnapshotMessage, cb)
 	assert(CopyClusterSnapshotMessage, "You must provide a CopyClusterSnapshotMessage")
 	local headers = {
@@ -9063,19 +9068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyClusterSnapshotSync(CopyClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyClusterSnapshotAsync(CopyClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyClusterSnapshotAsync(CopyClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateClusterSecurityGroup asynchronously, invoking a callback when done
 -- @param CreateClusterSecurityGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterSecurityGroupAsync(CreateClusterSecurityGroupMessage, cb)
 	assert(CreateClusterSecurityGroupMessage, "You must provide a CreateClusterSecurityGroupMessage")
 	local headers = {
@@ -9098,19 +9104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterSecurityGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSecurityGroupSync(CreateClusterSecurityGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterSecurityGroupAsync(CreateClusterSecurityGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterSecurityGroupAsync(CreateClusterSecurityGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEvents asynchronously, invoking a callback when done
 -- @param DescribeEventsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventsAsync(DescribeEventsMessage, cb)
 	assert(DescribeEventsMessage, "You must provide a DescribeEventsMessage")
 	local headers = {
@@ -9133,19 +9140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventsSync(DescribeEventsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventsAsync(DescribeEventsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventSubscriptions asynchronously, invoking a callback when done
 -- @param DescribeEventSubscriptionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, cb)
 	assert(DescribeEventSubscriptionsMessage, "You must provide a DescribeEventSubscriptionsMessage")
 	local headers = {
@@ -9168,19 +9176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventSubscriptionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventSubscriptionsSync(DescribeEventSubscriptionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventSubscriptionsAsync(DescribeEventSubscriptionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateEventSubscription asynchronously, invoking a callback when done
 -- @param CreateEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, cb)
 	assert(CreateEventSubscriptionMessage, "You must provide a CreateEventSubscriptionMessage")
 	local headers = {
@@ -9203,19 +9212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateEventSubscriptionSync(CreateEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateEventSubscriptionAsync(CreateEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHsmClientCertificates asynchronously, invoking a callback when done
 -- @param DescribeHsmClientCertificatesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHsmClientCertificatesAsync(DescribeHsmClientCertificatesMessage, cb)
 	assert(DescribeHsmClientCertificatesMessage, "You must provide a DescribeHsmClientCertificatesMessage")
 	local headers = {
@@ -9238,19 +9248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHsmClientCertificatesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHsmClientCertificatesSync(DescribeHsmClientCertificatesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHsmClientCertificatesAsync(DescribeHsmClientCertificatesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHsmClientCertificatesAsync(DescribeHsmClientCertificatesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCluster asynchronously, invoking a callback when done
 -- @param DeleteClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterAsync(DeleteClusterMessage, cb)
 	assert(DeleteClusterMessage, "You must provide a DeleteClusterMessage")
 	local headers = {
@@ -9273,19 +9284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSync(DeleteClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterAsync(DeleteClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterAsync(DeleteClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSnapshotCopyGrant asynchronously, invoking a callback when done
 -- @param CreateSnapshotCopyGrantMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSnapshotCopyGrantAsync(CreateSnapshotCopyGrantMessage, cb)
 	assert(CreateSnapshotCopyGrantMessage, "You must provide a CreateSnapshotCopyGrantMessage")
 	local headers = {
@@ -9308,19 +9320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSnapshotCopyGrantMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSnapshotCopyGrantSync(CreateSnapshotCopyGrantMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSnapshotCopyGrantAsync(CreateSnapshotCopyGrantMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSnapshotCopyGrantAsync(CreateSnapshotCopyGrantMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEventCategories asynchronously, invoking a callback when done
 -- @param DescribeEventCategoriesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, cb)
 	assert(DescribeEventCategoriesMessage, "You must provide a DescribeEventCategoriesMessage")
 	local headers = {
@@ -9343,19 +9356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEventCategoriesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEventCategoriesSync(DescribeEventCategoriesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEventCategoriesAsync(DescribeEventCategoriesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifySnapshotCopyRetentionPeriod asynchronously, invoking a callback when done
 -- @param ModifySnapshotCopyRetentionPeriodMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifySnapshotCopyRetentionPeriodAsync(ModifySnapshotCopyRetentionPeriodMessage, cb)
 	assert(ModifySnapshotCopyRetentionPeriodMessage, "You must provide a ModifySnapshotCopyRetentionPeriodMessage")
 	local headers = {
@@ -9378,19 +9392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifySnapshotCopyRetentionPeriodMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifySnapshotCopyRetentionPeriodSync(ModifySnapshotCopyRetentionPeriodMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifySnapshotCopyRetentionPeriodAsync(ModifySnapshotCopyRetentionPeriodMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifySnapshotCopyRetentionPeriodAsync(ModifySnapshotCopyRetentionPeriodMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetClusterCredentials asynchronously, invoking a callback when done
 -- @param GetClusterCredentialsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetClusterCredentialsAsync(GetClusterCredentialsMessage, cb)
 	assert(GetClusterCredentialsMessage, "You must provide a GetClusterCredentialsMessage")
 	local headers = {
@@ -9413,19 +9428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetClusterCredentialsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetClusterCredentialsSync(GetClusterCredentialsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetClusterCredentialsAsync(GetClusterCredentialsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetClusterCredentialsAsync(GetClusterCredentialsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSnapshotCopyGrant asynchronously, invoking a callback when done
 -- @param DeleteSnapshotCopyGrantMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSnapshotCopyGrantAsync(DeleteSnapshotCopyGrantMessage, cb)
 	assert(DeleteSnapshotCopyGrantMessage, "You must provide a DeleteSnapshotCopyGrantMessage")
 	local headers = {
@@ -9448,19 +9464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSnapshotCopyGrantMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSnapshotCopyGrantSync(DeleteSnapshotCopyGrantMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSnapshotCopyGrantAsync(DeleteSnapshotCopyGrantMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSnapshotCopyGrantAsync(DeleteSnapshotCopyGrantMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedNodes asynchronously, invoking a callback when done
 -- @param DescribeReservedNodesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedNodesAsync(DescribeReservedNodesMessage, cb)
 	assert(DescribeReservedNodesMessage, "You must provide a DescribeReservedNodesMessage")
 	local headers = {
@@ -9483,19 +9500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedNodesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedNodesSync(DescribeReservedNodesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedNodesAsync(DescribeReservedNodesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedNodesAsync(DescribeReservedNodesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AuthorizeSnapshotAccess asynchronously, invoking a callback when done
 -- @param AuthorizeSnapshotAccessMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AuthorizeSnapshotAccessAsync(AuthorizeSnapshotAccessMessage, cb)
 	assert(AuthorizeSnapshotAccessMessage, "You must provide a AuthorizeSnapshotAccessMessage")
 	local headers = {
@@ -9518,19 +9536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AuthorizeSnapshotAccessMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AuthorizeSnapshotAccessSync(AuthorizeSnapshotAccessMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AuthorizeSnapshotAccessAsync(AuthorizeSnapshotAccessMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AuthorizeSnapshotAccessAsync(AuthorizeSnapshotAccessMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableLogging asynchronously, invoking a callback when done
 -- @param EnableLoggingMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableLoggingAsync(EnableLoggingMessage, cb)
 	assert(EnableLoggingMessage, "You must provide a EnableLoggingMessage")
 	local headers = {
@@ -9553,19 +9572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableLoggingMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableLoggingSync(EnableLoggingMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableLoggingAsync(EnableLoggingMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableLoggingAsync(EnableLoggingMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableSnapshotCopy asynchronously, invoking a callback when done
 -- @param DisableSnapshotCopyMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableSnapshotCopyAsync(DisableSnapshotCopyMessage, cb)
 	assert(DisableSnapshotCopyMessage, "You must provide a DisableSnapshotCopyMessage")
 	local headers = {
@@ -9588,19 +9608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableSnapshotCopyMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableSnapshotCopySync(DisableSnapshotCopyMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableSnapshotCopyAsync(DisableSnapshotCopyMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableSnapshotCopyAsync(DisableSnapshotCopyMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHsmClientCertificate asynchronously, invoking a callback when done
 -- @param DeleteHsmClientCertificateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHsmClientCertificateAsync(DeleteHsmClientCertificateMessage, cb)
 	assert(DeleteHsmClientCertificateMessage, "You must provide a DeleteHsmClientCertificateMessage")
 	local headers = {
@@ -9623,19 +9644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHsmClientCertificateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHsmClientCertificateSync(DeleteHsmClientCertificateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHsmClientCertificateAsync(DeleteHsmClientCertificateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHsmClientCertificateAsync(DeleteHsmClientCertificateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootCluster asynchronously, invoking a callback when done
 -- @param RebootClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootClusterAsync(RebootClusterMessage, cb)
 	assert(RebootClusterMessage, "You must provide a RebootClusterMessage")
 	local headers = {
@@ -9658,19 +9680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootClusterSync(RebootClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootClusterAsync(RebootClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootClusterAsync(RebootClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterDbRevisions asynchronously, invoking a callback when done
 -- @param DescribeClusterDbRevisionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterDbRevisionsAsync(DescribeClusterDbRevisionsMessage, cb)
 	assert(DescribeClusterDbRevisionsMessage, "You must provide a DescribeClusterDbRevisionsMessage")
 	local headers = {
@@ -9693,19 +9716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterDbRevisionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterDbRevisionsSync(DescribeClusterDbRevisionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterDbRevisionsAsync(DescribeClusterDbRevisionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterDbRevisionsAsync(DescribeClusterDbRevisionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHsmConfiguration asynchronously, invoking a callback when done
 -- @param CreateHsmConfigurationMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHsmConfigurationAsync(CreateHsmConfigurationMessage, cb)
 	assert(CreateHsmConfigurationMessage, "You must provide a CreateHsmConfigurationMessage")
 	local headers = {
@@ -9728,19 +9752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHsmConfigurationMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHsmConfigurationSync(CreateHsmConfigurationMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHsmConfigurationAsync(CreateHsmConfigurationMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHsmConfigurationAsync(CreateHsmConfigurationMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeSnapshotAccess asynchronously, invoking a callback when done
 -- @param RevokeSnapshotAccessMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeSnapshotAccessAsync(RevokeSnapshotAccessMessage, cb)
 	assert(RevokeSnapshotAccessMessage, "You must provide a RevokeSnapshotAccessMessage")
 	local headers = {
@@ -9763,19 +9788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeSnapshotAccessMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeSnapshotAccessSync(RevokeSnapshotAccessMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeSnapshotAccessAsync(RevokeSnapshotAccessMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeSnapshotAccessAsync(RevokeSnapshotAccessMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusters asynchronously, invoking a callback when done
 -- @param DescribeClustersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClustersAsync(DescribeClustersMessage, cb)
 	assert(DescribeClustersMessage, "You must provide a DescribeClustersMessage")
 	local headers = {
@@ -9798,19 +9824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClustersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClustersSync(DescribeClustersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClustersAsync(DescribeClustersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClustersAsync(DescribeClustersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyClusterIamRoles asynchronously, invoking a callback when done
 -- @param ModifyClusterIamRolesMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyClusterIamRolesAsync(ModifyClusterIamRolesMessage, cb)
 	assert(ModifyClusterIamRolesMessage, "You must provide a ModifyClusterIamRolesMessage")
 	local headers = {
@@ -9833,19 +9860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyClusterIamRolesMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyClusterIamRolesSync(ModifyClusterIamRolesMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyClusterIamRolesAsync(ModifyClusterIamRolesMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyClusterIamRolesAsync(ModifyClusterIamRolesMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetClusterParameterGroup asynchronously, invoking a callback when done
 -- @param ResetClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetClusterParameterGroupAsync(ResetClusterParameterGroupMessage, cb)
 	assert(ResetClusterParameterGroupMessage, "You must provide a ResetClusterParameterGroupMessage")
 	local headers = {
@@ -9868,19 +9896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetClusterParameterGroupSync(ResetClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetClusterParameterGroupAsync(ResetClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetClusterParameterGroupAsync(ResetClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTableRestoreStatus asynchronously, invoking a callback when done
 -- @param DescribeTableRestoreStatusMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTableRestoreStatusAsync(DescribeTableRestoreStatusMessage, cb)
 	assert(DescribeTableRestoreStatusMessage, "You must provide a DescribeTableRestoreStatusMessage")
 	local headers = {
@@ -9903,19 +9932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTableRestoreStatusMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTableRestoreStatusSync(DescribeTableRestoreStatusMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTableRestoreStatusAsync(DescribeTableRestoreStatusMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTableRestoreStatusAsync(DescribeTableRestoreStatusMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteClusterSecurityGroup asynchronously, invoking a callback when done
 -- @param DeleteClusterSecurityGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterSecurityGroupAsync(DeleteClusterSecurityGroupMessage, cb)
 	assert(DeleteClusterSecurityGroupMessage, "You must provide a DeleteClusterSecurityGroupMessage")
 	local headers = {
@@ -9938,19 +9968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterSecurityGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSecurityGroupSync(DeleteClusterSecurityGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterSecurityGroupAsync(DeleteClusterSecurityGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterSecurityGroupAsync(DeleteClusterSecurityGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyClusterParameterGroup asynchronously, invoking a callback when done
 -- @param ModifyClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyClusterParameterGroupAsync(ModifyClusterParameterGroupMessage, cb)
 	assert(ModifyClusterParameterGroupMessage, "You must provide a ModifyClusterParameterGroupMessage")
 	local headers = {
@@ -9973,19 +10004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyClusterParameterGroupSync(ModifyClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyClusterParameterGroupAsync(ModifyClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyClusterParameterGroupAsync(ModifyClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterSnapshots asynchronously, invoking a callback when done
 -- @param DescribeClusterSnapshotsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterSnapshotsAsync(DescribeClusterSnapshotsMessage, cb)
 	assert(DescribeClusterSnapshotsMessage, "You must provide a DescribeClusterSnapshotsMessage")
 	local headers = {
@@ -10008,19 +10040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterSnapshotsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterSnapshotsSync(DescribeClusterSnapshotsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterSnapshotsAsync(DescribeClusterSnapshotsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterSnapshotsAsync(DescribeClusterSnapshotsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateClusterParameterGroup asynchronously, invoking a callback when done
 -- @param CreateClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterParameterGroupAsync(CreateClusterParameterGroupMessage, cb)
 	assert(CreateClusterParameterGroupMessage, "You must provide a CreateClusterParameterGroupMessage")
 	local headers = {
@@ -10043,19 +10076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterParameterGroupSync(CreateClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterParameterGroupAsync(CreateClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterParameterGroupAsync(CreateClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableLogging asynchronously, invoking a callback when done
 -- @param DisableLoggingMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableLoggingAsync(DisableLoggingMessage, cb)
 	assert(DisableLoggingMessage, "You must provide a DisableLoggingMessage")
 	local headers = {
@@ -10078,19 +10112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableLoggingMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableLoggingSync(DisableLoggingMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableLoggingAsync(DisableLoggingMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableLoggingAsync(DisableLoggingMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterVersions asynchronously, invoking a callback when done
 -- @param DescribeClusterVersionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterVersionsAsync(DescribeClusterVersionsMessage, cb)
 	assert(DescribeClusterVersionsMessage, "You must provide a DescribeClusterVersionsMessage")
 	local headers = {
@@ -10113,19 +10148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterVersionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterVersionsSync(DescribeClusterVersionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterVersionsAsync(DescribeClusterVersionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterVersionsAsync(DescribeClusterVersionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeResize asynchronously, invoking a callback when done
 -- @param DescribeResizeMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeResizeAsync(DescribeResizeMessage, cb)
 	assert(DescribeResizeMessage, "You must provide a DescribeResizeMessage")
 	local headers = {
@@ -10148,19 +10184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeResizeMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeResizeSync(DescribeResizeMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeResizeAsync(DescribeResizeMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeResizeAsync(DescribeResizeMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterSubnetGroups asynchronously, invoking a callback when done
 -- @param DescribeClusterSubnetGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterSubnetGroupsAsync(DescribeClusterSubnetGroupsMessage, cb)
 	assert(DescribeClusterSubnetGroupsMessage, "You must provide a DescribeClusterSubnetGroupsMessage")
 	local headers = {
@@ -10183,19 +10220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterSubnetGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterSubnetGroupsSync(DescribeClusterSubnetGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterSubnetGroupsAsync(DescribeClusterSubnetGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterSubnetGroupsAsync(DescribeClusterSubnetGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AuthorizeClusterSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param AuthorizeClusterSecurityGroupIngressMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AuthorizeClusterSecurityGroupIngressAsync(AuthorizeClusterSecurityGroupIngressMessage, cb)
 	assert(AuthorizeClusterSecurityGroupIngressMessage, "You must provide a AuthorizeClusterSecurityGroupIngressMessage")
 	local headers = {
@@ -10218,19 +10256,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AuthorizeClusterSecurityGroupIngressMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AuthorizeClusterSecurityGroupIngressSync(AuthorizeClusterSecurityGroupIngressMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AuthorizeClusterSecurityGroupIngressAsync(AuthorizeClusterSecurityGroupIngressMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AuthorizeClusterSecurityGroupIngressAsync(AuthorizeClusterSecurityGroupIngressMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeHsmConfigurations asynchronously, invoking a callback when done
 -- @param DescribeHsmConfigurationsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeHsmConfigurationsAsync(DescribeHsmConfigurationsMessage, cb)
 	assert(DescribeHsmConfigurationsMessage, "You must provide a DescribeHsmConfigurationsMessage")
 	local headers = {
@@ -10253,19 +10292,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeHsmConfigurationsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeHsmConfigurationsSync(DescribeHsmConfigurationsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeHsmConfigurationsAsync(DescribeHsmConfigurationsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeHsmConfigurationsAsync(DescribeHsmConfigurationsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEventSubscription asynchronously, invoking a callback when done
 -- @param DeleteEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, cb)
 	assert(DeleteEventSubscriptionMessage, "You must provide a DeleteEventSubscriptionMessage")
 	local headers = {
@@ -10288,19 +10328,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEventSubscriptionSync(DeleteEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEventSubscriptionAsync(DeleteEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsMessage, cb)
 	assert(DescribeTagsMessage, "You must provide a DescribeTagsMessage")
 	local headers = {
@@ -10323,19 +10364,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHsmConfiguration asynchronously, invoking a callback when done
 -- @param DeleteHsmConfigurationMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHsmConfigurationAsync(DeleteHsmConfigurationMessage, cb)
 	assert(DeleteHsmConfigurationMessage, "You must provide a DeleteHsmConfigurationMessage")
 	local headers = {
@@ -10358,19 +10400,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHsmConfigurationMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHsmConfigurationSync(DeleteHsmConfigurationMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHsmConfigurationAsync(DeleteHsmConfigurationMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHsmConfigurationAsync(DeleteHsmConfigurationMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateClusterSubnetGroup asynchronously, invoking a callback when done
 -- @param CreateClusterSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterSubnetGroupAsync(CreateClusterSubnetGroupMessage, cb)
 	assert(CreateClusterSubnetGroupMessage, "You must provide a CreateClusterSubnetGroupMessage")
 	local headers = {
@@ -10393,19 +10436,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSubnetGroupSync(CreateClusterSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterSubnetGroupAsync(CreateClusterSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterSubnetGroupAsync(CreateClusterSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResizeCluster asynchronously, invoking a callback when done
 -- @param ResizeClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResizeClusterAsync(ResizeClusterMessage, cb)
 	assert(ResizeClusterMessage, "You must provide a ResizeClusterMessage")
 	local headers = {
@@ -10428,19 +10472,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResizeClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResizeClusterSync(ResizeClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResizeClusterAsync(ResizeClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResizeClusterAsync(ResizeClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyClusterDbRevision asynchronously, invoking a callback when done
 -- @param ModifyClusterDbRevisionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyClusterDbRevisionAsync(ModifyClusterDbRevisionMessage, cb)
 	assert(ModifyClusterDbRevisionMessage, "You must provide a ModifyClusterDbRevisionMessage")
 	local headers = {
@@ -10463,19 +10508,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyClusterDbRevisionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyClusterDbRevisionSync(ModifyClusterDbRevisionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyClusterDbRevisionAsync(ModifyClusterDbRevisionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyClusterDbRevisionAsync(ModifyClusterDbRevisionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterParameters asynchronously, invoking a callback when done
 -- @param DescribeClusterParametersMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterParametersAsync(DescribeClusterParametersMessage, cb)
 	assert(DescribeClusterParametersMessage, "You must provide a DescribeClusterParametersMessage")
 	local headers = {
@@ -10498,19 +10544,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterParametersMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterParametersSync(DescribeClusterParametersMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterParametersAsync(DescribeClusterParametersMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterParametersAsync(DescribeClusterParametersMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHsmClientCertificate asynchronously, invoking a callback when done
 -- @param CreateHsmClientCertificateMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHsmClientCertificateAsync(CreateHsmClientCertificateMessage, cb)
 	assert(CreateHsmClientCertificateMessage, "You must provide a CreateHsmClientCertificateMessage")
 	local headers = {
@@ -10533,19 +10580,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHsmClientCertificateMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHsmClientCertificateSync(CreateHsmClientCertificateMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHsmClientCertificateAsync(CreateHsmClientCertificateMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHsmClientCertificateAsync(CreateHsmClientCertificateMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyClusterSubnetGroup asynchronously, invoking a callback when done
 -- @param ModifyClusterSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyClusterSubnetGroupAsync(ModifyClusterSubnetGroupMessage, cb)
 	assert(ModifyClusterSubnetGroupMessage, "You must provide a ModifyClusterSubnetGroupMessage")
 	local headers = {
@@ -10568,19 +10616,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyClusterSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyClusterSubnetGroupSync(ModifyClusterSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyClusterSubnetGroupAsync(ModifyClusterSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyClusterSubnetGroupAsync(ModifyClusterSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSnapshotCopyGrants asynchronously, invoking a callback when done
 -- @param DescribeSnapshotCopyGrantsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSnapshotCopyGrantsAsync(DescribeSnapshotCopyGrantsMessage, cb)
 	assert(DescribeSnapshotCopyGrantsMessage, "You must provide a DescribeSnapshotCopyGrantsMessage")
 	local headers = {
@@ -10603,19 +10652,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSnapshotCopyGrantsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSnapshotCopyGrantsSync(DescribeSnapshotCopyGrantsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSnapshotCopyGrantsAsync(DescribeSnapshotCopyGrantsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSnapshotCopyGrantsAsync(DescribeSnapshotCopyGrantsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptReservedNodeExchange asynchronously, invoking a callback when done
 -- @param AcceptReservedNodeExchangeInputMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptReservedNodeExchangeAsync(AcceptReservedNodeExchangeInputMessage, cb)
 	assert(AcceptReservedNodeExchangeInputMessage, "You must provide a AcceptReservedNodeExchangeInputMessage")
 	local headers = {
@@ -10638,19 +10688,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptReservedNodeExchangeInputMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptReservedNodeExchangeSync(AcceptReservedNodeExchangeInputMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptReservedNodeExchangeAsync(AcceptReservedNodeExchangeInputMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptReservedNodeExchangeAsync(AcceptReservedNodeExchangeInputMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOrderableClusterOptions asynchronously, invoking a callback when done
 -- @param DescribeOrderableClusterOptionsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOrderableClusterOptionsAsync(DescribeOrderableClusterOptionsMessage, cb)
 	assert(DescribeOrderableClusterOptionsMessage, "You must provide a DescribeOrderableClusterOptionsMessage")
 	local headers = {
@@ -10673,19 +10724,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOrderableClusterOptionsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOrderableClusterOptionsSync(DescribeOrderableClusterOptionsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOrderableClusterOptionsAsync(DescribeOrderableClusterOptionsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOrderableClusterOptionsAsync(DescribeOrderableClusterOptionsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyCluster asynchronously, invoking a callback when done
 -- @param ModifyClusterMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyClusterAsync(ModifyClusterMessage, cb)
 	assert(ModifyClusterMessage, "You must provide a ModifyClusterMessage")
 	local headers = {
@@ -10708,19 +10760,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyClusterMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyClusterSync(ModifyClusterMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyClusterAsync(ModifyClusterMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyClusterAsync(ModifyClusterMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RotateEncryptionKey asynchronously, invoking a callback when done
 -- @param RotateEncryptionKeyMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RotateEncryptionKeyAsync(RotateEncryptionKeyMessage, cb)
 	assert(RotateEncryptionKeyMessage, "You must provide a RotateEncryptionKeyMessage")
 	local headers = {
@@ -10743,19 +10796,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RotateEncryptionKeyMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RotateEncryptionKeySync(RotateEncryptionKeyMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RotateEncryptionKeyAsync(RotateEncryptionKeyMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RotateEncryptionKeyAsync(RotateEncryptionKeyMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableSnapshotCopy asynchronously, invoking a callback when done
 -- @param EnableSnapshotCopyMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableSnapshotCopyAsync(EnableSnapshotCopyMessage, cb)
 	assert(EnableSnapshotCopyMessage, "You must provide a EnableSnapshotCopyMessage")
 	local headers = {
@@ -10778,19 +10832,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableSnapshotCopyMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableSnapshotCopySync(EnableSnapshotCopyMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableSnapshotCopyAsync(EnableSnapshotCopyMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableSnapshotCopyAsync(EnableSnapshotCopyMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateClusterSnapshot asynchronously, invoking a callback when done
 -- @param CreateClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterSnapshotAsync(CreateClusterSnapshotMessage, cb)
 	assert(CreateClusterSnapshotMessage, "You must provide a CreateClusterSnapshotMessage")
 	local headers = {
@@ -10813,19 +10868,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSnapshotSync(CreateClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterSnapshotAsync(CreateClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterSnapshotAsync(CreateClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteClusterSnapshot asynchronously, invoking a callback when done
 -- @param DeleteClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterSnapshotAsync(DeleteClusterSnapshotMessage, cb)
 	assert(DeleteClusterSnapshotMessage, "You must provide a DeleteClusterSnapshotMessage")
 	local headers = {
@@ -10848,19 +10904,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSnapshotSync(DeleteClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterSnapshotAsync(DeleteClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterSnapshotAsync(DeleteClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTags asynchronously, invoking a callback when done
 -- @param CreateTagsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTagsAsync(CreateTagsMessage, cb)
 	assert(CreateTagsMessage, "You must provide a CreateTagsMessage")
 	local headers = {
@@ -10883,19 +10940,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTagsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTagsSync(CreateTagsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTagsAsync(CreateTagsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTagsAsync(CreateTagsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterTracks asynchronously, invoking a callback when done
 -- @param DescribeClusterTracksMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterTracksAsync(DescribeClusterTracksMessage, cb)
 	assert(DescribeClusterTracksMessage, "You must provide a DescribeClusterTracksMessage")
 	local headers = {
@@ -10918,19 +10976,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterTracksMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterTracksSync(DescribeClusterTracksMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterTracksAsync(DescribeClusterTracksMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterTracksAsync(DescribeClusterTracksMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeReservedNodeOfferings asynchronously, invoking a callback when done
 -- @param DescribeReservedNodeOfferingsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeReservedNodeOfferingsAsync(DescribeReservedNodeOfferingsMessage, cb)
 	assert(DescribeReservedNodeOfferingsMessage, "You must provide a DescribeReservedNodeOfferingsMessage")
 	local headers = {
@@ -10953,19 +11012,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeReservedNodeOfferingsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeReservedNodeOfferingsSync(DescribeReservedNodeOfferingsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeReservedNodeOfferingsAsync(DescribeReservedNodeOfferingsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeReservedNodeOfferingsAsync(DescribeReservedNodeOfferingsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeLoggingStatus asynchronously, invoking a callback when done
 -- @param DescribeLoggingStatusMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeLoggingStatusAsync(DescribeLoggingStatusMessage, cb)
 	assert(DescribeLoggingStatusMessage, "You must provide a DescribeLoggingStatusMessage")
 	local headers = {
@@ -10988,19 +11048,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeLoggingStatusMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeLoggingStatusSync(DescribeLoggingStatusMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeLoggingStatusAsync(DescribeLoggingStatusMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeLoggingStatusAsync(DescribeLoggingStatusMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReservedNodeExchangeOfferings asynchronously, invoking a callback when done
 -- @param GetReservedNodeExchangeOfferingsInputMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReservedNodeExchangeOfferingsAsync(GetReservedNodeExchangeOfferingsInputMessage, cb)
 	assert(GetReservedNodeExchangeOfferingsInputMessage, "You must provide a GetReservedNodeExchangeOfferingsInputMessage")
 	local headers = {
@@ -11023,19 +11084,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReservedNodeExchangeOfferingsInputMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReservedNodeExchangeOfferingsSync(GetReservedNodeExchangeOfferingsInputMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReservedNodeExchangeOfferingsAsync(GetReservedNodeExchangeOfferingsInputMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReservedNodeExchangeOfferingsAsync(GetReservedNodeExchangeOfferingsInputMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyEventSubscription asynchronously, invoking a callback when done
 -- @param ModifyEventSubscriptionMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, cb)
 	assert(ModifyEventSubscriptionMessage, "You must provide a ModifyEventSubscriptionMessage")
 	local headers = {
@@ -11058,19 +11120,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyEventSubscriptionMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyEventSubscriptionSync(ModifyEventSubscriptionMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyEventSubscriptionAsync(ModifyEventSubscriptionMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreTableFromClusterSnapshot asynchronously, invoking a callback when done
 -- @param RestoreTableFromClusterSnapshotMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreTableFromClusterSnapshotAsync(RestoreTableFromClusterSnapshotMessage, cb)
 	assert(RestoreTableFromClusterSnapshotMessage, "You must provide a RestoreTableFromClusterSnapshotMessage")
 	local headers = {
@@ -11093,19 +11156,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreTableFromClusterSnapshotMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreTableFromClusterSnapshotSync(RestoreTableFromClusterSnapshotMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreTableFromClusterSnapshotAsync(RestoreTableFromClusterSnapshotMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreTableFromClusterSnapshotAsync(RestoreTableFromClusterSnapshotMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeClusterSecurityGroups asynchronously, invoking a callback when done
 -- @param DescribeClusterSecurityGroupsMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterSecurityGroupsAsync(DescribeClusterSecurityGroupsMessage, cb)
 	assert(DescribeClusterSecurityGroupsMessage, "You must provide a DescribeClusterSecurityGroupsMessage")
 	local headers = {
@@ -11128,19 +11192,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterSecurityGroupsMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterSecurityGroupsSync(DescribeClusterSecurityGroupsMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterSecurityGroupsAsync(DescribeClusterSecurityGroupsMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterSecurityGroupsAsync(DescribeClusterSecurityGroupsMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeClusterSecurityGroupIngress asynchronously, invoking a callback when done
 -- @param RevokeClusterSecurityGroupIngressMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeClusterSecurityGroupIngressAsync(RevokeClusterSecurityGroupIngressMessage, cb)
 	assert(RevokeClusterSecurityGroupIngressMessage, "You must provide a RevokeClusterSecurityGroupIngressMessage")
 	local headers = {
@@ -11163,19 +11228,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeClusterSecurityGroupIngressMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeClusterSecurityGroupIngressSync(RevokeClusterSecurityGroupIngressMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeClusterSecurityGroupIngressAsync(RevokeClusterSecurityGroupIngressMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeClusterSecurityGroupIngressAsync(RevokeClusterSecurityGroupIngressMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteClusterParameterGroup asynchronously, invoking a callback when done
 -- @param DeleteClusterParameterGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterParameterGroupAsync(DeleteClusterParameterGroupMessage, cb)
 	assert(DeleteClusterParameterGroupMessage, "You must provide a DeleteClusterParameterGroupMessage")
 	local headers = {
@@ -11198,19 +11264,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterParameterGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterParameterGroupSync(DeleteClusterParameterGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterParameterGroupAsync(DeleteClusterParameterGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterParameterGroupAsync(DeleteClusterParameterGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteClusterSubnetGroup asynchronously, invoking a callback when done
 -- @param DeleteClusterSubnetGroupMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteClusterSubnetGroupAsync(DeleteClusterSubnetGroupMessage, cb)
 	assert(DeleteClusterSubnetGroupMessage, "You must provide a DeleteClusterSubnetGroupMessage")
 	local headers = {
@@ -11233,19 +11300,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteClusterSubnetGroupMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteClusterSubnetGroupSync(DeleteClusterSubnetGroupMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteClusterSubnetGroupAsync(DeleteClusterSubnetGroupMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteClusterSubnetGroupAsync(DeleteClusterSubnetGroupMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurchaseReservedNodeOffering asynchronously, invoking a callback when done
 -- @param PurchaseReservedNodeOfferingMessage
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurchaseReservedNodeOfferingAsync(PurchaseReservedNodeOfferingMessage, cb)
 	assert(PurchaseReservedNodeOfferingMessage, "You must provide a PurchaseReservedNodeOfferingMessage")
 	local headers = {
@@ -11268,12 +11336,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurchaseReservedNodeOfferingMessage
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurchaseReservedNodeOfferingSync(PurchaseReservedNodeOfferingMessage, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurchaseReservedNodeOfferingAsync(PurchaseReservedNodeOfferingMessage, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurchaseReservedNodeOfferingAsync(PurchaseReservedNodeOfferingMessage, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/rekognition.lua
+++ b/aws-sdk/rekognition.lua
@@ -6186,7 +6186,7 @@ end
 --
 --- Call DeleteStreamProcessor asynchronously, invoking a callback when done
 -- @param DeleteStreamProcessorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStreamProcessorAsync(DeleteStreamProcessorRequest, cb)
 	assert(DeleteStreamProcessorRequest, "You must provide a DeleteStreamProcessorRequest")
 	local headers = {
@@ -6209,19 +6209,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStreamProcessorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStreamProcessorSync(DeleteStreamProcessorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStreamProcessorAsync(DeleteStreamProcessorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStreamProcessorAsync(DeleteStreamProcessorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call IndexFaces asynchronously, invoking a callback when done
 -- @param IndexFacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.IndexFacesAsync(IndexFacesRequest, cb)
 	assert(IndexFacesRequest, "You must provide a IndexFacesRequest")
 	local headers = {
@@ -6244,19 +6245,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param IndexFacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.IndexFacesSync(IndexFacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.IndexFacesAsync(IndexFacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.IndexFacesAsync(IndexFacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFaceSearch asynchronously, invoking a callback when done
 -- @param GetFaceSearchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFaceSearchAsync(GetFaceSearchRequest, cb)
 	assert(GetFaceSearchRequest, "You must provide a GetFaceSearchRequest")
 	local headers = {
@@ -6279,19 +6281,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFaceSearchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFaceSearchSync(GetFaceSearchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFaceSearchAsync(GetFaceSearchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFaceSearchAsync(GetFaceSearchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCelebrityInfo asynchronously, invoking a callback when done
 -- @param GetCelebrityInfoRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCelebrityInfoAsync(GetCelebrityInfoRequest, cb)
 	assert(GetCelebrityInfoRequest, "You must provide a GetCelebrityInfoRequest")
 	local headers = {
@@ -6314,19 +6317,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCelebrityInfoRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCelebrityInfoSync(GetCelebrityInfoRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCelebrityInfoAsync(GetCelebrityInfoRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCelebrityInfoAsync(GetCelebrityInfoRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectText asynchronously, invoking a callback when done
 -- @param DetectTextRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectTextAsync(DetectTextRequest, cb)
 	assert(DetectTextRequest, "You must provide a DetectTextRequest")
 	local headers = {
@@ -6349,19 +6353,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectTextRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectTextSync(DetectTextRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectTextAsync(DetectTextRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectTextAsync(DetectTextRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RecognizeCelebrities asynchronously, invoking a callback when done
 -- @param RecognizeCelebritiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RecognizeCelebritiesAsync(RecognizeCelebritiesRequest, cb)
 	assert(RecognizeCelebritiesRequest, "You must provide a RecognizeCelebritiesRequest")
 	local headers = {
@@ -6384,19 +6389,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RecognizeCelebritiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RecognizeCelebritiesSync(RecognizeCelebritiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RecognizeCelebritiesAsync(RecognizeCelebritiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RecognizeCelebritiesAsync(RecognizeCelebritiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFaces asynchronously, invoking a callback when done
 -- @param DeleteFacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFacesAsync(DeleteFacesRequest, cb)
 	assert(DeleteFacesRequest, "You must provide a DeleteFacesRequest")
 	local headers = {
@@ -6419,19 +6425,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFacesSync(DeleteFacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFacesAsync(DeleteFacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFacesAsync(DeleteFacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartPersonTracking asynchronously, invoking a callback when done
 -- @param StartPersonTrackingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartPersonTrackingAsync(StartPersonTrackingRequest, cb)
 	assert(StartPersonTrackingRequest, "You must provide a StartPersonTrackingRequest")
 	local headers = {
@@ -6454,19 +6461,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartPersonTrackingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartPersonTrackingSync(StartPersonTrackingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartPersonTrackingAsync(StartPersonTrackingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartPersonTrackingAsync(StartPersonTrackingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchFacesByImage asynchronously, invoking a callback when done
 -- @param SearchFacesByImageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchFacesByImageAsync(SearchFacesByImageRequest, cb)
 	assert(SearchFacesByImageRequest, "You must provide a SearchFacesByImageRequest")
 	local headers = {
@@ -6489,19 +6497,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchFacesByImageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchFacesByImageSync(SearchFacesByImageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchFacesByImageAsync(SearchFacesByImageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchFacesByImageAsync(SearchFacesByImageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLabelDetection asynchronously, invoking a callback when done
 -- @param GetLabelDetectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLabelDetectionAsync(GetLabelDetectionRequest, cb)
 	assert(GetLabelDetectionRequest, "You must provide a GetLabelDetectionRequest")
 	local headers = {
@@ -6524,19 +6533,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLabelDetectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLabelDetectionSync(GetLabelDetectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLabelDetectionAsync(GetLabelDetectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLabelDetectionAsync(GetLabelDetectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPersonTracking asynchronously, invoking a callback when done
 -- @param GetPersonTrackingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPersonTrackingAsync(GetPersonTrackingRequest, cb)
 	assert(GetPersonTrackingRequest, "You must provide a GetPersonTrackingRequest")
 	local headers = {
@@ -6559,19 +6569,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPersonTrackingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPersonTrackingSync(GetPersonTrackingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPersonTrackingAsync(GetPersonTrackingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPersonTrackingAsync(GetPersonTrackingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStreamProcessor asynchronously, invoking a callback when done
 -- @param CreateStreamProcessorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStreamProcessorAsync(CreateStreamProcessorRequest, cb)
 	assert(CreateStreamProcessorRequest, "You must provide a CreateStreamProcessorRequest")
 	local headers = {
@@ -6594,19 +6605,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStreamProcessorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStreamProcessorSync(CreateStreamProcessorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStreamProcessorAsync(CreateStreamProcessorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStreamProcessorAsync(CreateStreamProcessorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCelebrityRecognition asynchronously, invoking a callback when done
 -- @param GetCelebrityRecognitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCelebrityRecognitionAsync(GetCelebrityRecognitionRequest, cb)
 	assert(GetCelebrityRecognitionRequest, "You must provide a GetCelebrityRecognitionRequest")
 	local headers = {
@@ -6629,19 +6641,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCelebrityRecognitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCelebrityRecognitionSync(GetCelebrityRecognitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCelebrityRecognitionAsync(GetCelebrityRecognitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCelebrityRecognitionAsync(GetCelebrityRecognitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartLabelDetection asynchronously, invoking a callback when done
 -- @param StartLabelDetectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartLabelDetectionAsync(StartLabelDetectionRequest, cb)
 	assert(StartLabelDetectionRequest, "You must provide a StartLabelDetectionRequest")
 	local headers = {
@@ -6664,19 +6677,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartLabelDetectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartLabelDetectionSync(StartLabelDetectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartLabelDetectionAsync(StartLabelDetectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartLabelDetectionAsync(StartLabelDetectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectLabels asynchronously, invoking a callback when done
 -- @param DetectLabelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectLabelsAsync(DetectLabelsRequest, cb)
 	assert(DetectLabelsRequest, "You must provide a DetectLabelsRequest")
 	local headers = {
@@ -6699,19 +6713,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectLabelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectLabelsSync(DetectLabelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectLabelsAsync(DetectLabelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectLabelsAsync(DetectLabelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectFaces asynchronously, invoking a callback when done
 -- @param DetectFacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectFacesAsync(DetectFacesRequest, cb)
 	assert(DetectFacesRequest, "You must provide a DetectFacesRequest")
 	local headers = {
@@ -6734,19 +6749,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectFacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectFacesSync(DetectFacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectFacesAsync(DetectFacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectFacesAsync(DetectFacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCollection asynchronously, invoking a callback when done
 -- @param DeleteCollectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCollectionAsync(DeleteCollectionRequest, cb)
 	assert(DeleteCollectionRequest, "You must provide a DeleteCollectionRequest")
 	local headers = {
@@ -6769,19 +6785,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCollectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCollectionSync(DeleteCollectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCollectionAsync(DeleteCollectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCollectionAsync(DeleteCollectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFaces asynchronously, invoking a callback when done
 -- @param ListFacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFacesAsync(ListFacesRequest, cb)
 	assert(ListFacesRequest, "You must provide a ListFacesRequest")
 	local headers = {
@@ -6804,19 +6821,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFacesSync(ListFacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFacesAsync(ListFacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFacesAsync(ListFacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchFaces asynchronously, invoking a callback when done
 -- @param SearchFacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchFacesAsync(SearchFacesRequest, cb)
 	assert(SearchFacesRequest, "You must provide a SearchFacesRequest")
 	local headers = {
@@ -6839,19 +6857,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchFacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchFacesSync(SearchFacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchFacesAsync(SearchFacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchFacesAsync(SearchFacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetContentModeration asynchronously, invoking a callback when done
 -- @param GetContentModerationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetContentModerationAsync(GetContentModerationRequest, cb)
 	assert(GetContentModerationRequest, "You must provide a GetContentModerationRequest")
 	local headers = {
@@ -6874,19 +6893,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetContentModerationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetContentModerationSync(GetContentModerationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetContentModerationAsync(GetContentModerationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetContentModerationAsync(GetContentModerationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopStreamProcessor asynchronously, invoking a callback when done
 -- @param StopStreamProcessorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopStreamProcessorAsync(StopStreamProcessorRequest, cb)
 	assert(StopStreamProcessorRequest, "You must provide a StopStreamProcessorRequest")
 	local headers = {
@@ -6909,19 +6929,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopStreamProcessorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopStreamProcessorSync(StopStreamProcessorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopStreamProcessorAsync(StopStreamProcessorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopStreamProcessorAsync(StopStreamProcessorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFaceDetection asynchronously, invoking a callback when done
 -- @param GetFaceDetectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFaceDetectionAsync(GetFaceDetectionRequest, cb)
 	assert(GetFaceDetectionRequest, "You must provide a GetFaceDetectionRequest")
 	local headers = {
@@ -6944,19 +6965,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFaceDetectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFaceDetectionSync(GetFaceDetectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFaceDetectionAsync(GetFaceDetectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFaceDetectionAsync(GetFaceDetectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCollections asynchronously, invoking a callback when done
 -- @param ListCollectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCollectionsAsync(ListCollectionsRequest, cb)
 	assert(ListCollectionsRequest, "You must provide a ListCollectionsRequest")
 	local headers = {
@@ -6979,19 +7001,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCollectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCollectionsSync(ListCollectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCollectionsAsync(ListCollectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCollectionsAsync(ListCollectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartStreamProcessor asynchronously, invoking a callback when done
 -- @param StartStreamProcessorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartStreamProcessorAsync(StartStreamProcessorRequest, cb)
 	assert(StartStreamProcessorRequest, "You must provide a StartStreamProcessorRequest")
 	local headers = {
@@ -7014,19 +7037,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartStreamProcessorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartStreamProcessorSync(StartStreamProcessorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartStreamProcessorAsync(StartStreamProcessorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartStreamProcessorAsync(StartStreamProcessorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCollection asynchronously, invoking a callback when done
 -- @param CreateCollectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCollectionAsync(CreateCollectionRequest, cb)
 	assert(CreateCollectionRequest, "You must provide a CreateCollectionRequest")
 	local headers = {
@@ -7049,19 +7073,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCollectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCollectionSync(CreateCollectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCollectionAsync(CreateCollectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCollectionAsync(CreateCollectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CompareFaces asynchronously, invoking a callback when done
 -- @param CompareFacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CompareFacesAsync(CompareFacesRequest, cb)
 	assert(CompareFacesRequest, "You must provide a CompareFacesRequest")
 	local headers = {
@@ -7084,19 +7109,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CompareFacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CompareFacesSync(CompareFacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CompareFacesAsync(CompareFacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CompareFacesAsync(CompareFacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCollection asynchronously, invoking a callback when done
 -- @param DescribeCollectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCollectionAsync(DescribeCollectionRequest, cb)
 	assert(DescribeCollectionRequest, "You must provide a DescribeCollectionRequest")
 	local headers = {
@@ -7119,19 +7145,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCollectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCollectionSync(DescribeCollectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCollectionAsync(DescribeCollectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCollectionAsync(DescribeCollectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartCelebrityRecognition asynchronously, invoking a callback when done
 -- @param StartCelebrityRecognitionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartCelebrityRecognitionAsync(StartCelebrityRecognitionRequest, cb)
 	assert(StartCelebrityRecognitionRequest, "You must provide a StartCelebrityRecognitionRequest")
 	local headers = {
@@ -7154,19 +7181,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartCelebrityRecognitionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartCelebrityRecognitionSync(StartCelebrityRecognitionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartCelebrityRecognitionAsync(StartCelebrityRecognitionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartCelebrityRecognitionAsync(StartCelebrityRecognitionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DetectModerationLabels asynchronously, invoking a callback when done
 -- @param DetectModerationLabelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DetectModerationLabelsAsync(DetectModerationLabelsRequest, cb)
 	assert(DetectModerationLabelsRequest, "You must provide a DetectModerationLabelsRequest")
 	local headers = {
@@ -7189,19 +7217,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DetectModerationLabelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DetectModerationLabelsSync(DetectModerationLabelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DetectModerationLabelsAsync(DetectModerationLabelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DetectModerationLabelsAsync(DetectModerationLabelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStreamProcessors asynchronously, invoking a callback when done
 -- @param ListStreamProcessorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStreamProcessorsAsync(ListStreamProcessorsRequest, cb)
 	assert(ListStreamProcessorsRequest, "You must provide a ListStreamProcessorsRequest")
 	local headers = {
@@ -7224,19 +7253,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStreamProcessorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStreamProcessorsSync(ListStreamProcessorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStreamProcessorsAsync(ListStreamProcessorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStreamProcessorsAsync(ListStreamProcessorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartFaceSearch asynchronously, invoking a callback when done
 -- @param StartFaceSearchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartFaceSearchAsync(StartFaceSearchRequest, cb)
 	assert(StartFaceSearchRequest, "You must provide a StartFaceSearchRequest")
 	local headers = {
@@ -7259,19 +7289,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartFaceSearchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartFaceSearchSync(StartFaceSearchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartFaceSearchAsync(StartFaceSearchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartFaceSearchAsync(StartFaceSearchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartContentModeration asynchronously, invoking a callback when done
 -- @param StartContentModerationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartContentModerationAsync(StartContentModerationRequest, cb)
 	assert(StartContentModerationRequest, "You must provide a StartContentModerationRequest")
 	local headers = {
@@ -7294,19 +7325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartContentModerationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartContentModerationSync(StartContentModerationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartContentModerationAsync(StartContentModerationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartContentModerationAsync(StartContentModerationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStreamProcessor asynchronously, invoking a callback when done
 -- @param DescribeStreamProcessorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStreamProcessorAsync(DescribeStreamProcessorRequest, cb)
 	assert(DescribeStreamProcessorRequest, "You must provide a DescribeStreamProcessorRequest")
 	local headers = {
@@ -7329,19 +7361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStreamProcessorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStreamProcessorSync(DescribeStreamProcessorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStreamProcessorAsync(DescribeStreamProcessorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStreamProcessorAsync(DescribeStreamProcessorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartFaceDetection asynchronously, invoking a callback when done
 -- @param StartFaceDetectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartFaceDetectionAsync(StartFaceDetectionRequest, cb)
 	assert(StartFaceDetectionRequest, "You must provide a StartFaceDetectionRequest")
 	local headers = {
@@ -7364,12 +7397,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartFaceDetectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartFaceDetectionSync(StartFaceDetectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartFaceDetectionAsync(StartFaceDetectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartFaceDetectionAsync(StartFaceDetectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/resource-groups.lua
+++ b/aws-sdk/resource-groups.lua
@@ -1685,7 +1685,7 @@ end
 --
 --- Call GetTags asynchronously, invoking a callback when done
 -- @param GetTagsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTagsAsync(GetTagsInput, cb)
 	assert(GetTagsInput, "You must provide a GetTagsInput")
 	local headers = {
@@ -1708,19 +1708,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTagsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTagsSync(GetTagsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTagsAsync(GetTagsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTagsAsync(GetTagsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroups asynchronously, invoking a callback when done
 -- @param ListGroupsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupsAsync(ListGroupsInput, cb)
 	assert(ListGroupsInput, "You must provide a ListGroupsInput")
 	local headers = {
@@ -1743,19 +1744,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupsSync(ListGroupsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupsAsync(ListGroupsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupsAsync(ListGroupsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGroupQuery asynchronously, invoking a callback when done
 -- @param UpdateGroupQueryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGroupQueryAsync(UpdateGroupQueryInput, cb)
 	assert(UpdateGroupQueryInput, "You must provide a UpdateGroupQueryInput")
 	local headers = {
@@ -1778,19 +1780,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGroupQueryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGroupQuerySync(UpdateGroupQueryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGroupQueryAsync(UpdateGroupQueryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGroupQueryAsync(UpdateGroupQueryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroupResources asynchronously, invoking a callback when done
 -- @param ListGroupResourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupResourcesAsync(ListGroupResourcesInput, cb)
 	assert(ListGroupResourcesInput, "You must provide a ListGroupResourcesInput")
 	local headers = {
@@ -1813,19 +1816,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupResourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupResourcesSync(ListGroupResourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupResourcesAsync(ListGroupResourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupResourcesAsync(ListGroupResourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGroup asynchronously, invoking a callback when done
 -- @param UpdateGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGroupAsync(UpdateGroupInput, cb)
 	assert(UpdateGroupInput, "You must provide a UpdateGroupInput")
 	local headers = {
@@ -1848,19 +1852,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGroupSync(UpdateGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGroupAsync(UpdateGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGroupAsync(UpdateGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGroup asynchronously, invoking a callback when done
 -- @param DeleteGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGroupAsync(DeleteGroupInput, cb)
 	assert(DeleteGroupInput, "You must provide a DeleteGroupInput")
 	local headers = {
@@ -1883,19 +1888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGroupSync(DeleteGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGroupAsync(DeleteGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGroupAsync(DeleteGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Tag asynchronously, invoking a callback when done
 -- @param TagInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagAsync(TagInput, cb)
 	assert(TagInput, "You must provide a TagInput")
 	local headers = {
@@ -1918,19 +1924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagSync(TagInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagAsync(TagInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagAsync(TagInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGroup asynchronously, invoking a callback when done
 -- @param CreateGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGroupAsync(CreateGroupInput, cb)
 	assert(CreateGroupInput, "You must provide a CreateGroupInput")
 	local headers = {
@@ -1953,19 +1960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGroupSync(CreateGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGroupAsync(CreateGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGroupAsync(CreateGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroupQuery asynchronously, invoking a callback when done
 -- @param GetGroupQueryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupQueryAsync(GetGroupQueryInput, cb)
 	assert(GetGroupQueryInput, "You must provide a GetGroupQueryInput")
 	local headers = {
@@ -1988,19 +1996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupQueryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupQuerySync(GetGroupQueryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupQueryAsync(GetGroupQueryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupQueryAsync(GetGroupQueryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchResources asynchronously, invoking a callback when done
 -- @param SearchResourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchResourcesAsync(SearchResourcesInput, cb)
 	assert(SearchResourcesInput, "You must provide a SearchResourcesInput")
 	local headers = {
@@ -2023,19 +2032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchResourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchResourcesSync(SearchResourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchResourcesAsync(SearchResourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchResourcesAsync(SearchResourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGroup asynchronously, invoking a callback when done
 -- @param GetGroupInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGroupAsync(GetGroupInput, cb)
 	assert(GetGroupInput, "You must provide a GetGroupInput")
 	local headers = {
@@ -2058,19 +2068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGroupInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGroupSync(GetGroupInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGroupAsync(GetGroupInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGroupAsync(GetGroupInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Untag asynchronously, invoking a callback when done
 -- @param UntagInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagAsync(UntagInput, cb)
 	assert(UntagInput, "You must provide a UntagInput")
 	local headers = {
@@ -2093,12 +2104,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagSync(UntagInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagAsync(UntagInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagAsync(UntagInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/route53.lua
+++ b/aws-sdk/route53.lua
@@ -8050,7 +8050,7 @@ end
 --
 --- Call CreateQueryLoggingConfig asynchronously, invoking a callback when done
 -- @param CreateQueryLoggingConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateQueryLoggingConfigAsync(CreateQueryLoggingConfigRequest, cb)
 	assert(CreateQueryLoggingConfigRequest, "You must provide a CreateQueryLoggingConfigRequest")
 	local headers = {
@@ -8073,19 +8073,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateQueryLoggingConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateQueryLoggingConfigSync(CreateQueryLoggingConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateQueryLoggingConfigAsync(CreateQueryLoggingConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateQueryLoggingConfigAsync(CreateQueryLoggingConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTrafficPolicyInstancesByHostedZone asynchronously, invoking a callback when done
 -- @param ListTrafficPolicyInstancesByHostedZoneRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTrafficPolicyInstancesByHostedZoneAsync(ListTrafficPolicyInstancesByHostedZoneRequest, cb)
 	assert(ListTrafficPolicyInstancesByHostedZoneRequest, "You must provide a ListTrafficPolicyInstancesByHostedZoneRequest")
 	local headers = {
@@ -8108,19 +8109,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTrafficPolicyInstancesByHostedZoneRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTrafficPolicyInstancesByHostedZoneSync(ListTrafficPolicyInstancesByHostedZoneRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTrafficPolicyInstancesByHostedZoneAsync(ListTrafficPolicyInstancesByHostedZoneRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTrafficPolicyInstancesByHostedZoneAsync(ListTrafficPolicyInstancesByHostedZoneRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCheckerIpRanges asynchronously, invoking a callback when done
 -- @param GetCheckerIpRangesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCheckerIpRangesAsync(GetCheckerIpRangesRequest, cb)
 	assert(GetCheckerIpRangesRequest, "You must provide a GetCheckerIpRangesRequest")
 	local headers = {
@@ -8143,19 +8145,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCheckerIpRangesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCheckerIpRangesSync(GetCheckerIpRangesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCheckerIpRangesAsync(GetCheckerIpRangesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCheckerIpRangesAsync(GetCheckerIpRangesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTrafficPolicyInstancesByPolicy asynchronously, invoking a callback when done
 -- @param ListTrafficPolicyInstancesByPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTrafficPolicyInstancesByPolicyAsync(ListTrafficPolicyInstancesByPolicyRequest, cb)
 	assert(ListTrafficPolicyInstancesByPolicyRequest, "You must provide a ListTrafficPolicyInstancesByPolicyRequest")
 	local headers = {
@@ -8178,19 +8181,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTrafficPolicyInstancesByPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTrafficPolicyInstancesByPolicySync(ListTrafficPolicyInstancesByPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTrafficPolicyInstancesByPolicyAsync(ListTrafficPolicyInstancesByPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTrafficPolicyInstancesByPolicyAsync(ListTrafficPolicyInstancesByPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTrafficPolicies asynchronously, invoking a callback when done
 -- @param ListTrafficPoliciesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTrafficPoliciesAsync(ListTrafficPoliciesRequest, cb)
 	assert(ListTrafficPoliciesRequest, "You must provide a ListTrafficPoliciesRequest")
 	local headers = {
@@ -8213,19 +8217,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTrafficPoliciesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTrafficPoliciesSync(ListTrafficPoliciesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTrafficPoliciesAsync(ListTrafficPoliciesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTrafficPoliciesAsync(ListTrafficPoliciesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateHostedZoneComment asynchronously, invoking a callback when done
 -- @param UpdateHostedZoneCommentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateHostedZoneCommentAsync(UpdateHostedZoneCommentRequest, cb)
 	assert(UpdateHostedZoneCommentRequest, "You must provide a UpdateHostedZoneCommentRequest")
 	local headers = {
@@ -8248,19 +8253,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateHostedZoneCommentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateHostedZoneCommentSync(UpdateHostedZoneCommentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateHostedZoneCommentAsync(UpdateHostedZoneCommentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateHostedZoneCommentAsync(UpdateHostedZoneCommentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ChangeTagsForResource asynchronously, invoking a callback when done
 -- @param ChangeTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ChangeTagsForResourceAsync(ChangeTagsForResourceRequest, cb)
 	assert(ChangeTagsForResourceRequest, "You must provide a ChangeTagsForResourceRequest")
 	local headers = {
@@ -8283,19 +8289,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ChangeTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ChangeTagsForResourceSync(ChangeTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ChangeTagsForResourceAsync(ChangeTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ChangeTagsForResourceAsync(ChangeTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHealthCheck asynchronously, invoking a callback when done
 -- @param GetHealthCheckRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHealthCheckAsync(GetHealthCheckRequest, cb)
 	assert(GetHealthCheckRequest, "You must provide a GetHealthCheckRequest")
 	local headers = {
@@ -8318,19 +8325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHealthCheckRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHealthCheckSync(GetHealthCheckRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHealthCheckAsync(GetHealthCheckRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHealthCheckAsync(GetHealthCheckRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHostedZonesByName asynchronously, invoking a callback when done
 -- @param ListHostedZonesByNameRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHostedZonesByNameAsync(ListHostedZonesByNameRequest, cb)
 	assert(ListHostedZonesByNameRequest, "You must provide a ListHostedZonesByNameRequest")
 	local headers = {
@@ -8353,19 +8361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHostedZonesByNameRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHostedZonesByNameSync(ListHostedZonesByNameRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHostedZonesByNameAsync(ListHostedZonesByNameRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHostedZonesByNameAsync(ListHostedZonesByNameRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHostedZone asynchronously, invoking a callback when done
 -- @param GetHostedZoneRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHostedZoneAsync(GetHostedZoneRequest, cb)
 	assert(GetHostedZoneRequest, "You must provide a GetHostedZoneRequest")
 	local headers = {
@@ -8388,19 +8397,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHostedZoneRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHostedZoneSync(GetHostedZoneRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHostedZoneAsync(GetHostedZoneRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHostedZoneAsync(GetHostedZoneRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReusableDelegationSet asynchronously, invoking a callback when done
 -- @param DeleteReusableDelegationSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReusableDelegationSetAsync(DeleteReusableDelegationSetRequest, cb)
 	assert(DeleteReusableDelegationSetRequest, "You must provide a DeleteReusableDelegationSetRequest")
 	local headers = {
@@ -8423,19 +8433,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReusableDelegationSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReusableDelegationSetSync(DeleteReusableDelegationSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReusableDelegationSetAsync(DeleteReusableDelegationSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReusableDelegationSetAsync(DeleteReusableDelegationSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTrafficPolicyInstance asynchronously, invoking a callback when done
 -- @param DeleteTrafficPolicyInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTrafficPolicyInstanceAsync(DeleteTrafficPolicyInstanceRequest, cb)
 	assert(DeleteTrafficPolicyInstanceRequest, "You must provide a DeleteTrafficPolicyInstanceRequest")
 	local headers = {
@@ -8458,19 +8469,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTrafficPolicyInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTrafficPolicyInstanceSync(DeleteTrafficPolicyInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTrafficPolicyInstanceAsync(DeleteTrafficPolicyInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTrafficPolicyInstanceAsync(DeleteTrafficPolicyInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReusableDelegationSetLimit asynchronously, invoking a callback when done
 -- @param GetReusableDelegationSetLimitRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReusableDelegationSetLimitAsync(GetReusableDelegationSetLimitRequest, cb)
 	assert(GetReusableDelegationSetLimitRequest, "You must provide a GetReusableDelegationSetLimitRequest")
 	local headers = {
@@ -8493,19 +8505,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReusableDelegationSetLimitRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReusableDelegationSetLimitSync(GetReusableDelegationSetLimitRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReusableDelegationSetLimitAsync(GetReusableDelegationSetLimitRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReusableDelegationSetLimitAsync(GetReusableDelegationSetLimitRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHostedZoneCount asynchronously, invoking a callback when done
 -- @param GetHostedZoneCountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHostedZoneCountAsync(GetHostedZoneCountRequest, cb)
 	assert(GetHostedZoneCountRequest, "You must provide a GetHostedZoneCountRequest")
 	local headers = {
@@ -8528,19 +8541,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHostedZoneCountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHostedZoneCountSync(GetHostedZoneCountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHostedZoneCountAsync(GetHostedZoneCountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHostedZoneCountAsync(GetHostedZoneCountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTrafficPolicyInstanceCount asynchronously, invoking a callback when done
 -- @param GetTrafficPolicyInstanceCountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTrafficPolicyInstanceCountAsync(GetTrafficPolicyInstanceCountRequest, cb)
 	assert(GetTrafficPolicyInstanceCountRequest, "You must provide a GetTrafficPolicyInstanceCountRequest")
 	local headers = {
@@ -8563,19 +8577,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTrafficPolicyInstanceCountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTrafficPolicyInstanceCountSync(GetTrafficPolicyInstanceCountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTrafficPolicyInstanceCountAsync(GetTrafficPolicyInstanceCountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTrafficPolicyInstanceCountAsync(GetTrafficPolicyInstanceCountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTrafficPolicyComment asynchronously, invoking a callback when done
 -- @param UpdateTrafficPolicyCommentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTrafficPolicyCommentAsync(UpdateTrafficPolicyCommentRequest, cb)
 	assert(UpdateTrafficPolicyCommentRequest, "You must provide a UpdateTrafficPolicyCommentRequest")
 	local headers = {
@@ -8598,19 +8613,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTrafficPolicyCommentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTrafficPolicyCommentSync(UpdateTrafficPolicyCommentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTrafficPolicyCommentAsync(UpdateTrafficPolicyCommentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTrafficPolicyCommentAsync(UpdateTrafficPolicyCommentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ChangeResourceRecordSets asynchronously, invoking a callback when done
 -- @param ChangeResourceRecordSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ChangeResourceRecordSetsAsync(ChangeResourceRecordSetsRequest, cb)
 	assert(ChangeResourceRecordSetsRequest, "You must provide a ChangeResourceRecordSetsRequest")
 	local headers = {
@@ -8633,19 +8649,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ChangeResourceRecordSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ChangeResourceRecordSetsSync(ChangeResourceRecordSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ChangeResourceRecordSetsAsync(ChangeResourceRecordSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ChangeResourceRecordSetsAsync(ChangeResourceRecordSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTrafficPolicy asynchronously, invoking a callback when done
 -- @param DeleteTrafficPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTrafficPolicyAsync(DeleteTrafficPolicyRequest, cb)
 	assert(DeleteTrafficPolicyRequest, "You must provide a DeleteTrafficPolicyRequest")
 	local headers = {
@@ -8668,19 +8685,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTrafficPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTrafficPolicySync(DeleteTrafficPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTrafficPolicyAsync(DeleteTrafficPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTrafficPolicyAsync(DeleteTrafficPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHostedZone asynchronously, invoking a callback when done
 -- @param CreateHostedZoneRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHostedZoneAsync(CreateHostedZoneRequest, cb)
 	assert(CreateHostedZoneRequest, "You must provide a CreateHostedZoneRequest")
 	local headers = {
@@ -8703,19 +8721,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHostedZoneRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHostedZoneSync(CreateHostedZoneRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHostedZoneAsync(CreateHostedZoneRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHostedZoneAsync(CreateHostedZoneRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVPCAssociationAuthorization asynchronously, invoking a callback when done
 -- @param CreateVPCAssociationAuthorizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVPCAssociationAuthorizationAsync(CreateVPCAssociationAuthorizationRequest, cb)
 	assert(CreateVPCAssociationAuthorizationRequest, "You must provide a CreateVPCAssociationAuthorizationRequest")
 	local headers = {
@@ -8738,19 +8757,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVPCAssociationAuthorizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVPCAssociationAuthorizationSync(CreateVPCAssociationAuthorizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVPCAssociationAuthorizationAsync(CreateVPCAssociationAuthorizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVPCAssociationAuthorizationAsync(CreateVPCAssociationAuthorizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHostedZone asynchronously, invoking a callback when done
 -- @param DeleteHostedZoneRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHostedZoneAsync(DeleteHostedZoneRequest, cb)
 	assert(DeleteHostedZoneRequest, "You must provide a DeleteHostedZoneRequest")
 	local headers = {
@@ -8773,19 +8793,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHostedZoneRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHostedZoneSync(DeleteHostedZoneRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHostedZoneAsync(DeleteHostedZoneRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHostedZoneAsync(DeleteHostedZoneRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHealthCheckStatus asynchronously, invoking a callback when done
 -- @param GetHealthCheckStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHealthCheckStatusAsync(GetHealthCheckStatusRequest, cb)
 	assert(GetHealthCheckStatusRequest, "You must provide a GetHealthCheckStatusRequest")
 	local headers = {
@@ -8808,19 +8829,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHealthCheckStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHealthCheckStatusSync(GetHealthCheckStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHealthCheckStatusAsync(GetHealthCheckStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHealthCheckStatusAsync(GetHealthCheckStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TestDNSAnswer asynchronously, invoking a callback when done
 -- @param TestDNSAnswerRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TestDNSAnswerAsync(TestDNSAnswerRequest, cb)
 	assert(TestDNSAnswerRequest, "You must provide a TestDNSAnswerRequest")
 	local headers = {
@@ -8843,19 +8865,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TestDNSAnswerRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TestDNSAnswerSync(TestDNSAnswerRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TestDNSAnswerAsync(TestDNSAnswerRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TestDNSAnswerAsync(TestDNSAnswerRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListReusableDelegationSets asynchronously, invoking a callback when done
 -- @param ListReusableDelegationSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListReusableDelegationSetsAsync(ListReusableDelegationSetsRequest, cb)
 	assert(ListReusableDelegationSetsRequest, "You must provide a ListReusableDelegationSetsRequest")
 	local headers = {
@@ -8878,19 +8901,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListReusableDelegationSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListReusableDelegationSetsSync(ListReusableDelegationSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListReusableDelegationSetsAsync(ListReusableDelegationSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListReusableDelegationSetsAsync(ListReusableDelegationSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAccountLimit asynchronously, invoking a callback when done
 -- @param GetAccountLimitRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAccountLimitAsync(GetAccountLimitRequest, cb)
 	assert(GetAccountLimitRequest, "You must provide a GetAccountLimitRequest")
 	local headers = {
@@ -8913,19 +8937,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAccountLimitRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAccountLimitSync(GetAccountLimitRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAccountLimitAsync(GetAccountLimitRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAccountLimitAsync(GetAccountLimitRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTrafficPolicyInstance asynchronously, invoking a callback when done
 -- @param CreateTrafficPolicyInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTrafficPolicyInstanceAsync(CreateTrafficPolicyInstanceRequest, cb)
 	assert(CreateTrafficPolicyInstanceRequest, "You must provide a CreateTrafficPolicyInstanceRequest")
 	local headers = {
@@ -8948,19 +8973,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTrafficPolicyInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTrafficPolicyInstanceSync(CreateTrafficPolicyInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTrafficPolicyInstanceAsync(CreateTrafficPolicyInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTrafficPolicyInstanceAsync(CreateTrafficPolicyInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGeoLocation asynchronously, invoking a callback when done
 -- @param GetGeoLocationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGeoLocationAsync(GetGeoLocationRequest, cb)
 	assert(GetGeoLocationRequest, "You must provide a GetGeoLocationRequest")
 	local headers = {
@@ -8983,19 +9009,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGeoLocationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGeoLocationSync(GetGeoLocationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGeoLocationAsync(GetGeoLocationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGeoLocationAsync(GetGeoLocationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReusableDelegationSet asynchronously, invoking a callback when done
 -- @param GetReusableDelegationSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReusableDelegationSetAsync(GetReusableDelegationSetRequest, cb)
 	assert(GetReusableDelegationSetRequest, "You must provide a GetReusableDelegationSetRequest")
 	local headers = {
@@ -9018,19 +9045,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReusableDelegationSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReusableDelegationSetSync(GetReusableDelegationSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReusableDelegationSetAsync(GetReusableDelegationSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReusableDelegationSetAsync(GetReusableDelegationSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHostedZones asynchronously, invoking a callback when done
 -- @param ListHostedZonesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHostedZonesAsync(ListHostedZonesRequest, cb)
 	assert(ListHostedZonesRequest, "You must provide a ListHostedZonesRequest")
 	local headers = {
@@ -9053,19 +9081,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHostedZonesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHostedZonesSync(ListHostedZonesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHostedZonesAsync(ListHostedZonesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHostedZonesAsync(ListHostedZonesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTrafficPolicy asynchronously, invoking a callback when done
 -- @param GetTrafficPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTrafficPolicyAsync(GetTrafficPolicyRequest, cb)
 	assert(GetTrafficPolicyRequest, "You must provide a GetTrafficPolicyRequest")
 	local headers = {
@@ -9088,19 +9117,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTrafficPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTrafficPolicySync(GetTrafficPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTrafficPolicyAsync(GetTrafficPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTrafficPolicyAsync(GetTrafficPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListQueryLoggingConfigs asynchronously, invoking a callback when done
 -- @param ListQueryLoggingConfigsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListQueryLoggingConfigsAsync(ListQueryLoggingConfigsRequest, cb)
 	assert(ListQueryLoggingConfigsRequest, "You must provide a ListQueryLoggingConfigsRequest")
 	local headers = {
@@ -9123,19 +9153,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListQueryLoggingConfigsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListQueryLoggingConfigsSync(ListQueryLoggingConfigsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListQueryLoggingConfigsAsync(ListQueryLoggingConfigsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListQueryLoggingConfigsAsync(ListQueryLoggingConfigsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateHealthCheck asynchronously, invoking a callback when done
 -- @param UpdateHealthCheckRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateHealthCheckAsync(UpdateHealthCheckRequest, cb)
 	assert(UpdateHealthCheckRequest, "You must provide a UpdateHealthCheckRequest")
 	local headers = {
@@ -9158,19 +9189,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateHealthCheckRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateHealthCheckSync(UpdateHealthCheckRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateHealthCheckAsync(UpdateHealthCheckRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateHealthCheckAsync(UpdateHealthCheckRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHealthCheckCount asynchronously, invoking a callback when done
 -- @param GetHealthCheckCountRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHealthCheckCountAsync(GetHealthCheckCountRequest, cb)
 	assert(GetHealthCheckCountRequest, "You must provide a GetHealthCheckCountRequest")
 	local headers = {
@@ -9193,19 +9225,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHealthCheckCountRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHealthCheckCountSync(GetHealthCheckCountRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHealthCheckCountAsync(GetHealthCheckCountRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHealthCheckCountAsync(GetHealthCheckCountRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateVPCFromHostedZone asynchronously, invoking a callback when done
 -- @param DisassociateVPCFromHostedZoneRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateVPCFromHostedZoneAsync(DisassociateVPCFromHostedZoneRequest, cb)
 	assert(DisassociateVPCFromHostedZoneRequest, "You must provide a DisassociateVPCFromHostedZoneRequest")
 	local headers = {
@@ -9228,19 +9261,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateVPCFromHostedZoneRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateVPCFromHostedZoneSync(DisassociateVPCFromHostedZoneRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateVPCFromHostedZoneAsync(DisassociateVPCFromHostedZoneRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateVPCFromHostedZoneAsync(DisassociateVPCFromHostedZoneRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVPCAssociationAuthorization asynchronously, invoking a callback when done
 -- @param DeleteVPCAssociationAuthorizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVPCAssociationAuthorizationAsync(DeleteVPCAssociationAuthorizationRequest, cb)
 	assert(DeleteVPCAssociationAuthorizationRequest, "You must provide a DeleteVPCAssociationAuthorizationRequest")
 	local headers = {
@@ -9263,19 +9297,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVPCAssociationAuthorizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVPCAssociationAuthorizationSync(DeleteVPCAssociationAuthorizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVPCAssociationAuthorizationAsync(DeleteVPCAssociationAuthorizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVPCAssociationAuthorizationAsync(DeleteVPCAssociationAuthorizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTrafficPolicyInstance asynchronously, invoking a callback when done
 -- @param GetTrafficPolicyInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTrafficPolicyInstanceAsync(GetTrafficPolicyInstanceRequest, cb)
 	assert(GetTrafficPolicyInstanceRequest, "You must provide a GetTrafficPolicyInstanceRequest")
 	local headers = {
@@ -9298,19 +9333,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTrafficPolicyInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTrafficPolicyInstanceSync(GetTrafficPolicyInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTrafficPolicyInstanceAsync(GetTrafficPolicyInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTrafficPolicyInstanceAsync(GetTrafficPolicyInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteHealthCheck asynchronously, invoking a callback when done
 -- @param DeleteHealthCheckRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteHealthCheckAsync(DeleteHealthCheckRequest, cb)
 	assert(DeleteHealthCheckRequest, "You must provide a DeleteHealthCheckRequest")
 	local headers = {
@@ -9333,19 +9369,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteHealthCheckRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteHealthCheckSync(DeleteHealthCheckRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteHealthCheckAsync(DeleteHealthCheckRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteHealthCheckAsync(DeleteHealthCheckRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateHealthCheck asynchronously, invoking a callback when done
 -- @param CreateHealthCheckRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateHealthCheckAsync(CreateHealthCheckRequest, cb)
 	assert(CreateHealthCheckRequest, "You must provide a CreateHealthCheckRequest")
 	local headers = {
@@ -9368,19 +9405,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateHealthCheckRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateHealthCheckSync(CreateHealthCheckRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateHealthCheckAsync(CreateHealthCheckRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateHealthCheckAsync(CreateHealthCheckRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTrafficPolicyVersion asynchronously, invoking a callback when done
 -- @param CreateTrafficPolicyVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTrafficPolicyVersionAsync(CreateTrafficPolicyVersionRequest, cb)
 	assert(CreateTrafficPolicyVersionRequest, "You must provide a CreateTrafficPolicyVersionRequest")
 	local headers = {
@@ -9403,19 +9441,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTrafficPolicyVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTrafficPolicyVersionSync(CreateTrafficPolicyVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTrafficPolicyVersionAsync(CreateTrafficPolicyVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTrafficPolicyVersionAsync(CreateTrafficPolicyVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTrafficPolicy asynchronously, invoking a callback when done
 -- @param CreateTrafficPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTrafficPolicyAsync(CreateTrafficPolicyRequest, cb)
 	assert(CreateTrafficPolicyRequest, "You must provide a CreateTrafficPolicyRequest")
 	local headers = {
@@ -9438,19 +9477,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTrafficPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTrafficPolicySync(CreateTrafficPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTrafficPolicyAsync(CreateTrafficPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTrafficPolicyAsync(CreateTrafficPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGeoLocations asynchronously, invoking a callback when done
 -- @param ListGeoLocationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGeoLocationsAsync(ListGeoLocationsRequest, cb)
 	assert(ListGeoLocationsRequest, "You must provide a ListGeoLocationsRequest")
 	local headers = {
@@ -9473,19 +9513,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGeoLocationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGeoLocationsSync(ListGeoLocationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGeoLocationsAsync(ListGeoLocationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGeoLocationsAsync(ListGeoLocationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResources asynchronously, invoking a callback when done
 -- @param ListTagsForResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourcesAsync(ListTagsForResourcesRequest, cb)
 	assert(ListTagsForResourcesRequest, "You must provide a ListTagsForResourcesRequest")
 	local headers = {
@@ -9508,19 +9549,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourcesSync(ListTagsForResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourcesAsync(ListTagsForResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourcesAsync(ListTagsForResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQueryLoggingConfig asynchronously, invoking a callback when done
 -- @param GetQueryLoggingConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQueryLoggingConfigAsync(GetQueryLoggingConfigRequest, cb)
 	assert(GetQueryLoggingConfigRequest, "You must provide a GetQueryLoggingConfigRequest")
 	local headers = {
@@ -9543,19 +9585,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQueryLoggingConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQueryLoggingConfigSync(GetQueryLoggingConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQueryLoggingConfigAsync(GetQueryLoggingConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQueryLoggingConfigAsync(GetQueryLoggingConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHostedZoneLimit asynchronously, invoking a callback when done
 -- @param GetHostedZoneLimitRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHostedZoneLimitAsync(GetHostedZoneLimitRequest, cb)
 	assert(GetHostedZoneLimitRequest, "You must provide a GetHostedZoneLimitRequest")
 	local headers = {
@@ -9578,19 +9621,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHostedZoneLimitRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHostedZoneLimitSync(GetHostedZoneLimitRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHostedZoneLimitAsync(GetHostedZoneLimitRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHostedZoneLimitAsync(GetHostedZoneLimitRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateVPCWithHostedZone asynchronously, invoking a callback when done
 -- @param AssociateVPCWithHostedZoneRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateVPCWithHostedZoneAsync(AssociateVPCWithHostedZoneRequest, cb)
 	assert(AssociateVPCWithHostedZoneRequest, "You must provide a AssociateVPCWithHostedZoneRequest")
 	local headers = {
@@ -9613,19 +9657,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateVPCWithHostedZoneRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateVPCWithHostedZoneSync(AssociateVPCWithHostedZoneRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateVPCWithHostedZoneAsync(AssociateVPCWithHostedZoneRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateVPCWithHostedZoneAsync(AssociateVPCWithHostedZoneRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTrafficPolicyInstances asynchronously, invoking a callback when done
 -- @param ListTrafficPolicyInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTrafficPolicyInstancesAsync(ListTrafficPolicyInstancesRequest, cb)
 	assert(ListTrafficPolicyInstancesRequest, "You must provide a ListTrafficPolicyInstancesRequest")
 	local headers = {
@@ -9648,19 +9693,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTrafficPolicyInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTrafficPolicyInstancesSync(ListTrafficPolicyInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTrafficPolicyInstancesAsync(ListTrafficPolicyInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTrafficPolicyInstancesAsync(ListTrafficPolicyInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVPCAssociationAuthorizations asynchronously, invoking a callback when done
 -- @param ListVPCAssociationAuthorizationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVPCAssociationAuthorizationsAsync(ListVPCAssociationAuthorizationsRequest, cb)
 	assert(ListVPCAssociationAuthorizationsRequest, "You must provide a ListVPCAssociationAuthorizationsRequest")
 	local headers = {
@@ -9683,19 +9729,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVPCAssociationAuthorizationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVPCAssociationAuthorizationsSync(ListVPCAssociationAuthorizationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVPCAssociationAuthorizationsAsync(ListVPCAssociationAuthorizationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVPCAssociationAuthorizationsAsync(ListVPCAssociationAuthorizationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetHealthCheckLastFailureReason asynchronously, invoking a callback when done
 -- @param GetHealthCheckLastFailureReasonRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetHealthCheckLastFailureReasonAsync(GetHealthCheckLastFailureReasonRequest, cb)
 	assert(GetHealthCheckLastFailureReasonRequest, "You must provide a GetHealthCheckLastFailureReasonRequest")
 	local headers = {
@@ -9718,19 +9765,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetHealthCheckLastFailureReasonRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetHealthCheckLastFailureReasonSync(GetHealthCheckLastFailureReasonRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetHealthCheckLastFailureReasonAsync(GetHealthCheckLastFailureReasonRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetHealthCheckLastFailureReasonAsync(GetHealthCheckLastFailureReasonRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetChange asynchronously, invoking a callback when done
 -- @param GetChangeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetChangeAsync(GetChangeRequest, cb)
 	assert(GetChangeRequest, "You must provide a GetChangeRequest")
 	local headers = {
@@ -9753,19 +9801,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetChangeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetChangeSync(GetChangeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetChangeAsync(GetChangeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetChangeAsync(GetChangeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTrafficPolicyInstance asynchronously, invoking a callback when done
 -- @param UpdateTrafficPolicyInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTrafficPolicyInstanceAsync(UpdateTrafficPolicyInstanceRequest, cb)
 	assert(UpdateTrafficPolicyInstanceRequest, "You must provide a UpdateTrafficPolicyInstanceRequest")
 	local headers = {
@@ -9788,19 +9837,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTrafficPolicyInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTrafficPolicyInstanceSync(UpdateTrafficPolicyInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTrafficPolicyInstanceAsync(UpdateTrafficPolicyInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTrafficPolicyInstanceAsync(UpdateTrafficPolicyInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReusableDelegationSet asynchronously, invoking a callback when done
 -- @param CreateReusableDelegationSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReusableDelegationSetAsync(CreateReusableDelegationSetRequest, cb)
 	assert(CreateReusableDelegationSetRequest, "You must provide a CreateReusableDelegationSetRequest")
 	local headers = {
@@ -9823,19 +9873,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReusableDelegationSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReusableDelegationSetSync(CreateReusableDelegationSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReusableDelegationSetAsync(CreateReusableDelegationSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReusableDelegationSetAsync(CreateReusableDelegationSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteQueryLoggingConfig asynchronously, invoking a callback when done
 -- @param DeleteQueryLoggingConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteQueryLoggingConfigAsync(DeleteQueryLoggingConfigRequest, cb)
 	assert(DeleteQueryLoggingConfigRequest, "You must provide a DeleteQueryLoggingConfigRequest")
 	local headers = {
@@ -9858,19 +9909,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteQueryLoggingConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteQueryLoggingConfigSync(DeleteQueryLoggingConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteQueryLoggingConfigAsync(DeleteQueryLoggingConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteQueryLoggingConfigAsync(DeleteQueryLoggingConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceRecordSets asynchronously, invoking a callback when done
 -- @param ListResourceRecordSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceRecordSetsAsync(ListResourceRecordSetsRequest, cb)
 	assert(ListResourceRecordSetsRequest, "You must provide a ListResourceRecordSetsRequest")
 	local headers = {
@@ -9893,19 +9945,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceRecordSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceRecordSetsSync(ListResourceRecordSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceRecordSetsAsync(ListResourceRecordSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceRecordSetsAsync(ListResourceRecordSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -9928,19 +9981,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListHealthChecks asynchronously, invoking a callback when done
 -- @param ListHealthChecksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListHealthChecksAsync(ListHealthChecksRequest, cb)
 	assert(ListHealthChecksRequest, "You must provide a ListHealthChecksRequest")
 	local headers = {
@@ -9963,19 +10017,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListHealthChecksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListHealthChecksSync(ListHealthChecksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListHealthChecksAsync(ListHealthChecksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListHealthChecksAsync(ListHealthChecksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTrafficPolicyVersions asynchronously, invoking a callback when done
 -- @param ListTrafficPolicyVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTrafficPolicyVersionsAsync(ListTrafficPolicyVersionsRequest, cb)
 	assert(ListTrafficPolicyVersionsRequest, "You must provide a ListTrafficPolicyVersionsRequest")
 	local headers = {
@@ -9998,12 +10053,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTrafficPolicyVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTrafficPolicyVersionsSync(ListTrafficPolicyVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTrafficPolicyVersionsAsync(ListTrafficPolicyVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTrafficPolicyVersionsAsync(ListTrafficPolicyVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/route53domains.lua
+++ b/aws-sdk/route53domains.lua
@@ -3441,7 +3441,7 @@ end
 --
 --- Call CheckDomainTransferability asynchronously, invoking a callback when done
 -- @param CheckDomainTransferabilityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CheckDomainTransferabilityAsync(CheckDomainTransferabilityRequest, cb)
 	assert(CheckDomainTransferabilityRequest, "You must provide a CheckDomainTransferabilityRequest")
 	local headers = {
@@ -3464,19 +3464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CheckDomainTransferabilityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CheckDomainTransferabilitySync(CheckDomainTransferabilityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CheckDomainTransferabilityAsync(CheckDomainTransferabilityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CheckDomainTransferabilityAsync(CheckDomainTransferabilityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResendContactReachabilityEmail asynchronously, invoking a callback when done
 -- @param ResendContactReachabilityEmailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResendContactReachabilityEmailAsync(ResendContactReachabilityEmailRequest, cb)
 	assert(ResendContactReachabilityEmailRequest, "You must provide a ResendContactReachabilityEmailRequest")
 	local headers = {
@@ -3499,19 +3500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResendContactReachabilityEmailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResendContactReachabilityEmailSync(ResendContactReachabilityEmailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResendContactReachabilityEmailAsync(ResendContactReachabilityEmailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResendContactReachabilityEmailAsync(ResendContactReachabilityEmailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDomains asynchronously, invoking a callback when done
 -- @param ListDomainsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDomainsAsync(ListDomainsRequest, cb)
 	assert(ListDomainsRequest, "You must provide a ListDomainsRequest")
 	local headers = {
@@ -3534,19 +3536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDomainsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDomainsSync(ListDomainsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDomainsAsync(ListDomainsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDomainsAsync(ListDomainsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableDomainTransferLock asynchronously, invoking a callback when done
 -- @param DisableDomainTransferLockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableDomainTransferLockAsync(DisableDomainTransferLockRequest, cb)
 	assert(DisableDomainTransferLockRequest, "You must provide a DisableDomainTransferLockRequest")
 	local headers = {
@@ -3569,19 +3572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableDomainTransferLockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableDomainTransferLockSync(DisableDomainTransferLockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableDomainTransferLockAsync(DisableDomainTransferLockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableDomainTransferLockAsync(DisableDomainTransferLockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RetrieveDomainAuthCode asynchronously, invoking a callback when done
 -- @param RetrieveDomainAuthCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RetrieveDomainAuthCodeAsync(RetrieveDomainAuthCodeRequest, cb)
 	assert(RetrieveDomainAuthCodeRequest, "You must provide a RetrieveDomainAuthCodeRequest")
 	local headers = {
@@ -3604,19 +3608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RetrieveDomainAuthCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RetrieveDomainAuthCodeSync(RetrieveDomainAuthCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RetrieveDomainAuthCodeAsync(RetrieveDomainAuthCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RetrieveDomainAuthCodeAsync(RetrieveDomainAuthCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ViewBilling asynchronously, invoking a callback when done
 -- @param ViewBillingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ViewBillingAsync(ViewBillingRequest, cb)
 	assert(ViewBillingRequest, "You must provide a ViewBillingRequest")
 	local headers = {
@@ -3639,19 +3644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ViewBillingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ViewBillingSync(ViewBillingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ViewBillingAsync(ViewBillingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ViewBillingAsync(ViewBillingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDomainNameservers asynchronously, invoking a callback when done
 -- @param UpdateDomainNameserversRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDomainNameserversAsync(UpdateDomainNameserversRequest, cb)
 	assert(UpdateDomainNameserversRequest, "You must provide a UpdateDomainNameserversRequest")
 	local headers = {
@@ -3674,19 +3680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDomainNameserversRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDomainNameserversSync(UpdateDomainNameserversRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDomainNameserversAsync(UpdateDomainNameserversRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDomainNameserversAsync(UpdateDomainNameserversRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTagsForDomain asynchronously, invoking a callback when done
 -- @param UpdateTagsForDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTagsForDomainAsync(UpdateTagsForDomainRequest, cb)
 	assert(UpdateTagsForDomainRequest, "You must provide a UpdateTagsForDomainRequest")
 	local headers = {
@@ -3709,19 +3716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTagsForDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTagsForDomainSync(UpdateTagsForDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTagsForDomainAsync(UpdateTagsForDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTagsForDomainAsync(UpdateTagsForDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CheckDomainAvailability asynchronously, invoking a callback when done
 -- @param CheckDomainAvailabilityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CheckDomainAvailabilityAsync(CheckDomainAvailabilityRequest, cb)
 	assert(CheckDomainAvailabilityRequest, "You must provide a CheckDomainAvailabilityRequest")
 	local headers = {
@@ -3744,19 +3752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CheckDomainAvailabilityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CheckDomainAvailabilitySync(CheckDomainAvailabilityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CheckDomainAvailabilityAsync(CheckDomainAvailabilityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CheckDomainAvailabilityAsync(CheckDomainAvailabilityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDomainSuggestions asynchronously, invoking a callback when done
 -- @param GetDomainSuggestionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDomainSuggestionsAsync(GetDomainSuggestionsRequest, cb)
 	assert(GetDomainSuggestionsRequest, "You must provide a GetDomainSuggestionsRequest")
 	local headers = {
@@ -3779,19 +3788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDomainSuggestionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDomainSuggestionsSync(GetDomainSuggestionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDomainSuggestionsAsync(GetDomainSuggestionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDomainSuggestionsAsync(GetDomainSuggestionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOperationDetail asynchronously, invoking a callback when done
 -- @param GetOperationDetailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOperationDetailAsync(GetOperationDetailRequest, cb)
 	assert(GetOperationDetailRequest, "You must provide a GetOperationDetailRequest")
 	local headers = {
@@ -3814,19 +3824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOperationDetailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOperationDetailSync(GetOperationDetailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOperationDetailAsync(GetOperationDetailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOperationDetailAsync(GetOperationDetailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RenewDomain asynchronously, invoking a callback when done
 -- @param RenewDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RenewDomainAsync(RenewDomainRequest, cb)
 	assert(RenewDomainRequest, "You must provide a RenewDomainRequest")
 	local headers = {
@@ -3849,19 +3860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RenewDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RenewDomainSync(RenewDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RenewDomainAsync(RenewDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RenewDomainAsync(RenewDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TransferDomain asynchronously, invoking a callback when done
 -- @param TransferDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TransferDomainAsync(TransferDomainRequest, cb)
 	assert(TransferDomainRequest, "You must provide a TransferDomainRequest")
 	local headers = {
@@ -3884,19 +3896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TransferDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TransferDomainSync(TransferDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TransferDomainAsync(TransferDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TransferDomainAsync(TransferDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableDomainAutoRenew asynchronously, invoking a callback when done
 -- @param DisableDomainAutoRenewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableDomainAutoRenewAsync(DisableDomainAutoRenewRequest, cb)
 	assert(DisableDomainAutoRenewRequest, "You must provide a DisableDomainAutoRenewRequest")
 	local headers = {
@@ -3919,19 +3932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableDomainAutoRenewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableDomainAutoRenewSync(DisableDomainAutoRenewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableDomainAutoRenewAsync(DisableDomainAutoRenewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableDomainAutoRenewAsync(DisableDomainAutoRenewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTagsForDomain asynchronously, invoking a callback when done
 -- @param DeleteTagsForDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsForDomainAsync(DeleteTagsForDomainRequest, cb)
 	assert(DeleteTagsForDomainRequest, "You must provide a DeleteTagsForDomainRequest")
 	local headers = {
@@ -3954,19 +3968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsForDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsForDomainSync(DeleteTagsForDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsForDomainAsync(DeleteTagsForDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsForDomainAsync(DeleteTagsForDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterDomain asynchronously, invoking a callback when done
 -- @param RegisterDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterDomainAsync(RegisterDomainRequest, cb)
 	assert(RegisterDomainRequest, "You must provide a RegisterDomainRequest")
 	local headers = {
@@ -3989,19 +4004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterDomainSync(RegisterDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterDomainAsync(RegisterDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterDomainAsync(RegisterDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDomainDetail asynchronously, invoking a callback when done
 -- @param GetDomainDetailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDomainDetailAsync(GetDomainDetailRequest, cb)
 	assert(GetDomainDetailRequest, "You must provide a GetDomainDetailRequest")
 	local headers = {
@@ -4024,19 +4040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDomainDetailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDomainDetailSync(GetDomainDetailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDomainDetailAsync(GetDomainDetailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDomainDetailAsync(GetDomainDetailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableDomainAutoRenew asynchronously, invoking a callback when done
 -- @param EnableDomainAutoRenewRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableDomainAutoRenewAsync(EnableDomainAutoRenewRequest, cb)
 	assert(EnableDomainAutoRenewRequest, "You must provide a EnableDomainAutoRenewRequest")
 	local headers = {
@@ -4059,19 +4076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableDomainAutoRenewRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableDomainAutoRenewSync(EnableDomainAutoRenewRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableDomainAutoRenewAsync(EnableDomainAutoRenewRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableDomainAutoRenewAsync(EnableDomainAutoRenewRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDomainContactPrivacy asynchronously, invoking a callback when done
 -- @param UpdateDomainContactPrivacyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDomainContactPrivacyAsync(UpdateDomainContactPrivacyRequest, cb)
 	assert(UpdateDomainContactPrivacyRequest, "You must provide a UpdateDomainContactPrivacyRequest")
 	local headers = {
@@ -4094,19 +4112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDomainContactPrivacyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDomainContactPrivacySync(UpdateDomainContactPrivacyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDomainContactPrivacyAsync(UpdateDomainContactPrivacyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDomainContactPrivacyAsync(UpdateDomainContactPrivacyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForDomain asynchronously, invoking a callback when done
 -- @param ListTagsForDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForDomainAsync(ListTagsForDomainRequest, cb)
 	assert(ListTagsForDomainRequest, "You must provide a ListTagsForDomainRequest")
 	local headers = {
@@ -4129,19 +4148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForDomainSync(ListTagsForDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForDomainAsync(ListTagsForDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForDomainAsync(ListTagsForDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetContactReachabilityStatus asynchronously, invoking a callback when done
 -- @param GetContactReachabilityStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetContactReachabilityStatusAsync(GetContactReachabilityStatusRequest, cb)
 	assert(GetContactReachabilityStatusRequest, "You must provide a GetContactReachabilityStatusRequest")
 	local headers = {
@@ -4164,19 +4184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetContactReachabilityStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetContactReachabilityStatusSync(GetContactReachabilityStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetContactReachabilityStatusAsync(GetContactReachabilityStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetContactReachabilityStatusAsync(GetContactReachabilityStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDomainContact asynchronously, invoking a callback when done
 -- @param UpdateDomainContactRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDomainContactAsync(UpdateDomainContactRequest, cb)
 	assert(UpdateDomainContactRequest, "You must provide a UpdateDomainContactRequest")
 	local headers = {
@@ -4199,19 +4220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDomainContactRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDomainContactSync(UpdateDomainContactRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDomainContactAsync(UpdateDomainContactRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDomainContactAsync(UpdateDomainContactRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOperations asynchronously, invoking a callback when done
 -- @param ListOperationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOperationsAsync(ListOperationsRequest, cb)
 	assert(ListOperationsRequest, "You must provide a ListOperationsRequest")
 	local headers = {
@@ -4234,19 +4256,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOperationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOperationsSync(ListOperationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOperationsAsync(ListOperationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOperationsAsync(ListOperationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableDomainTransferLock asynchronously, invoking a callback when done
 -- @param EnableDomainTransferLockRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableDomainTransferLockAsync(EnableDomainTransferLockRequest, cb)
 	assert(EnableDomainTransferLockRequest, "You must provide a EnableDomainTransferLockRequest")
 	local headers = {
@@ -4269,12 +4292,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableDomainTransferLockRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableDomainTransferLockSync(EnableDomainTransferLockRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableDomainTransferLockAsync(EnableDomainTransferLockRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableDomainTransferLockAsync(EnableDomainTransferLockRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/runtime_lex.lua
+++ b/aws-sdk/runtime_lex.lua
@@ -1137,7 +1137,7 @@ end
 --
 --- Call PostContent asynchronously, invoking a callback when done
 -- @param PostContentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PostContentAsync(PostContentRequest, cb)
 	assert(PostContentRequest, "You must provide a PostContentRequest")
 	local headers = {
@@ -1160,19 +1160,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PostContentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PostContentSync(PostContentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PostContentAsync(PostContentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PostContentAsync(PostContentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PostText asynchronously, invoking a callback when done
 -- @param PostTextRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PostTextAsync(PostTextRequest, cb)
 	assert(PostTextRequest, "You must provide a PostTextRequest")
 	local headers = {
@@ -1195,12 +1196,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PostTextRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PostTextSync(PostTextRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PostTextAsync(PostTextRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PostTextAsync(PostTextRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/runtime_sagemaker.lua
+++ b/aws-sdk/runtime_sagemaker.lua
@@ -221,7 +221,7 @@ end
 --
 --- Call InvokeEndpoint asynchronously, invoking a callback when done
 -- @param InvokeEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InvokeEndpointAsync(InvokeEndpointInput, cb)
 	assert(InvokeEndpointInput, "You must provide a InvokeEndpointInput")
 	local headers = {
@@ -244,12 +244,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InvokeEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InvokeEndpointSync(InvokeEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InvokeEndpointAsync(InvokeEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InvokeEndpointAsync(InvokeEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/s3.lua
+++ b/aws-sdk/s3.lua
@@ -14134,7 +14134,7 @@ end
 --
 --- Call ListObjectVersions asynchronously, invoking a callback when done
 -- @param ListObjectVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectVersionsAsync(ListObjectVersionsRequest, cb)
 	assert(ListObjectVersionsRequest, "You must provide a ListObjectVersionsRequest")
 	local headers = {
@@ -14157,19 +14157,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectVersionsSync(ListObjectVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectVersionsAsync(ListObjectVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectVersionsAsync(ListObjectVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketPolicy asynchronously, invoking a callback when done
 -- @param PutBucketPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketPolicyAsync(PutBucketPolicyRequest, cb)
 	assert(PutBucketPolicyRequest, "You must provide a PutBucketPolicyRequest")
 	local headers = {
@@ -14192,19 +14193,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketPolicySync(PutBucketPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketPolicyAsync(PutBucketPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketPolicyAsync(PutBucketPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBucketInventoryConfigurations asynchronously, invoking a callback when done
 -- @param ListBucketInventoryConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBucketInventoryConfigurationsAsync(ListBucketInventoryConfigurationsRequest, cb)
 	assert(ListBucketInventoryConfigurationsRequest, "You must provide a ListBucketInventoryConfigurationsRequest")
 	local headers = {
@@ -14227,19 +14229,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBucketInventoryConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBucketInventoryConfigurationsSync(ListBucketInventoryConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBucketInventoryConfigurationsAsync(ListBucketInventoryConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBucketInventoryConfigurationsAsync(ListBucketInventoryConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketPolicy asynchronously, invoking a callback when done
 -- @param DeleteBucketPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketPolicyAsync(DeleteBucketPolicyRequest, cb)
 	assert(DeleteBucketPolicyRequest, "You must provide a DeleteBucketPolicyRequest")
 	local headers = {
@@ -14262,19 +14265,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketPolicySync(DeleteBucketPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketPolicyAsync(DeleteBucketPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketPolicyAsync(DeleteBucketPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketLifecycleConfiguration asynchronously, invoking a callback when done
 -- @param PutBucketLifecycleConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketLifecycleConfigurationAsync(PutBucketLifecycleConfigurationRequest, cb)
 	assert(PutBucketLifecycleConfigurationRequest, "You must provide a PutBucketLifecycleConfigurationRequest")
 	local headers = {
@@ -14297,19 +14301,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketLifecycleConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketLifecycleConfigurationSync(PutBucketLifecycleConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketLifecycleConfigurationAsync(PutBucketLifecycleConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketLifecycleConfigurationAsync(PutBucketLifecycleConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketRequestPayment asynchronously, invoking a callback when done
 -- @param PutBucketRequestPaymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketRequestPaymentAsync(PutBucketRequestPaymentRequest, cb)
 	assert(PutBucketRequestPaymentRequest, "You must provide a PutBucketRequestPaymentRequest")
 	local headers = {
@@ -14332,19 +14337,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketRequestPaymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketRequestPaymentSync(PutBucketRequestPaymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketRequestPaymentAsync(PutBucketRequestPaymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketRequestPaymentAsync(PutBucketRequestPaymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketEncryption asynchronously, invoking a callback when done
 -- @param GetBucketEncryptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketEncryptionAsync(GetBucketEncryptionRequest, cb)
 	assert(GetBucketEncryptionRequest, "You must provide a GetBucketEncryptionRequest")
 	local headers = {
@@ -14367,19 +14373,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketEncryptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketEncryptionSync(GetBucketEncryptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketEncryptionAsync(GetBucketEncryptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketEncryptionAsync(GetBucketEncryptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListObjects asynchronously, invoking a callback when done
 -- @param ListObjectsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectsAsync(ListObjectsRequest, cb)
 	assert(ListObjectsRequest, "You must provide a ListObjectsRequest")
 	local headers = {
@@ -14402,19 +14409,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectsSync(ListObjectsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectsAsync(ListObjectsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectsAsync(ListObjectsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketMetricsConfiguration asynchronously, invoking a callback when done
 -- @param GetBucketMetricsConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketMetricsConfigurationAsync(GetBucketMetricsConfigurationRequest, cb)
 	assert(GetBucketMetricsConfigurationRequest, "You must provide a GetBucketMetricsConfigurationRequest")
 	local headers = {
@@ -14437,19 +14445,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketMetricsConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketMetricsConfigurationSync(GetBucketMetricsConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketMetricsConfigurationAsync(GetBucketMetricsConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketMetricsConfigurationAsync(GetBucketMetricsConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketInventoryConfiguration asynchronously, invoking a callback when done
 -- @param PutBucketInventoryConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketInventoryConfigurationAsync(PutBucketInventoryConfigurationRequest, cb)
 	assert(PutBucketInventoryConfigurationRequest, "You must provide a PutBucketInventoryConfigurationRequest")
 	local headers = {
@@ -14472,19 +14481,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketInventoryConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketInventoryConfigurationSync(PutBucketInventoryConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketInventoryConfigurationAsync(PutBucketInventoryConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketInventoryConfigurationAsync(PutBucketInventoryConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketLogging asynchronously, invoking a callback when done
 -- @param PutBucketLoggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketLoggingAsync(PutBucketLoggingRequest, cb)
 	assert(PutBucketLoggingRequest, "You must provide a PutBucketLoggingRequest")
 	local headers = {
@@ -14507,19 +14517,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketLoggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketLoggingSync(PutBucketLoggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketLoggingAsync(PutBucketLoggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketLoggingAsync(PutBucketLoggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketReplication asynchronously, invoking a callback when done
 -- @param PutBucketReplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketReplicationAsync(PutBucketReplicationRequest, cb)
 	assert(PutBucketReplicationRequest, "You must provide a PutBucketReplicationRequest")
 	local headers = {
@@ -14542,19 +14553,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketReplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketReplicationSync(PutBucketReplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketReplicationAsync(PutBucketReplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketReplicationAsync(PutBucketReplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketAccelerateConfiguration asynchronously, invoking a callback when done
 -- @param PutBucketAccelerateConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketAccelerateConfigurationAsync(PutBucketAccelerateConfigurationRequest, cb)
 	assert(PutBucketAccelerateConfigurationRequest, "You must provide a PutBucketAccelerateConfigurationRequest")
 	local headers = {
@@ -14577,19 +14589,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketAccelerateConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketAccelerateConfigurationSync(PutBucketAccelerateConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketAccelerateConfigurationAsync(PutBucketAccelerateConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketAccelerateConfigurationAsync(PutBucketAccelerateConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketAcl asynchronously, invoking a callback when done
 -- @param PutBucketAclRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketAclAsync(PutBucketAclRequest, cb)
 	assert(PutBucketAclRequest, "You must provide a PutBucketAclRequest")
 	local headers = {
@@ -14612,19 +14625,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketAclRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketAclSync(PutBucketAclRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketAclAsync(PutBucketAclRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketAclAsync(PutBucketAclRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadPart asynchronously, invoking a callback when done
 -- @param UploadPartRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadPartAsync(UploadPartRequest, cb)
 	assert(UploadPartRequest, "You must provide a UploadPartRequest")
 	local headers = {
@@ -14647,19 +14661,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadPartRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadPartSync(UploadPartRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadPartAsync(UploadPartRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadPartAsync(UploadPartRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutObject asynchronously, invoking a callback when done
 -- @param PutObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutObjectAsync(PutObjectRequest, cb)
 	assert(PutObjectRequest, "You must provide a PutObjectRequest")
 	local headers = {
@@ -14682,19 +14697,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutObjectSync(PutObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutObjectAsync(PutObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutObjectAsync(PutObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketCors asynchronously, invoking a callback when done
 -- @param DeleteBucketCorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketCorsAsync(DeleteBucketCorsRequest, cb)
 	assert(DeleteBucketCorsRequest, "You must provide a DeleteBucketCorsRequest")
 	local headers = {
@@ -14717,19 +14733,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketCorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketCorsSync(DeleteBucketCorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketCorsAsync(DeleteBucketCorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketCorsAsync(DeleteBucketCorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketVersioning asynchronously, invoking a callback when done
 -- @param PutBucketVersioningRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketVersioningAsync(PutBucketVersioningRequest, cb)
 	assert(PutBucketVersioningRequest, "You must provide a PutBucketVersioningRequest")
 	local headers = {
@@ -14752,19 +14769,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketVersioningRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketVersioningSync(PutBucketVersioningRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketVersioningAsync(PutBucketVersioningRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketVersioningAsync(PutBucketVersioningRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyObject asynchronously, invoking a callback when done
 -- @param CopyObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyObjectAsync(CopyObjectRequest, cb)
 	assert(CopyObjectRequest, "You must provide a CopyObjectRequest")
 	local headers = {
@@ -14787,19 +14805,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyObjectSync(CopyObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyObjectAsync(CopyObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyObjectAsync(CopyObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBucketAnalyticsConfigurations asynchronously, invoking a callback when done
 -- @param ListBucketAnalyticsConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBucketAnalyticsConfigurationsAsync(ListBucketAnalyticsConfigurationsRequest, cb)
 	assert(ListBucketAnalyticsConfigurationsRequest, "You must provide a ListBucketAnalyticsConfigurationsRequest")
 	local headers = {
@@ -14822,19 +14841,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBucketAnalyticsConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBucketAnalyticsConfigurationsSync(ListBucketAnalyticsConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBucketAnalyticsConfigurationsAsync(ListBucketAnalyticsConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBucketAnalyticsConfigurationsAsync(ListBucketAnalyticsConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketAcl asynchronously, invoking a callback when done
 -- @param GetBucketAclRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketAclAsync(GetBucketAclRequest, cb)
 	assert(GetBucketAclRequest, "You must provide a GetBucketAclRequest")
 	local headers = {
@@ -14857,19 +14877,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketAclRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketAclSync(GetBucketAclRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketAclAsync(GetBucketAclRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketAclAsync(GetBucketAclRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketMetricsConfiguration asynchronously, invoking a callback when done
 -- @param DeleteBucketMetricsConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketMetricsConfigurationAsync(DeleteBucketMetricsConfigurationRequest, cb)
 	assert(DeleteBucketMetricsConfigurationRequest, "You must provide a DeleteBucketMetricsConfigurationRequest")
 	local headers = {
@@ -14892,19 +14913,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketMetricsConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketMetricsConfigurationSync(DeleteBucketMetricsConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketMetricsConfigurationAsync(DeleteBucketMetricsConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketMetricsConfigurationAsync(DeleteBucketMetricsConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketLogging asynchronously, invoking a callback when done
 -- @param GetBucketLoggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketLoggingAsync(GetBucketLoggingRequest, cb)
 	assert(GetBucketLoggingRequest, "You must provide a GetBucketLoggingRequest")
 	local headers = {
@@ -14927,19 +14949,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketLoggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketLoggingSync(GetBucketLoggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketLoggingAsync(GetBucketLoggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketLoggingAsync(GetBucketLoggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call HeadBucket asynchronously, invoking a callback when done
 -- @param HeadBucketRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.HeadBucketAsync(HeadBucketRequest, cb)
 	assert(HeadBucketRequest, "You must provide a HeadBucketRequest")
 	local headers = {
@@ -14962,19 +14985,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param HeadBucketRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.HeadBucketSync(HeadBucketRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.HeadBucketAsync(HeadBucketRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.HeadBucketAsync(HeadBucketRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBucketMetricsConfigurations asynchronously, invoking a callback when done
 -- @param ListBucketMetricsConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBucketMetricsConfigurationsAsync(ListBucketMetricsConfigurationsRequest, cb)
 	assert(ListBucketMetricsConfigurationsRequest, "You must provide a ListBucketMetricsConfigurationsRequest")
 	local headers = {
@@ -14997,18 +15021,19 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListBucketMetricsConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBucketMetricsConfigurationsSync(ListBucketMetricsConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBucketMetricsConfigurationsAsync(ListBucketMetricsConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBucketMetricsConfigurationsAsync(ListBucketMetricsConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListBuckets asynchronously, invoking a callback when done
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListBucketsAsync(cb)
 	local headers = {
 		[request_headers.CONTENT_TYPE_HEADER] = content_type.from_protocol(M.metadata.protocol, M.metadata.json_version),
@@ -15027,19 +15052,20 @@ end
 --- Call ListBuckets synchronously, returning when done
 -- This assumes that the function is called from within a coroutine
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListBucketsSync(...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListBucketsAsync(function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListBucketsAsync(function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketWebsite asynchronously, invoking a callback when done
 -- @param DeleteBucketWebsiteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketWebsiteAsync(DeleteBucketWebsiteRequest, cb)
 	assert(DeleteBucketWebsiteRequest, "You must provide a DeleteBucketWebsiteRequest")
 	local headers = {
@@ -15062,19 +15088,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketWebsiteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketWebsiteSync(DeleteBucketWebsiteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketWebsiteAsync(DeleteBucketWebsiteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketWebsiteAsync(DeleteBucketWebsiteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketInventoryConfiguration asynchronously, invoking a callback when done
 -- @param DeleteBucketInventoryConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketInventoryConfigurationAsync(DeleteBucketInventoryConfigurationRequest, cb)
 	assert(DeleteBucketInventoryConfigurationRequest, "You must provide a DeleteBucketInventoryConfigurationRequest")
 	local headers = {
@@ -15097,19 +15124,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketInventoryConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketInventoryConfigurationSync(DeleteBucketInventoryConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketInventoryConfigurationAsync(DeleteBucketInventoryConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketInventoryConfigurationAsync(DeleteBucketInventoryConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketNotificationConfiguration asynchronously, invoking a callback when done
 -- @param GetBucketNotificationConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketNotificationConfigurationAsync(GetBucketNotificationConfigurationRequest, cb)
 	assert(GetBucketNotificationConfigurationRequest, "You must provide a GetBucketNotificationConfigurationRequest")
 	local headers = {
@@ -15132,19 +15160,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketNotificationConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketNotificationConfigurationSync(GetBucketNotificationConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketNotificationConfigurationAsync(GetBucketNotificationConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketNotificationConfigurationAsync(GetBucketNotificationConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteObjects asynchronously, invoking a callback when done
 -- @param DeleteObjectsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteObjectsAsync(DeleteObjectsRequest, cb)
 	assert(DeleteObjectsRequest, "You must provide a DeleteObjectsRequest")
 	local headers = {
@@ -15167,19 +15196,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteObjectsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteObjectsSync(DeleteObjectsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteObjectsAsync(DeleteObjectsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteObjectsAsync(DeleteObjectsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketReplication asynchronously, invoking a callback when done
 -- @param DeleteBucketReplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketReplicationAsync(DeleteBucketReplicationRequest, cb)
 	assert(DeleteBucketReplicationRequest, "You must provide a DeleteBucketReplicationRequest")
 	local headers = {
@@ -15202,19 +15232,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketReplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketReplicationSync(DeleteBucketReplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketReplicationAsync(DeleteBucketReplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketReplicationAsync(DeleteBucketReplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketWebsite asynchronously, invoking a callback when done
 -- @param PutBucketWebsiteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketWebsiteAsync(PutBucketWebsiteRequest, cb)
 	assert(PutBucketWebsiteRequest, "You must provide a PutBucketWebsiteRequest")
 	local headers = {
@@ -15237,19 +15268,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketWebsiteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketWebsiteSync(PutBucketWebsiteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketWebsiteAsync(PutBucketWebsiteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketWebsiteAsync(PutBucketWebsiteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetObjectTagging asynchronously, invoking a callback when done
 -- @param GetObjectTaggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetObjectTaggingAsync(GetObjectTaggingRequest, cb)
 	assert(GetObjectTaggingRequest, "You must provide a GetObjectTaggingRequest")
 	local headers = {
@@ -15272,19 +15304,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetObjectTaggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetObjectTaggingSync(GetObjectTaggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetObjectTaggingAsync(GetObjectTaggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetObjectTaggingAsync(GetObjectTaggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketReplication asynchronously, invoking a callback when done
 -- @param GetBucketReplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketReplicationAsync(GetBucketReplicationRequest, cb)
 	assert(GetBucketReplicationRequest, "You must provide a GetBucketReplicationRequest")
 	local headers = {
@@ -15307,19 +15340,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketReplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketReplicationSync(GetBucketReplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketReplicationAsync(GetBucketReplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketReplicationAsync(GetBucketReplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketAnalyticsConfiguration asynchronously, invoking a callback when done
 -- @param GetBucketAnalyticsConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketAnalyticsConfigurationAsync(GetBucketAnalyticsConfigurationRequest, cb)
 	assert(GetBucketAnalyticsConfigurationRequest, "You must provide a GetBucketAnalyticsConfigurationRequest")
 	local headers = {
@@ -15342,19 +15376,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketAnalyticsConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketAnalyticsConfigurationSync(GetBucketAnalyticsConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketAnalyticsConfigurationAsync(GetBucketAnalyticsConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketAnalyticsConfigurationAsync(GetBucketAnalyticsConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketNotificationConfiguration asynchronously, invoking a callback when done
 -- @param PutBucketNotificationConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketNotificationConfigurationAsync(PutBucketNotificationConfigurationRequest, cb)
 	assert(PutBucketNotificationConfigurationRequest, "You must provide a PutBucketNotificationConfigurationRequest")
 	local headers = {
@@ -15377,19 +15412,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketNotificationConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketNotificationConfigurationSync(PutBucketNotificationConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketNotificationConfigurationAsync(PutBucketNotificationConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketNotificationConfigurationAsync(PutBucketNotificationConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketAccelerateConfiguration asynchronously, invoking a callback when done
 -- @param GetBucketAccelerateConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketAccelerateConfigurationAsync(GetBucketAccelerateConfigurationRequest, cb)
 	assert(GetBucketAccelerateConfigurationRequest, "You must provide a GetBucketAccelerateConfigurationRequest")
 	local headers = {
@@ -15412,19 +15448,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketAccelerateConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketAccelerateConfigurationSync(GetBucketAccelerateConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketAccelerateConfigurationAsync(GetBucketAccelerateConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketAccelerateConfigurationAsync(GetBucketAccelerateConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteObjectTagging asynchronously, invoking a callback when done
 -- @param DeleteObjectTaggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteObjectTaggingAsync(DeleteObjectTaggingRequest, cb)
 	assert(DeleteObjectTaggingRequest, "You must provide a DeleteObjectTaggingRequest")
 	local headers = {
@@ -15447,19 +15484,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteObjectTaggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteObjectTaggingSync(DeleteObjectTaggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteObjectTaggingAsync(DeleteObjectTaggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteObjectTaggingAsync(DeleteObjectTaggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketTagging asynchronously, invoking a callback when done
 -- @param DeleteBucketTaggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketTaggingAsync(DeleteBucketTaggingRequest, cb)
 	assert(DeleteBucketTaggingRequest, "You must provide a DeleteBucketTaggingRequest")
 	local headers = {
@@ -15482,19 +15520,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketTaggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketTaggingSync(DeleteBucketTaggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketTaggingAsync(DeleteBucketTaggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketTaggingAsync(DeleteBucketTaggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetObjectTorrent asynchronously, invoking a callback when done
 -- @param GetObjectTorrentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetObjectTorrentAsync(GetObjectTorrentRequest, cb)
 	assert(GetObjectTorrentRequest, "You must provide a GetObjectTorrentRequest")
 	local headers = {
@@ -15517,19 +15556,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetObjectTorrentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetObjectTorrentSync(GetObjectTorrentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetObjectTorrentAsync(GetObjectTorrentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetObjectTorrentAsync(GetObjectTorrentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketCors asynchronously, invoking a callback when done
 -- @param GetBucketCorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketCorsAsync(GetBucketCorsRequest, cb)
 	assert(GetBucketCorsRequest, "You must provide a GetBucketCorsRequest")
 	local headers = {
@@ -15552,19 +15592,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketCorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketCorsSync(GetBucketCorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketCorsAsync(GetBucketCorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketCorsAsync(GetBucketCorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateBucket asynchronously, invoking a callback when done
 -- @param CreateBucketRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateBucketAsync(CreateBucketRequest, cb)
 	assert(CreateBucketRequest, "You must provide a CreateBucketRequest")
 	local headers = {
@@ -15587,19 +15628,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateBucketRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateBucketSync(CreateBucketRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateBucketAsync(CreateBucketRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateBucketAsync(CreateBucketRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CompleteMultipartUpload asynchronously, invoking a callback when done
 -- @param CompleteMultipartUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CompleteMultipartUploadAsync(CompleteMultipartUploadRequest, cb)
 	assert(CompleteMultipartUploadRequest, "You must provide a CompleteMultipartUploadRequest")
 	local headers = {
@@ -15622,19 +15664,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CompleteMultipartUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CompleteMultipartUploadSync(CompleteMultipartUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CompleteMultipartUploadAsync(CompleteMultipartUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CompleteMultipartUploadAsync(CompleteMultipartUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketWebsite asynchronously, invoking a callback when done
 -- @param GetBucketWebsiteRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketWebsiteAsync(GetBucketWebsiteRequest, cb)
 	assert(GetBucketWebsiteRequest, "You must provide a GetBucketWebsiteRequest")
 	local headers = {
@@ -15657,19 +15700,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketWebsiteRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketWebsiteSync(GetBucketWebsiteRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketWebsiteAsync(GetBucketWebsiteRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketWebsiteAsync(GetBucketWebsiteRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMultipartUpload asynchronously, invoking a callback when done
 -- @param CreateMultipartUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMultipartUploadAsync(CreateMultipartUploadRequest, cb)
 	assert(CreateMultipartUploadRequest, "You must provide a CreateMultipartUploadRequest")
 	local headers = {
@@ -15692,19 +15736,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMultipartUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMultipartUploadSync(CreateMultipartUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMultipartUploadAsync(CreateMultipartUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMultipartUploadAsync(CreateMultipartUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucket asynchronously, invoking a callback when done
 -- @param DeleteBucketRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketAsync(DeleteBucketRequest, cb)
 	assert(DeleteBucketRequest, "You must provide a DeleteBucketRequest")
 	local headers = {
@@ -15727,19 +15772,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketSync(DeleteBucketRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketAsync(DeleteBucketRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketAsync(DeleteBucketRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetObject asynchronously, invoking a callback when done
 -- @param GetObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetObjectAsync(GetObjectRequest, cb)
 	assert(GetObjectRequest, "You must provide a GetObjectRequest")
 	local headers = {
@@ -15762,19 +15808,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetObjectSync(GetObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetObjectAsync(GetObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetObjectAsync(GetObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketEncryption asynchronously, invoking a callback when done
 -- @param PutBucketEncryptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketEncryptionAsync(PutBucketEncryptionRequest, cb)
 	assert(PutBucketEncryptionRequest, "You must provide a PutBucketEncryptionRequest")
 	local headers = {
@@ -15797,19 +15844,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketEncryptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketEncryptionSync(PutBucketEncryptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketEncryptionAsync(PutBucketEncryptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketEncryptionAsync(PutBucketEncryptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutObjectTagging asynchronously, invoking a callback when done
 -- @param PutObjectTaggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutObjectTaggingAsync(PutObjectTaggingRequest, cb)
 	assert(PutObjectTaggingRequest, "You must provide a PutObjectTaggingRequest")
 	local headers = {
@@ -15832,19 +15880,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutObjectTaggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutObjectTaggingSync(PutObjectTaggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutObjectTaggingAsync(PutObjectTaggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutObjectTaggingAsync(PutObjectTaggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketPolicy asynchronously, invoking a callback when done
 -- @param GetBucketPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketPolicyAsync(GetBucketPolicyRequest, cb)
 	assert(GetBucketPolicyRequest, "You must provide a GetBucketPolicyRequest")
 	local headers = {
@@ -15867,19 +15916,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketPolicySync(GetBucketPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketPolicyAsync(GetBucketPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketPolicyAsync(GetBucketPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketVersioning asynchronously, invoking a callback when done
 -- @param GetBucketVersioningRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketVersioningAsync(GetBucketVersioningRequest, cb)
 	assert(GetBucketVersioningRequest, "You must provide a GetBucketVersioningRequest")
 	local headers = {
@@ -15902,19 +15952,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketVersioningRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketVersioningSync(GetBucketVersioningRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketVersioningAsync(GetBucketVersioningRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketVersioningAsync(GetBucketVersioningRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call HeadObject asynchronously, invoking a callback when done
 -- @param HeadObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.HeadObjectAsync(HeadObjectRequest, cb)
 	assert(HeadObjectRequest, "You must provide a HeadObjectRequest")
 	local headers = {
@@ -15937,19 +15988,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param HeadObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.HeadObjectSync(HeadObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.HeadObjectAsync(HeadObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.HeadObjectAsync(HeadObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMultipartUploads asynchronously, invoking a callback when done
 -- @param ListMultipartUploadsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMultipartUploadsAsync(ListMultipartUploadsRequest, cb)
 	assert(ListMultipartUploadsRequest, "You must provide a ListMultipartUploadsRequest")
 	local headers = {
@@ -15972,19 +16024,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMultipartUploadsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMultipartUploadsSync(ListMultipartUploadsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMultipartUploadsAsync(ListMultipartUploadsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMultipartUploadsAsync(ListMultipartUploadsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketLifecycleConfiguration asynchronously, invoking a callback when done
 -- @param GetBucketLifecycleConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketLifecycleConfigurationAsync(GetBucketLifecycleConfigurationRequest, cb)
 	assert(GetBucketLifecycleConfigurationRequest, "You must provide a GetBucketLifecycleConfigurationRequest")
 	local headers = {
@@ -16007,19 +16060,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketLifecycleConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketLifecycleConfigurationSync(GetBucketLifecycleConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketLifecycleConfigurationAsync(GetBucketLifecycleConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketLifecycleConfigurationAsync(GetBucketLifecycleConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketRequestPayment asynchronously, invoking a callback when done
 -- @param GetBucketRequestPaymentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketRequestPaymentAsync(GetBucketRequestPaymentRequest, cb)
 	assert(GetBucketRequestPaymentRequest, "You must provide a GetBucketRequestPaymentRequest")
 	local headers = {
@@ -16042,19 +16096,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketRequestPaymentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketRequestPaymentSync(GetBucketRequestPaymentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketRequestPaymentAsync(GetBucketRequestPaymentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketRequestPaymentAsync(GetBucketRequestPaymentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketCors asynchronously, invoking a callback when done
 -- @param PutBucketCorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketCorsAsync(PutBucketCorsRequest, cb)
 	assert(PutBucketCorsRequest, "You must provide a PutBucketCorsRequest")
 	local headers = {
@@ -16077,19 +16132,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketCorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketCorsSync(PutBucketCorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketCorsAsync(PutBucketCorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketCorsAsync(PutBucketCorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketTagging asynchronously, invoking a callback when done
 -- @param PutBucketTaggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketTaggingAsync(PutBucketTaggingRequest, cb)
 	assert(PutBucketTaggingRequest, "You must provide a PutBucketTaggingRequest")
 	local headers = {
@@ -16112,19 +16168,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketTaggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketTaggingSync(PutBucketTaggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketTaggingAsync(PutBucketTaggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketTaggingAsync(PutBucketTaggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketTagging asynchronously, invoking a callback when done
 -- @param GetBucketTaggingRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketTaggingAsync(GetBucketTaggingRequest, cb)
 	assert(GetBucketTaggingRequest, "You must provide a GetBucketTaggingRequest")
 	local headers = {
@@ -16147,19 +16204,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketTaggingRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketTaggingSync(GetBucketTaggingRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketTaggingAsync(GetBucketTaggingRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketTaggingAsync(GetBucketTaggingRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AbortMultipartUpload asynchronously, invoking a callback when done
 -- @param AbortMultipartUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AbortMultipartUploadAsync(AbortMultipartUploadRequest, cb)
 	assert(AbortMultipartUploadRequest, "You must provide a AbortMultipartUploadRequest")
 	local headers = {
@@ -16182,19 +16240,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AbortMultipartUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AbortMultipartUploadSync(AbortMultipartUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AbortMultipartUploadAsync(AbortMultipartUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AbortMultipartUploadAsync(AbortMultipartUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutObjectAcl asynchronously, invoking a callback when done
 -- @param PutObjectAclRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutObjectAclAsync(PutObjectAclRequest, cb)
 	assert(PutObjectAclRequest, "You must provide a PutObjectAclRequest")
 	local headers = {
@@ -16217,19 +16276,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutObjectAclRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutObjectAclSync(PutObjectAclRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutObjectAclAsync(PutObjectAclRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutObjectAclAsync(PutObjectAclRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListObjectsV2 asynchronously, invoking a callback when done
 -- @param ListObjectsV2Request
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListObjectsV2Async(ListObjectsV2Request, cb)
 	assert(ListObjectsV2Request, "You must provide a ListObjectsV2Request")
 	local headers = {
@@ -16252,19 +16312,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListObjectsV2Request
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListObjectsV2Sync(ListObjectsV2Request, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListObjectsV2Async(ListObjectsV2Request, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListObjectsV2Async(ListObjectsV2Request, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketLocation asynchronously, invoking a callback when done
 -- @param GetBucketLocationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketLocationAsync(GetBucketLocationRequest, cb)
 	assert(GetBucketLocationRequest, "You must provide a GetBucketLocationRequest")
 	local headers = {
@@ -16287,19 +16348,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketLocationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketLocationSync(GetBucketLocationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketLocationAsync(GetBucketLocationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketLocationAsync(GetBucketLocationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetBucketInventoryConfiguration asynchronously, invoking a callback when done
 -- @param GetBucketInventoryConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetBucketInventoryConfigurationAsync(GetBucketInventoryConfigurationRequest, cb)
 	assert(GetBucketInventoryConfigurationRequest, "You must provide a GetBucketInventoryConfigurationRequest")
 	local headers = {
@@ -16322,19 +16384,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetBucketInventoryConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetBucketInventoryConfigurationSync(GetBucketInventoryConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetBucketInventoryConfigurationAsync(GetBucketInventoryConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetBucketInventoryConfigurationAsync(GetBucketInventoryConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketLifecycle asynchronously, invoking a callback when done
 -- @param DeleteBucketLifecycleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketLifecycleAsync(DeleteBucketLifecycleRequest, cb)
 	assert(DeleteBucketLifecycleRequest, "You must provide a DeleteBucketLifecycleRequest")
 	local headers = {
@@ -16357,19 +16420,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketLifecycleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketLifecycleSync(DeleteBucketLifecycleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketLifecycleAsync(DeleteBucketLifecycleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketLifecycleAsync(DeleteBucketLifecycleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SelectObjectContent asynchronously, invoking a callback when done
 -- @param SelectObjectContentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SelectObjectContentAsync(SelectObjectContentRequest, cb)
 	assert(SelectObjectContentRequest, "You must provide a SelectObjectContentRequest")
 	local headers = {
@@ -16392,19 +16456,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SelectObjectContentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SelectObjectContentSync(SelectObjectContentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SelectObjectContentAsync(SelectObjectContentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SelectObjectContentAsync(SelectObjectContentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketAnalyticsConfiguration asynchronously, invoking a callback when done
 -- @param PutBucketAnalyticsConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketAnalyticsConfigurationAsync(PutBucketAnalyticsConfigurationRequest, cb)
 	assert(PutBucketAnalyticsConfigurationRequest, "You must provide a PutBucketAnalyticsConfigurationRequest")
 	local headers = {
@@ -16427,19 +16492,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketAnalyticsConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketAnalyticsConfigurationSync(PutBucketAnalyticsConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketAnalyticsConfigurationAsync(PutBucketAnalyticsConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketAnalyticsConfigurationAsync(PutBucketAnalyticsConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListParts asynchronously, invoking a callback when done
 -- @param ListPartsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPartsAsync(ListPartsRequest, cb)
 	assert(ListPartsRequest, "You must provide a ListPartsRequest")
 	local headers = {
@@ -16462,19 +16528,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPartsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPartsSync(ListPartsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPartsAsync(ListPartsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPartsAsync(ListPartsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketEncryption asynchronously, invoking a callback when done
 -- @param DeleteBucketEncryptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketEncryptionAsync(DeleteBucketEncryptionRequest, cb)
 	assert(DeleteBucketEncryptionRequest, "You must provide a DeleteBucketEncryptionRequest")
 	local headers = {
@@ -16497,19 +16564,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketEncryptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketEncryptionSync(DeleteBucketEncryptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketEncryptionAsync(DeleteBucketEncryptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketEncryptionAsync(DeleteBucketEncryptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetObjectAcl asynchronously, invoking a callback when done
 -- @param GetObjectAclRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetObjectAclAsync(GetObjectAclRequest, cb)
 	assert(GetObjectAclRequest, "You must provide a GetObjectAclRequest")
 	local headers = {
@@ -16532,19 +16600,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetObjectAclRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetObjectAclSync(GetObjectAclRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetObjectAclAsync(GetObjectAclRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetObjectAclAsync(GetObjectAclRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UploadPartCopy asynchronously, invoking a callback when done
 -- @param UploadPartCopyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UploadPartCopyAsync(UploadPartCopyRequest, cb)
 	assert(UploadPartCopyRequest, "You must provide a UploadPartCopyRequest")
 	local headers = {
@@ -16567,19 +16636,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UploadPartCopyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UploadPartCopySync(UploadPartCopyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UploadPartCopyAsync(UploadPartCopyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UploadPartCopyAsync(UploadPartCopyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutBucketMetricsConfiguration asynchronously, invoking a callback when done
 -- @param PutBucketMetricsConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutBucketMetricsConfigurationAsync(PutBucketMetricsConfigurationRequest, cb)
 	assert(PutBucketMetricsConfigurationRequest, "You must provide a PutBucketMetricsConfigurationRequest")
 	local headers = {
@@ -16602,19 +16672,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutBucketMetricsConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutBucketMetricsConfigurationSync(PutBucketMetricsConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutBucketMetricsConfigurationAsync(PutBucketMetricsConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutBucketMetricsConfigurationAsync(PutBucketMetricsConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteObject asynchronously, invoking a callback when done
 -- @param DeleteObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteObjectAsync(DeleteObjectRequest, cb)
 	assert(DeleteObjectRequest, "You must provide a DeleteObjectRequest")
 	local headers = {
@@ -16637,19 +16708,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteObjectSync(DeleteObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteObjectAsync(DeleteObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteObjectAsync(DeleteObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreObject asynchronously, invoking a callback when done
 -- @param RestoreObjectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreObjectAsync(RestoreObjectRequest, cb)
 	assert(RestoreObjectRequest, "You must provide a RestoreObjectRequest")
 	local headers = {
@@ -16672,19 +16744,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreObjectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreObjectSync(RestoreObjectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreObjectAsync(RestoreObjectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreObjectAsync(RestoreObjectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBucketAnalyticsConfiguration asynchronously, invoking a callback when done
 -- @param DeleteBucketAnalyticsConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBucketAnalyticsConfigurationAsync(DeleteBucketAnalyticsConfigurationRequest, cb)
 	assert(DeleteBucketAnalyticsConfigurationRequest, "You must provide a DeleteBucketAnalyticsConfigurationRequest")
 	local headers = {
@@ -16707,12 +16780,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBucketAnalyticsConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBucketAnalyticsConfigurationSync(DeleteBucketAnalyticsConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBucketAnalyticsConfigurationAsync(DeleteBucketAnalyticsConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBucketAnalyticsConfigurationAsync(DeleteBucketAnalyticsConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/sdb.lua
+++ b/aws-sdk/sdb.lua
@@ -1797,7 +1797,7 @@ end
 --
 --- Call DeleteAttributes asynchronously, invoking a callback when done
 -- @param DeleteAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAttributesAsync(DeleteAttributesRequest, cb)
 	assert(DeleteAttributesRequest, "You must provide a DeleteAttributesRequest")
 	local headers = {
@@ -1820,19 +1820,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAttributesSync(DeleteAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAttributesAsync(DeleteAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAttributesAsync(DeleteAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchPutAttributes asynchronously, invoking a callback when done
 -- @param BatchPutAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchPutAttributesAsync(BatchPutAttributesRequest, cb)
 	assert(BatchPutAttributesRequest, "You must provide a BatchPutAttributesRequest")
 	local headers = {
@@ -1855,19 +1856,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchPutAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchPutAttributesSync(BatchPutAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchPutAttributesAsync(BatchPutAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchPutAttributesAsync(BatchPutAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutAttributes asynchronously, invoking a callback when done
 -- @param PutAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutAttributesAsync(PutAttributesRequest, cb)
 	assert(PutAttributesRequest, "You must provide a PutAttributesRequest")
 	local headers = {
@@ -1890,19 +1892,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutAttributesSync(PutAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutAttributesAsync(PutAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutAttributesAsync(PutAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDomains asynchronously, invoking a callback when done
 -- @param ListDomainsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDomainsAsync(ListDomainsRequest, cb)
 	assert(ListDomainsRequest, "You must provide a ListDomainsRequest")
 	local headers = {
@@ -1925,19 +1928,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDomainsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDomainsSync(ListDomainsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDomainsAsync(ListDomainsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDomainsAsync(ListDomainsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DomainMetadata asynchronously, invoking a callback when done
 -- @param DomainMetadataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DomainMetadataAsync(DomainMetadataRequest, cb)
 	assert(DomainMetadataRequest, "You must provide a DomainMetadataRequest")
 	local headers = {
@@ -1960,19 +1964,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DomainMetadataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DomainMetadataSync(DomainMetadataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DomainMetadataAsync(DomainMetadataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DomainMetadataAsync(DomainMetadataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDeleteAttributes asynchronously, invoking a callback when done
 -- @param BatchDeleteAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDeleteAttributesAsync(BatchDeleteAttributesRequest, cb)
 	assert(BatchDeleteAttributesRequest, "You must provide a BatchDeleteAttributesRequest")
 	local headers = {
@@ -1995,19 +2000,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDeleteAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDeleteAttributesSync(BatchDeleteAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDeleteAttributesAsync(BatchDeleteAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDeleteAttributesAsync(BatchDeleteAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAttributes asynchronously, invoking a callback when done
 -- @param GetAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAttributesAsync(GetAttributesRequest, cb)
 	assert(GetAttributesRequest, "You must provide a GetAttributesRequest")
 	local headers = {
@@ -2030,19 +2036,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAttributesSync(GetAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAttributesAsync(GetAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAttributesAsync(GetAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDomain asynchronously, invoking a callback when done
 -- @param DeleteDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDomainAsync(DeleteDomainRequest, cb)
 	assert(DeleteDomainRequest, "You must provide a DeleteDomainRequest")
 	local headers = {
@@ -2065,19 +2072,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDomainSync(DeleteDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDomainAsync(DeleteDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDomainAsync(DeleteDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDomain asynchronously, invoking a callback when done
 -- @param CreateDomainRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDomainAsync(CreateDomainRequest, cb)
 	assert(CreateDomainRequest, "You must provide a CreateDomainRequest")
 	local headers = {
@@ -2100,19 +2108,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDomainRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDomainSync(CreateDomainRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDomainAsync(CreateDomainRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDomainAsync(CreateDomainRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Select asynchronously, invoking a callback when done
 -- @param SelectRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SelectAsync(SelectRequest, cb)
 	assert(SelectRequest, "You must provide a SelectRequest")
 	local headers = {
@@ -2135,12 +2144,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SelectRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SelectSync(SelectRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SelectAsync(SelectRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SelectAsync(SelectRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/secretsmanager.lua
+++ b/aws-sdk/secretsmanager.lua
@@ -2302,7 +2302,7 @@ end
 --
 --- Call PutSecretValue asynchronously, invoking a callback when done
 -- @param PutSecretValueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutSecretValueAsync(PutSecretValueRequest, cb)
 	assert(PutSecretValueRequest, "You must provide a PutSecretValueRequest")
 	local headers = {
@@ -2325,19 +2325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutSecretValueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutSecretValueSync(PutSecretValueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutSecretValueAsync(PutSecretValueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutSecretValueAsync(PutSecretValueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSecretVersionIds asynchronously, invoking a callback when done
 -- @param ListSecretVersionIdsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSecretVersionIdsAsync(ListSecretVersionIdsRequest, cb)
 	assert(ListSecretVersionIdsRequest, "You must provide a ListSecretVersionIdsRequest")
 	local headers = {
@@ -2360,19 +2361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSecretVersionIdsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSecretVersionIdsSync(ListSecretVersionIdsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSecretVersionIdsAsync(ListSecretVersionIdsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSecretVersionIdsAsync(ListSecretVersionIdsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RestoreSecret asynchronously, invoking a callback when done
 -- @param RestoreSecretRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RestoreSecretAsync(RestoreSecretRequest, cb)
 	assert(RestoreSecretRequest, "You must provide a RestoreSecretRequest")
 	local headers = {
@@ -2395,19 +2397,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RestoreSecretRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RestoreSecretSync(RestoreSecretRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RestoreSecretAsync(RestoreSecretRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RestoreSecretAsync(RestoreSecretRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSecret asynchronously, invoking a callback when done
 -- @param CreateSecretRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSecretAsync(CreateSecretRequest, cb)
 	assert(CreateSecretRequest, "You must provide a CreateSecretRequest")
 	local headers = {
@@ -2430,19 +2433,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSecretRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSecretSync(CreateSecretRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSecretAsync(CreateSecretRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSecretAsync(CreateSecretRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSecret asynchronously, invoking a callback when done
 -- @param DeleteSecretRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSecretAsync(DeleteSecretRequest, cb)
 	assert(DeleteSecretRequest, "You must provide a DeleteSecretRequest")
 	local headers = {
@@ -2465,19 +2469,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSecretRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSecretSync(DeleteSecretRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSecretAsync(DeleteSecretRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSecretAsync(DeleteSecretRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResource asynchronously, invoking a callback when done
 -- @param UntagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourceAsync(UntagResourceRequest, cb)
 	assert(UntagResourceRequest, "You must provide a UntagResourceRequest")
 	local headers = {
@@ -2500,19 +2505,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourceSync(UntagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourceAsync(UntagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourceAsync(UntagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRandomPassword asynchronously, invoking a callback when done
 -- @param GetRandomPasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRandomPasswordAsync(GetRandomPasswordRequest, cb)
 	assert(GetRandomPasswordRequest, "You must provide a GetRandomPasswordRequest")
 	local headers = {
@@ -2535,19 +2541,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRandomPasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRandomPasswordSync(GetRandomPasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRandomPasswordAsync(GetRandomPasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRandomPasswordAsync(GetRandomPasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutResourcePolicy asynchronously, invoking a callback when done
 -- @param PutResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutResourcePolicyAsync(PutResourcePolicyRequest, cb)
 	assert(PutResourcePolicyRequest, "You must provide a PutResourcePolicyRequest")
 	local headers = {
@@ -2570,19 +2577,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutResourcePolicySync(PutResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutResourcePolicyAsync(PutResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutResourcePolicyAsync(PutResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResourcePolicy asynchronously, invoking a callback when done
 -- @param DeleteResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, cb)
 	assert(DeleteResourcePolicyRequest, "You must provide a DeleteResourcePolicyRequest")
 	local headers = {
@@ -2605,19 +2613,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourcePolicySync(DeleteResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourcePolicyAsync(DeleteResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSecrets asynchronously, invoking a callback when done
 -- @param ListSecretsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSecretsAsync(ListSecretsRequest, cb)
 	assert(ListSecretsRequest, "You must provide a ListSecretsRequest")
 	local headers = {
@@ -2640,19 +2649,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSecretsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSecretsSync(ListSecretsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSecretsAsync(ListSecretsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSecretsAsync(ListSecretsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelRotateSecret asynchronously, invoking a callback when done
 -- @param CancelRotateSecretRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelRotateSecretAsync(CancelRotateSecretRequest, cb)
 	assert(CancelRotateSecretRequest, "You must provide a CancelRotateSecretRequest")
 	local headers = {
@@ -2675,19 +2685,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelRotateSecretRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelRotateSecretSync(CancelRotateSecretRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelRotateSecretAsync(CancelRotateSecretRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelRotateSecretAsync(CancelRotateSecretRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResourcePolicy asynchronously, invoking a callback when done
 -- @param GetResourcePolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourcePolicyAsync(GetResourcePolicyRequest, cb)
 	assert(GetResourcePolicyRequest, "You must provide a GetResourcePolicyRequest")
 	local headers = {
@@ -2710,19 +2721,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourcePolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourcePolicySync(GetResourcePolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourcePolicyAsync(GetResourcePolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourcePolicyAsync(GetResourcePolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSecret asynchronously, invoking a callback when done
 -- @param DescribeSecretRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSecretAsync(DescribeSecretRequest, cb)
 	assert(DescribeSecretRequest, "You must provide a DescribeSecretRequest")
 	local headers = {
@@ -2745,19 +2757,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSecretRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSecretSync(DescribeSecretRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSecretAsync(DescribeSecretRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSecretAsync(DescribeSecretRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSecret asynchronously, invoking a callback when done
 -- @param UpdateSecretRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSecretAsync(UpdateSecretRequest, cb)
 	assert(UpdateSecretRequest, "You must provide a UpdateSecretRequest")
 	local headers = {
@@ -2780,19 +2793,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSecretRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSecretSync(UpdateSecretRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSecretAsync(UpdateSecretRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSecretAsync(UpdateSecretRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResource asynchronously, invoking a callback when done
 -- @param TagResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourceAsync(TagResourceRequest, cb)
 	assert(TagResourceRequest, "You must provide a TagResourceRequest")
 	local headers = {
@@ -2815,19 +2829,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourceSync(TagResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourceAsync(TagResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourceAsync(TagResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSecretVersionStage asynchronously, invoking a callback when done
 -- @param UpdateSecretVersionStageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSecretVersionStageAsync(UpdateSecretVersionStageRequest, cb)
 	assert(UpdateSecretVersionStageRequest, "You must provide a UpdateSecretVersionStageRequest")
 	local headers = {
@@ -2850,19 +2865,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSecretVersionStageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSecretVersionStageSync(UpdateSecretVersionStageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSecretVersionStageAsync(UpdateSecretVersionStageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSecretVersionStageAsync(UpdateSecretVersionStageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RotateSecret asynchronously, invoking a callback when done
 -- @param RotateSecretRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RotateSecretAsync(RotateSecretRequest, cb)
 	assert(RotateSecretRequest, "You must provide a RotateSecretRequest")
 	local headers = {
@@ -2885,19 +2901,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RotateSecretRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RotateSecretSync(RotateSecretRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RotateSecretAsync(RotateSecretRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RotateSecretAsync(RotateSecretRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSecretValue asynchronously, invoking a callback when done
 -- @param GetSecretValueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSecretValueAsync(GetSecretValueRequest, cb)
 	assert(GetSecretValueRequest, "You must provide a GetSecretValueRequest")
 	local headers = {
@@ -2920,12 +2937,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSecretValueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSecretValueSync(GetSecretValueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSecretValueAsync(GetSecretValueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSecretValueAsync(GetSecretValueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/serverlessrepo.lua
+++ b/aws-sdk/serverlessrepo.lua
@@ -2242,7 +2242,7 @@ end
 --
 --- Call UpdateApplication asynchronously, invoking a callback when done
 -- @param UpdateApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateApplicationAsync(UpdateApplicationRequest, cb)
 	assert(UpdateApplicationRequest, "You must provide a UpdateApplicationRequest")
 	local headers = {
@@ -2265,19 +2265,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateApplicationSync(UpdateApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateApplicationAsync(UpdateApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateApplicationAsync(UpdateApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListApplications asynchronously, invoking a callback when done
 -- @param ListApplicationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListApplicationsAsync(ListApplicationsRequest, cb)
 	assert(ListApplicationsRequest, "You must provide a ListApplicationsRequest")
 	local headers = {
@@ -2300,19 +2301,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListApplicationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListApplicationsSync(ListApplicationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListApplicationsAsync(ListApplicationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListApplicationsAsync(ListApplicationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutApplicationPolicy asynchronously, invoking a callback when done
 -- @param PutApplicationPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutApplicationPolicyAsync(PutApplicationPolicyRequest, cb)
 	assert(PutApplicationPolicyRequest, "You must provide a PutApplicationPolicyRequest")
 	local headers = {
@@ -2335,19 +2337,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutApplicationPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutApplicationPolicySync(PutApplicationPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutApplicationPolicyAsync(PutApplicationPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutApplicationPolicyAsync(PutApplicationPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApplication asynchronously, invoking a callback when done
 -- @param GetApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApplicationAsync(GetApplicationRequest, cb)
 	assert(GetApplicationRequest, "You must provide a GetApplicationRequest")
 	local headers = {
@@ -2370,19 +2373,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApplicationSync(GetApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApplicationAsync(GetApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApplicationAsync(GetApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCloudFormationChangeSet asynchronously, invoking a callback when done
 -- @param CreateCloudFormationChangeSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCloudFormationChangeSetAsync(CreateCloudFormationChangeSetRequest, cb)
 	assert(CreateCloudFormationChangeSetRequest, "You must provide a CreateCloudFormationChangeSetRequest")
 	local headers = {
@@ -2405,19 +2409,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCloudFormationChangeSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCloudFormationChangeSetSync(CreateCloudFormationChangeSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCloudFormationChangeSetAsync(CreateCloudFormationChangeSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCloudFormationChangeSetAsync(CreateCloudFormationChangeSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetApplicationPolicy asynchronously, invoking a callback when done
 -- @param GetApplicationPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetApplicationPolicyAsync(GetApplicationPolicyRequest, cb)
 	assert(GetApplicationPolicyRequest, "You must provide a GetApplicationPolicyRequest")
 	local headers = {
@@ -2440,19 +2445,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetApplicationPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetApplicationPolicySync(GetApplicationPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetApplicationPolicyAsync(GetApplicationPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetApplicationPolicyAsync(GetApplicationPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteApplication asynchronously, invoking a callback when done
 -- @param DeleteApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteApplicationAsync(DeleteApplicationRequest, cb)
 	assert(DeleteApplicationRequest, "You must provide a DeleteApplicationRequest")
 	local headers = {
@@ -2475,19 +2481,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteApplicationSync(DeleteApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteApplicationAsync(DeleteApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteApplicationAsync(DeleteApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApplicationVersion asynchronously, invoking a callback when done
 -- @param CreateApplicationVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApplicationVersionAsync(CreateApplicationVersionRequest, cb)
 	assert(CreateApplicationVersionRequest, "You must provide a CreateApplicationVersionRequest")
 	local headers = {
@@ -2510,19 +2517,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApplicationVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApplicationVersionSync(CreateApplicationVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApplicationVersionAsync(CreateApplicationVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApplicationVersionAsync(CreateApplicationVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListApplicationVersions asynchronously, invoking a callback when done
 -- @param ListApplicationVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListApplicationVersionsAsync(ListApplicationVersionsRequest, cb)
 	assert(ListApplicationVersionsRequest, "You must provide a ListApplicationVersionsRequest")
 	local headers = {
@@ -2545,19 +2553,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListApplicationVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListApplicationVersionsSync(ListApplicationVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListApplicationVersionsAsync(ListApplicationVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListApplicationVersionsAsync(ListApplicationVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateApplication asynchronously, invoking a callback when done
 -- @param CreateApplicationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateApplicationAsync(CreateApplicationRequest, cb)
 	assert(CreateApplicationRequest, "You must provide a CreateApplicationRequest")
 	local headers = {
@@ -2580,12 +2589,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateApplicationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateApplicationSync(CreateApplicationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateApplicationAsync(CreateApplicationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateApplicationAsync(CreateApplicationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/servicecatalog.lua
+++ b/aws-sdk/servicecatalog.lua
@@ -11190,7 +11190,7 @@ end
 --
 --- Call ExecuteProvisionedProductPlan asynchronously, invoking a callback when done
 -- @param ExecuteProvisionedProductPlanInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExecuteProvisionedProductPlanAsync(ExecuteProvisionedProductPlanInput, cb)
 	assert(ExecuteProvisionedProductPlanInput, "You must provide a ExecuteProvisionedProductPlanInput")
 	local headers = {
@@ -11213,19 +11213,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExecuteProvisionedProductPlanInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExecuteProvisionedProductPlanSync(ExecuteProvisionedProductPlanInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExecuteProvisionedProductPlanAsync(ExecuteProvisionedProductPlanInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExecuteProvisionedProductPlanAsync(ExecuteProvisionedProductPlanInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateConstraint asynchronously, invoking a callback when done
 -- @param CreateConstraintInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateConstraintAsync(CreateConstraintInput, cb)
 	assert(CreateConstraintInput, "You must provide a CreateConstraintInput")
 	local headers = {
@@ -11248,19 +11249,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateConstraintInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateConstraintSync(CreateConstraintInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateConstraintAsync(CreateConstraintInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateConstraintAsync(CreateConstraintInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProductAsAdmin asynchronously, invoking a callback when done
 -- @param DescribeProductAsAdminInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProductAsAdminAsync(DescribeProductAsAdminInput, cb)
 	assert(DescribeProductAsAdminInput, "You must provide a DescribeProductAsAdminInput")
 	local headers = {
@@ -11283,19 +11285,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProductAsAdminInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProductAsAdminSync(DescribeProductAsAdminInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProductAsAdminAsync(DescribeProductAsAdminInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProductAsAdminAsync(DescribeProductAsAdminInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateProductWithPortfolio asynchronously, invoking a callback when done
 -- @param AssociateProductWithPortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateProductWithPortfolioAsync(AssociateProductWithPortfolioInput, cb)
 	assert(AssociateProductWithPortfolioInput, "You must provide a AssociateProductWithPortfolioInput")
 	local headers = {
@@ -11318,19 +11321,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateProductWithPortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateProductWithPortfolioSync(AssociateProductWithPortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateProductWithPortfolioAsync(AssociateProductWithPortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateProductWithPortfolioAsync(AssociateProductWithPortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPrincipalsForPortfolio asynchronously, invoking a callback when done
 -- @param ListPrincipalsForPortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPrincipalsForPortfolioAsync(ListPrincipalsForPortfolioInput, cb)
 	assert(ListPrincipalsForPortfolioInput, "You must provide a ListPrincipalsForPortfolioInput")
 	local headers = {
@@ -11353,19 +11357,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPrincipalsForPortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPrincipalsForPortfolioSync(ListPrincipalsForPortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPrincipalsForPortfolioAsync(ListPrincipalsForPortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPrincipalsForPortfolioAsync(ListPrincipalsForPortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateTagOption asynchronously, invoking a callback when done
 -- @param UpdateTagOptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateTagOptionAsync(UpdateTagOptionInput, cb)
 	assert(UpdateTagOptionInput, "You must provide a UpdateTagOptionInput")
 	local headers = {
@@ -11388,19 +11393,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateTagOptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateTagOptionSync(UpdateTagOptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateTagOptionAsync(UpdateTagOptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateTagOptionAsync(UpdateTagOptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTagOption asynchronously, invoking a callback when done
 -- @param DeleteTagOptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagOptionAsync(DeleteTagOptionInput, cb)
 	assert(DeleteTagOptionInput, "You must provide a DeleteTagOptionInput")
 	local headers = {
@@ -11423,19 +11429,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagOptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagOptionSync(DeleteTagOptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagOptionAsync(DeleteTagOptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagOptionAsync(DeleteTagOptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociatePrincipalWithPortfolio asynchronously, invoking a callback when done
 -- @param AssociatePrincipalWithPortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociatePrincipalWithPortfolioAsync(AssociatePrincipalWithPortfolioInput, cb)
 	assert(AssociatePrincipalWithPortfolioInput, "You must provide a AssociatePrincipalWithPortfolioInput")
 	local headers = {
@@ -11458,19 +11465,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociatePrincipalWithPortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociatePrincipalWithPortfolioSync(AssociatePrincipalWithPortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociatePrincipalWithPortfolioAsync(AssociatePrincipalWithPortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociatePrincipalWithPortfolioAsync(AssociatePrincipalWithPortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRecordHistory asynchronously, invoking a callback when done
 -- @param ListRecordHistoryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRecordHistoryAsync(ListRecordHistoryInput, cb)
 	assert(ListRecordHistoryInput, "You must provide a ListRecordHistoryInput")
 	local headers = {
@@ -11493,19 +11501,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRecordHistoryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRecordHistorySync(ListRecordHistoryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRecordHistoryAsync(ListRecordHistoryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRecordHistoryAsync(ListRecordHistoryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePortfolio asynchronously, invoking a callback when done
 -- @param UpdatePortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePortfolioAsync(UpdatePortfolioInput, cb)
 	assert(UpdatePortfolioInput, "You must provide a UpdatePortfolioInput")
 	local headers = {
@@ -11528,19 +11537,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePortfolioSync(UpdatePortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePortfolioAsync(UpdatePortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePortfolioAsync(UpdatePortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProduct asynchronously, invoking a callback when done
 -- @param UpdateProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProductAsync(UpdateProductInput, cb)
 	assert(UpdateProductInput, "You must provide a UpdateProductInput")
 	local headers = {
@@ -11563,19 +11573,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProductSync(UpdateProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProductAsync(UpdateProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProductAsync(UpdateProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchProductsAsAdmin asynchronously, invoking a callback when done
 -- @param SearchProductsAsAdminInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchProductsAsAdminAsync(SearchProductsAsAdminInput, cb)
 	assert(SearchProductsAsAdminInput, "You must provide a SearchProductsAsAdminInput")
 	local headers = {
@@ -11598,19 +11609,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchProductsAsAdminInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchProductsAsAdminSync(SearchProductsAsAdminInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchProductsAsAdminAsync(SearchProductsAsAdminInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchProductsAsAdminAsync(SearchProductsAsAdminInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProvisionedProductPlans asynchronously, invoking a callback when done
 -- @param ListProvisionedProductPlansInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProvisionedProductPlansAsync(ListProvisionedProductPlansInput, cb)
 	assert(ListProvisionedProductPlansInput, "You must provide a ListProvisionedProductPlansInput")
 	local headers = {
@@ -11633,19 +11645,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProvisionedProductPlansInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProvisionedProductPlansSync(ListProvisionedProductPlansInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProvisionedProductPlansAsync(ListProvisionedProductPlansInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProvisionedProductPlansAsync(ListProvisionedProductPlansInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProvisioningArtifact asynchronously, invoking a callback when done
 -- @param CreateProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProvisioningArtifactAsync(CreateProvisioningArtifactInput, cb)
 	assert(CreateProvisioningArtifactInput, "You must provide a CreateProvisioningArtifactInput")
 	local headers = {
@@ -11668,19 +11681,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProvisioningArtifactSync(CreateProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProvisioningArtifactAsync(CreateProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProvisioningArtifactAsync(CreateProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePortfolioShareStatus asynchronously, invoking a callback when done
 -- @param DescribePortfolioShareStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePortfolioShareStatusAsync(DescribePortfolioShareStatusInput, cb)
 	assert(DescribePortfolioShareStatusInput, "You must provide a DescribePortfolioShareStatusInput")
 	local headers = {
@@ -11703,19 +11717,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePortfolioShareStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePortfolioShareStatusSync(DescribePortfolioShareStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePortfolioShareStatusAsync(DescribePortfolioShareStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePortfolioShareStatusAsync(DescribePortfolioShareStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPortfolios asynchronously, invoking a callback when done
 -- @param ListPortfoliosInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPortfoliosAsync(ListPortfoliosInput, cb)
 	assert(ListPortfoliosInput, "You must provide a ListPortfoliosInput")
 	local headers = {
@@ -11738,19 +11753,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPortfoliosInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPortfoliosSync(ListPortfoliosInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPortfoliosAsync(ListPortfoliosInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPortfoliosAsync(ListPortfoliosInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchProvisionedProducts asynchronously, invoking a callback when done
 -- @param SearchProvisionedProductsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchProvisionedProductsAsync(SearchProvisionedProductsInput, cb)
 	assert(SearchProvisionedProductsInput, "You must provide a SearchProvisionedProductsInput")
 	local headers = {
@@ -11773,19 +11789,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchProvisionedProductsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchProvisionedProductsSync(SearchProvisionedProductsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchProvisionedProductsAsync(SearchProvisionedProductsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchProvisionedProductsAsync(SearchProvisionedProductsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProduct asynchronously, invoking a callback when done
 -- @param DescribeProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProductAsync(DescribeProductInput, cb)
 	assert(DescribeProductInput, "You must provide a DescribeProductInput")
 	local headers = {
@@ -11808,19 +11825,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProductSync(DescribeProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProductAsync(DescribeProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProductAsync(DescribeProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePortfolioShare asynchronously, invoking a callback when done
 -- @param CreatePortfolioShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePortfolioShareAsync(CreatePortfolioShareInput, cb)
 	assert(CreatePortfolioShareInput, "You must provide a CreatePortfolioShareInput")
 	local headers = {
@@ -11843,19 +11861,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePortfolioShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePortfolioShareSync(CreatePortfolioShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePortfolioShareAsync(CreatePortfolioShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePortfolioShareAsync(CreatePortfolioShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagOptions asynchronously, invoking a callback when done
 -- @param ListTagOptionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagOptionsAsync(ListTagOptionsInput, cb)
 	assert(ListTagOptionsInput, "You must provide a ListTagOptionsInput")
 	local headers = {
@@ -11878,19 +11897,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagOptionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagOptionsSync(ListTagOptionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagOptionsAsync(ListTagOptionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagOptionsAsync(ListTagOptionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateServiceActionFromProvisioningArtifact asynchronously, invoking a callback when done
 -- @param DisassociateServiceActionFromProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateServiceActionFromProvisioningArtifactAsync(DisassociateServiceActionFromProvisioningArtifactInput, cb)
 	assert(DisassociateServiceActionFromProvisioningArtifactInput, "You must provide a DisassociateServiceActionFromProvisioningArtifactInput")
 	local headers = {
@@ -11913,19 +11933,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateServiceActionFromProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateServiceActionFromProvisioningArtifactSync(DisassociateServiceActionFromProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateServiceActionFromProvisioningArtifactAsync(DisassociateServiceActionFromProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateServiceActionFromProvisioningArtifactAsync(DisassociateServiceActionFromProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchAssociateServiceActionWithProvisioningArtifact asynchronously, invoking a callback when done
 -- @param BatchAssociateServiceActionWithProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchAssociateServiceActionWithProvisioningArtifactAsync(BatchAssociateServiceActionWithProvisioningArtifactInput, cb)
 	assert(BatchAssociateServiceActionWithProvisioningArtifactInput, "You must provide a BatchAssociateServiceActionWithProvisioningArtifactInput")
 	local headers = {
@@ -11948,19 +11969,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchAssociateServiceActionWithProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchAssociateServiceActionWithProvisioningArtifactSync(BatchAssociateServiceActionWithProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchAssociateServiceActionWithProvisioningArtifactAsync(BatchAssociateServiceActionWithProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchAssociateServiceActionWithProvisioningArtifactAsync(BatchAssociateServiceActionWithProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLaunchPaths asynchronously, invoking a callback when done
 -- @param ListLaunchPathsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLaunchPathsAsync(ListLaunchPathsInput, cb)
 	assert(ListLaunchPathsInput, "You must provide a ListLaunchPathsInput")
 	local headers = {
@@ -11983,19 +12005,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLaunchPathsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLaunchPathsSync(ListLaunchPathsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLaunchPathsAsync(ListLaunchPathsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLaunchPathsAsync(ListLaunchPathsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociatePrincipalFromPortfolio asynchronously, invoking a callback when done
 -- @param DisassociatePrincipalFromPortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociatePrincipalFromPortfolioAsync(DisassociatePrincipalFromPortfolioInput, cb)
 	assert(DisassociatePrincipalFromPortfolioInput, "You must provide a DisassociatePrincipalFromPortfolioInput")
 	local headers = {
@@ -12018,19 +12041,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociatePrincipalFromPortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociatePrincipalFromPortfolioSync(DisassociatePrincipalFromPortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociatePrincipalFromPortfolioAsync(DisassociatePrincipalFromPortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociatePrincipalFromPortfolioAsync(DisassociatePrincipalFromPortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListServiceActionsForProvisioningArtifact asynchronously, invoking a callback when done
 -- @param ListServiceActionsForProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListServiceActionsForProvisioningArtifactAsync(ListServiceActionsForProvisioningArtifactInput, cb)
 	assert(ListServiceActionsForProvisioningArtifactInput, "You must provide a ListServiceActionsForProvisioningArtifactInput")
 	local headers = {
@@ -12053,19 +12077,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListServiceActionsForProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListServiceActionsForProvisioningArtifactSync(ListServiceActionsForProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListServiceActionsForProvisioningArtifactAsync(ListServiceActionsForProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListServiceActionsForProvisioningArtifactAsync(ListServiceActionsForProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProduct asynchronously, invoking a callback when done
 -- @param CreateProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProductAsync(CreateProductInput, cb)
 	assert(CreateProductInput, "You must provide a CreateProductInput")
 	local headers = {
@@ -12088,19 +12113,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProductSync(CreateProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProductAsync(CreateProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProductAsync(CreateProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAcceptedPortfolioShares asynchronously, invoking a callback when done
 -- @param ListAcceptedPortfolioSharesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAcceptedPortfolioSharesAsync(ListAcceptedPortfolioSharesInput, cb)
 	assert(ListAcceptedPortfolioSharesInput, "You must provide a ListAcceptedPortfolioSharesInput")
 	local headers = {
@@ -12123,19 +12149,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAcceptedPortfolioSharesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAcceptedPortfolioSharesSync(ListAcceptedPortfolioSharesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAcceptedPortfolioSharesAsync(ListAcceptedPortfolioSharesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAcceptedPortfolioSharesAsync(ListAcceptedPortfolioSharesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPortfoliosForProduct asynchronously, invoking a callback when done
 -- @param ListPortfoliosForProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPortfoliosForProductAsync(ListPortfoliosForProductInput, cb)
 	assert(ListPortfoliosForProductInput, "You must provide a ListPortfoliosForProductInput")
 	local headers = {
@@ -12158,19 +12185,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPortfoliosForProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPortfoliosForProductSync(ListPortfoliosForProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPortfoliosForProductAsync(ListPortfoliosForProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPortfoliosForProductAsync(ListPortfoliosForProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeServiceAction asynchronously, invoking a callback when done
 -- @param DescribeServiceActionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeServiceActionAsync(DescribeServiceActionInput, cb)
 	assert(DescribeServiceActionInput, "You must provide a DescribeServiceActionInput")
 	local headers = {
@@ -12193,19 +12221,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeServiceActionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeServiceActionSync(DescribeServiceActionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeServiceActionAsync(DescribeServiceActionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeServiceActionAsync(DescribeServiceActionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateConstraint asynchronously, invoking a callback when done
 -- @param UpdateConstraintInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateConstraintAsync(UpdateConstraintInput, cb)
 	assert(UpdateConstraintInput, "You must provide a UpdateConstraintInput")
 	local headers = {
@@ -12228,19 +12257,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateConstraintInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateConstraintSync(UpdateConstraintInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateConstraintAsync(UpdateConstraintInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateConstraintAsync(UpdateConstraintInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateServiceActionWithProvisioningArtifact asynchronously, invoking a callback when done
 -- @param AssociateServiceActionWithProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateServiceActionWithProvisioningArtifactAsync(AssociateServiceActionWithProvisioningArtifactInput, cb)
 	assert(AssociateServiceActionWithProvisioningArtifactInput, "You must provide a AssociateServiceActionWithProvisioningArtifactInput")
 	local headers = {
@@ -12263,19 +12293,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateServiceActionWithProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateServiceActionWithProvisioningArtifactSync(AssociateServiceActionWithProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateServiceActionWithProvisioningArtifactAsync(AssociateServiceActionWithProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateServiceActionWithProvisioningArtifactAsync(AssociateServiceActionWithProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProvisionedProductPlan asynchronously, invoking a callback when done
 -- @param DeleteProvisionedProductPlanInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProvisionedProductPlanAsync(DeleteProvisionedProductPlanInput, cb)
 	assert(DeleteProvisionedProductPlanInput, "You must provide a DeleteProvisionedProductPlanInput")
 	local headers = {
@@ -12298,19 +12329,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProvisionedProductPlanInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProvisionedProductPlanSync(DeleteProvisionedProductPlanInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProvisionedProductPlanAsync(DeleteProvisionedProductPlanInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProvisionedProductPlanAsync(DeleteProvisionedProductPlanInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateServiceAction asynchronously, invoking a callback when done
 -- @param CreateServiceActionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateServiceActionAsync(CreateServiceActionInput, cb)
 	assert(CreateServiceActionInput, "You must provide a CreateServiceActionInput")
 	local headers = {
@@ -12333,19 +12365,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateServiceActionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateServiceActionSync(CreateServiceActionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateServiceActionAsync(CreateServiceActionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateServiceActionAsync(CreateServiceActionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProvisioningArtifacts asynchronously, invoking a callback when done
 -- @param ListProvisioningArtifactsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProvisioningArtifactsAsync(ListProvisioningArtifactsInput, cb)
 	assert(ListProvisioningArtifactsInput, "You must provide a ListProvisioningArtifactsInput")
 	local headers = {
@@ -12368,19 +12401,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProvisioningArtifactsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProvisioningArtifactsSync(ListProvisioningArtifactsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProvisioningArtifactsAsync(ListProvisioningArtifactsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProvisioningArtifactsAsync(ListProvisioningArtifactsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProvisioningArtifactsForServiceAction asynchronously, invoking a callback when done
 -- @param ListProvisioningArtifactsForServiceActionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProvisioningArtifactsForServiceActionAsync(ListProvisioningArtifactsForServiceActionInput, cb)
 	assert(ListProvisioningArtifactsForServiceActionInput, "You must provide a ListProvisioningArtifactsForServiceActionInput")
 	local headers = {
@@ -12403,19 +12437,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProvisioningArtifactsForServiceActionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProvisioningArtifactsForServiceActionSync(ListProvisioningArtifactsForServiceActionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProvisioningArtifactsForServiceActionAsync(ListProvisioningArtifactsForServiceActionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProvisioningArtifactsForServiceActionAsync(ListProvisioningArtifactsForServiceActionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RejectPortfolioShare asynchronously, invoking a callback when done
 -- @param RejectPortfolioShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RejectPortfolioShareAsync(RejectPortfolioShareInput, cb)
 	assert(RejectPortfolioShareInput, "You must provide a RejectPortfolioShareInput")
 	local headers = {
@@ -12438,19 +12473,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RejectPortfolioShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RejectPortfolioShareSync(RejectPortfolioShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RejectPortfolioShareAsync(RejectPortfolioShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RejectPortfolioShareAsync(RejectPortfolioShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateProductFromPortfolio asynchronously, invoking a callback when done
 -- @param DisassociateProductFromPortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateProductFromPortfolioAsync(DisassociateProductFromPortfolioInput, cb)
 	assert(DisassociateProductFromPortfolioInput, "You must provide a DisassociateProductFromPortfolioInput")
 	local headers = {
@@ -12473,19 +12509,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateProductFromPortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateProductFromPortfolioSync(DisassociateProductFromPortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateProductFromPortfolioAsync(DisassociateProductFromPortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateProductFromPortfolioAsync(DisassociateProductFromPortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AcceptPortfolioShare asynchronously, invoking a callback when done
 -- @param AcceptPortfolioShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AcceptPortfolioShareAsync(AcceptPortfolioShareInput, cb)
 	assert(AcceptPortfolioShareInput, "You must provide a AcceptPortfolioShareInput")
 	local headers = {
@@ -12508,19 +12545,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AcceptPortfolioShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AcceptPortfolioShareSync(AcceptPortfolioShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AcceptPortfolioShareAsync(AcceptPortfolioShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AcceptPortfolioShareAsync(AcceptPortfolioShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProvisionedProduct asynchronously, invoking a callback when done
 -- @param DescribeProvisionedProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProvisionedProductAsync(DescribeProvisionedProductInput, cb)
 	assert(DescribeProvisionedProductInput, "You must provide a DescribeProvisionedProductInput")
 	local headers = {
@@ -12543,19 +12581,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProvisionedProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProvisionedProductSync(DescribeProvisionedProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProvisionedProductAsync(DescribeProvisionedProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProvisionedProductAsync(DescribeProvisionedProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListServiceActions asynchronously, invoking a callback when done
 -- @param ListServiceActionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListServiceActionsAsync(ListServiceActionsInput, cb)
 	assert(ListServiceActionsInput, "You must provide a ListServiceActionsInput")
 	local headers = {
@@ -12578,19 +12617,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListServiceActionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListServiceActionsSync(ListServiceActionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListServiceActionsAsync(ListServiceActionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListServiceActionsAsync(ListServiceActionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteServiceAction asynchronously, invoking a callback when done
 -- @param DeleteServiceActionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServiceActionAsync(DeleteServiceActionInput, cb)
 	assert(DeleteServiceActionInput, "You must provide a DeleteServiceActionInput")
 	local headers = {
@@ -12613,19 +12653,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServiceActionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServiceActionSync(DeleteServiceActionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServiceActionAsync(DeleteServiceActionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServiceActionAsync(DeleteServiceActionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableAWSOrganizationsAccess asynchronously, invoking a callback when done
 -- @param DisableAWSOrganizationsAccessInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableAWSOrganizationsAccessAsync(DisableAWSOrganizationsAccessInput, cb)
 	assert(DisableAWSOrganizationsAccessInput, "You must provide a DisableAWSOrganizationsAccessInput")
 	local headers = {
@@ -12648,19 +12689,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableAWSOrganizationsAccessInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableAWSOrganizationsAccessSync(DisableAWSOrganizationsAccessInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableAWSOrganizationsAccessAsync(DisableAWSOrganizationsAccessInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableAWSOrganizationsAccessAsync(DisableAWSOrganizationsAccessInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProvisioningArtifact asynchronously, invoking a callback when done
 -- @param DeleteProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProvisioningArtifactAsync(DeleteProvisioningArtifactInput, cb)
 	assert(DeleteProvisioningArtifactInput, "You must provide a DeleteProvisioningArtifactInput")
 	local headers = {
@@ -12683,19 +12725,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProvisioningArtifactSync(DeleteProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProvisioningArtifactAsync(DeleteProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProvisioningArtifactAsync(DeleteProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProvisioningArtifact asynchronously, invoking a callback when done
 -- @param UpdateProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProvisioningArtifactAsync(UpdateProvisioningArtifactInput, cb)
 	assert(UpdateProvisioningArtifactInput, "You must provide a UpdateProvisioningArtifactInput")
 	local headers = {
@@ -12718,19 +12761,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProvisioningArtifactSync(UpdateProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProvisioningArtifactAsync(UpdateProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProvisioningArtifactAsync(UpdateProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeConstraint asynchronously, invoking a callback when done
 -- @param DescribeConstraintInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeConstraintAsync(DescribeConstraintInput, cb)
 	assert(DescribeConstraintInput, "You must provide a DescribeConstraintInput")
 	local headers = {
@@ -12753,19 +12797,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeConstraintInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeConstraintSync(DescribeConstraintInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeConstraintAsync(DescribeConstraintInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeConstraintAsync(DescribeConstraintInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchDisassociateServiceActionFromProvisioningArtifact asynchronously, invoking a callback when done
 -- @param BatchDisassociateServiceActionFromProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchDisassociateServiceActionFromProvisioningArtifactAsync(BatchDisassociateServiceActionFromProvisioningArtifactInput, cb)
 	assert(BatchDisassociateServiceActionFromProvisioningArtifactInput, "You must provide a BatchDisassociateServiceActionFromProvisioningArtifactInput")
 	local headers = {
@@ -12788,19 +12833,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchDisassociateServiceActionFromProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchDisassociateServiceActionFromProvisioningArtifactSync(BatchDisassociateServiceActionFromProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchDisassociateServiceActionFromProvisioningArtifactAsync(BatchDisassociateServiceActionFromProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchDisassociateServiceActionFromProvisioningArtifactAsync(BatchDisassociateServiceActionFromProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProvisionedProductPlan asynchronously, invoking a callback when done
 -- @param DescribeProvisionedProductPlanInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProvisionedProductPlanAsync(DescribeProvisionedProductPlanInput, cb)
 	assert(DescribeProvisionedProductPlanInput, "You must provide a DescribeProvisionedProductPlanInput")
 	local headers = {
@@ -12823,19 +12869,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProvisionedProductPlanInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProvisionedProductPlanSync(DescribeProvisionedProductPlanInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProvisionedProductPlanAsync(DescribeProvisionedProductPlanInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProvisionedProductPlanAsync(DescribeProvisionedProductPlanInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePortfolio asynchronously, invoking a callback when done
 -- @param DeletePortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePortfolioAsync(DeletePortfolioInput, cb)
 	assert(DeletePortfolioInput, "You must provide a DeletePortfolioInput")
 	local headers = {
@@ -12858,19 +12905,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePortfolioSync(DeletePortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePortfolioAsync(DeletePortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePortfolioAsync(DeletePortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRecord asynchronously, invoking a callback when done
 -- @param DescribeRecordInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRecordAsync(DescribeRecordInput, cb)
 	assert(DescribeRecordInput, "You must provide a DescribeRecordInput")
 	local headers = {
@@ -12893,19 +12941,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRecordInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRecordSync(DescribeRecordInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRecordAsync(DescribeRecordInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRecordAsync(DescribeRecordInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateTagOptionWithResource asynchronously, invoking a callback when done
 -- @param AssociateTagOptionWithResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateTagOptionWithResourceAsync(AssociateTagOptionWithResourceInput, cb)
 	assert(AssociateTagOptionWithResourceInput, "You must provide a AssociateTagOptionWithResourceInput")
 	local headers = {
@@ -12928,19 +12977,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateTagOptionWithResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateTagOptionWithResourceSync(AssociateTagOptionWithResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateTagOptionWithResourceAsync(AssociateTagOptionWithResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateTagOptionWithResourceAsync(AssociateTagOptionWithResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCopyProductStatus asynchronously, invoking a callback when done
 -- @param DescribeCopyProductStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCopyProductStatusAsync(DescribeCopyProductStatusInput, cb)
 	assert(DescribeCopyProductStatusInput, "You must provide a DescribeCopyProductStatusInput")
 	local headers = {
@@ -12963,19 +13013,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCopyProductStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCopyProductStatusSync(DescribeCopyProductStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCopyProductStatusAsync(DescribeCopyProductStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCopyProductStatusAsync(DescribeCopyProductStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProduct asynchronously, invoking a callback when done
 -- @param DeleteProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProductAsync(DeleteProductInput, cb)
 	assert(DeleteProductInput, "You must provide a DeleteProductInput")
 	local headers = {
@@ -12998,19 +13049,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProductSync(DeleteProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProductAsync(DeleteProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProductAsync(DeleteProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call EnableAWSOrganizationsAccess asynchronously, invoking a callback when done
 -- @param EnableAWSOrganizationsAccessInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.EnableAWSOrganizationsAccessAsync(EnableAWSOrganizationsAccessInput, cb)
 	assert(EnableAWSOrganizationsAccessInput, "You must provide a EnableAWSOrganizationsAccessInput")
 	local headers = {
@@ -13033,19 +13085,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param EnableAWSOrganizationsAccessInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.EnableAWSOrganizationsAccessSync(EnableAWSOrganizationsAccessInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.EnableAWSOrganizationsAccessAsync(EnableAWSOrganizationsAccessInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.EnableAWSOrganizationsAccessAsync(EnableAWSOrganizationsAccessInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProductView asynchronously, invoking a callback when done
 -- @param DescribeProductViewInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProductViewAsync(DescribeProductViewInput, cb)
 	assert(DescribeProductViewInput, "You must provide a DescribeProductViewInput")
 	local headers = {
@@ -13068,19 +13121,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProductViewInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProductViewSync(DescribeProductViewInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProductViewAsync(DescribeProductViewInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProductViewAsync(DescribeProductViewInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateProvisionedProduct asynchronously, invoking a callback when done
 -- @param TerminateProvisionedProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateProvisionedProductAsync(TerminateProvisionedProductInput, cb)
 	assert(TerminateProvisionedProductInput, "You must provide a TerminateProvisionedProductInput")
 	local headers = {
@@ -13103,19 +13157,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateProvisionedProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateProvisionedProductSync(TerminateProvisionedProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateProvisionedProductAsync(TerminateProvisionedProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateProvisionedProductAsync(TerminateProvisionedProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePortfolio asynchronously, invoking a callback when done
 -- @param DescribePortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePortfolioAsync(DescribePortfolioInput, cb)
 	assert(DescribePortfolioInput, "You must provide a DescribePortfolioInput")
 	local headers = {
@@ -13138,19 +13193,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePortfolioSync(DescribePortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePortfolioAsync(DescribePortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePortfolioAsync(DescribePortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOrganizationPortfolioAccess asynchronously, invoking a callback when done
 -- @param ListOrganizationPortfolioAccessInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOrganizationPortfolioAccessAsync(ListOrganizationPortfolioAccessInput, cb)
 	assert(ListOrganizationPortfolioAccessInput, "You must provide a ListOrganizationPortfolioAccessInput")
 	local headers = {
@@ -13173,19 +13229,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOrganizationPortfolioAccessInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOrganizationPortfolioAccessSync(ListOrganizationPortfolioAccessInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOrganizationPortfolioAccessAsync(ListOrganizationPortfolioAccessInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOrganizationPortfolioAccessAsync(ListOrganizationPortfolioAccessInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePortfolioShare asynchronously, invoking a callback when done
 -- @param DeletePortfolioShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePortfolioShareAsync(DeletePortfolioShareInput, cb)
 	assert(DeletePortfolioShareInput, "You must provide a DeletePortfolioShareInput")
 	local headers = {
@@ -13208,19 +13265,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePortfolioShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePortfolioShareSync(DeletePortfolioShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePortfolioShareAsync(DeletePortfolioShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePortfolioShareAsync(DeletePortfolioShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAWSOrganizationsAccessStatus asynchronously, invoking a callback when done
 -- @param GetAWSOrganizationsAccessStatusInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAWSOrganizationsAccessStatusAsync(GetAWSOrganizationsAccessStatusInput, cb)
 	assert(GetAWSOrganizationsAccessStatusInput, "You must provide a GetAWSOrganizationsAccessStatusInput")
 	local headers = {
@@ -13243,19 +13301,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAWSOrganizationsAccessStatusInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAWSOrganizationsAccessStatusSync(GetAWSOrganizationsAccessStatusInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAWSOrganizationsAccessStatusAsync(GetAWSOrganizationsAccessStatusInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAWSOrganizationsAccessStatusAsync(GetAWSOrganizationsAccessStatusInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateServiceAction asynchronously, invoking a callback when done
 -- @param UpdateServiceActionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServiceActionAsync(UpdateServiceActionInput, cb)
 	assert(UpdateServiceActionInput, "You must provide a UpdateServiceActionInput")
 	local headers = {
@@ -13278,19 +13337,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServiceActionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServiceActionSync(UpdateServiceActionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServiceActionAsync(UpdateServiceActionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServiceActionAsync(UpdateServiceActionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProvisionedProductPlan asynchronously, invoking a callback when done
 -- @param CreateProvisionedProductPlanInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProvisionedProductPlanAsync(CreateProvisionedProductPlanInput, cb)
 	assert(CreateProvisionedProductPlanInput, "You must provide a CreateProvisionedProductPlanInput")
 	local headers = {
@@ -13313,19 +13373,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProvisionedProductPlanInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProvisionedProductPlanSync(CreateProvisionedProductPlanInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProvisionedProductPlanAsync(CreateProvisionedProductPlanInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProvisionedProductPlanAsync(CreateProvisionedProductPlanInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ScanProvisionedProducts asynchronously, invoking a callback when done
 -- @param ScanProvisionedProductsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ScanProvisionedProductsAsync(ScanProvisionedProductsInput, cb)
 	assert(ScanProvisionedProductsInput, "You must provide a ScanProvisionedProductsInput")
 	local headers = {
@@ -13348,19 +13409,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ScanProvisionedProductsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ScanProvisionedProductsSync(ScanProvisionedProductsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ScanProvisionedProductsAsync(ScanProvisionedProductsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ScanProvisionedProductsAsync(ScanProvisionedProductsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTagOption asynchronously, invoking a callback when done
 -- @param CreateTagOptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTagOptionAsync(CreateTagOptionInput, cb)
 	assert(CreateTagOptionInput, "You must provide a CreateTagOptionInput")
 	local headers = {
@@ -13383,19 +13445,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTagOptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTagOptionSync(CreateTagOptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTagOptionAsync(CreateTagOptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTagOptionAsync(CreateTagOptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateProvisionedProduct asynchronously, invoking a callback when done
 -- @param UpdateProvisionedProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateProvisionedProductAsync(UpdateProvisionedProductInput, cb)
 	assert(UpdateProvisionedProductInput, "You must provide a UpdateProvisionedProductInput")
 	local headers = {
@@ -13418,19 +13481,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateProvisionedProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateProvisionedProductSync(UpdateProvisionedProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateProvisionedProductAsync(UpdateProvisionedProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateProvisionedProductAsync(UpdateProvisionedProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourcesForTagOption asynchronously, invoking a callback when done
 -- @param ListResourcesForTagOptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourcesForTagOptionAsync(ListResourcesForTagOptionInput, cb)
 	assert(ListResourcesForTagOptionInput, "You must provide a ListResourcesForTagOptionInput")
 	local headers = {
@@ -13453,19 +13517,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourcesForTagOptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourcesForTagOptionSync(ListResourcesForTagOptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourcesForTagOptionAsync(ListResourcesForTagOptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourcesForTagOptionAsync(ListResourcesForTagOptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProvisioningArtifact asynchronously, invoking a callback when done
 -- @param DescribeProvisioningArtifactInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProvisioningArtifactAsync(DescribeProvisioningArtifactInput, cb)
 	assert(DescribeProvisioningArtifactInput, "You must provide a DescribeProvisioningArtifactInput")
 	local headers = {
@@ -13488,19 +13553,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProvisioningArtifactInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProvisioningArtifactSync(DescribeProvisioningArtifactInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProvisioningArtifactAsync(DescribeProvisioningArtifactInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProvisioningArtifactAsync(DescribeProvisioningArtifactInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPortfolioAccess asynchronously, invoking a callback when done
 -- @param ListPortfolioAccessInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPortfolioAccessAsync(ListPortfolioAccessInput, cb)
 	assert(ListPortfolioAccessInput, "You must provide a ListPortfolioAccessInput")
 	local headers = {
@@ -13523,19 +13589,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPortfolioAccessInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPortfolioAccessSync(ListPortfolioAccessInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPortfolioAccessAsync(ListPortfolioAccessInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPortfolioAccessAsync(ListPortfolioAccessInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListConstraintsForPortfolio asynchronously, invoking a callback when done
 -- @param ListConstraintsForPortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListConstraintsForPortfolioAsync(ListConstraintsForPortfolioInput, cb)
 	assert(ListConstraintsForPortfolioInput, "You must provide a ListConstraintsForPortfolioInput")
 	local headers = {
@@ -13558,19 +13625,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListConstraintsForPortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListConstraintsForPortfolioSync(ListConstraintsForPortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListConstraintsForPortfolioAsync(ListConstraintsForPortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListConstraintsForPortfolioAsync(ListConstraintsForPortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateTagOptionFromResource asynchronously, invoking a callback when done
 -- @param DisassociateTagOptionFromResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateTagOptionFromResourceAsync(DisassociateTagOptionFromResourceInput, cb)
 	assert(DisassociateTagOptionFromResourceInput, "You must provide a DisassociateTagOptionFromResourceInput")
 	local headers = {
@@ -13593,19 +13661,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateTagOptionFromResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateTagOptionFromResourceSync(DisassociateTagOptionFromResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateTagOptionFromResourceAsync(DisassociateTagOptionFromResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateTagOptionFromResourceAsync(DisassociateTagOptionFromResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ExecuteProvisionedProductServiceAction asynchronously, invoking a callback when done
 -- @param ExecuteProvisionedProductServiceActionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ExecuteProvisionedProductServiceActionAsync(ExecuteProvisionedProductServiceActionInput, cb)
 	assert(ExecuteProvisionedProductServiceActionInput, "You must provide a ExecuteProvisionedProductServiceActionInput")
 	local headers = {
@@ -13628,19 +13697,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ExecuteProvisionedProductServiceActionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ExecuteProvisionedProductServiceActionSync(ExecuteProvisionedProductServiceActionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ExecuteProvisionedProductServiceActionAsync(ExecuteProvisionedProductServiceActionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ExecuteProvisionedProductServiceActionAsync(ExecuteProvisionedProductServiceActionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SearchProducts asynchronously, invoking a callback when done
 -- @param SearchProductsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SearchProductsAsync(SearchProductsInput, cb)
 	assert(SearchProductsInput, "You must provide a SearchProductsInput")
 	local headers = {
@@ -13663,19 +13733,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SearchProductsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SearchProductsSync(SearchProductsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SearchProductsAsync(SearchProductsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SearchProductsAsync(SearchProductsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CopyProduct asynchronously, invoking a callback when done
 -- @param CopyProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CopyProductAsync(CopyProductInput, cb)
 	assert(CopyProductInput, "You must provide a CopyProductInput")
 	local headers = {
@@ -13698,19 +13769,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CopyProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CopyProductSync(CopyProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CopyProductAsync(CopyProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CopyProductAsync(CopyProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteConstraint asynchronously, invoking a callback when done
 -- @param DeleteConstraintInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteConstraintAsync(DeleteConstraintInput, cb)
 	assert(DeleteConstraintInput, "You must provide a DeleteConstraintInput")
 	local headers = {
@@ -13733,19 +13805,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteConstraintInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteConstraintSync(DeleteConstraintInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteConstraintAsync(DeleteConstraintInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteConstraintAsync(DeleteConstraintInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ProvisionProduct asynchronously, invoking a callback when done
 -- @param ProvisionProductInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ProvisionProductAsync(ProvisionProductInput, cb)
 	assert(ProvisionProductInput, "You must provide a ProvisionProductInput")
 	local headers = {
@@ -13768,19 +13841,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ProvisionProductInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ProvisionProductSync(ProvisionProductInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ProvisionProductAsync(ProvisionProductInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ProvisionProductAsync(ProvisionProductInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePortfolio asynchronously, invoking a callback when done
 -- @param CreatePortfolioInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePortfolioAsync(CreatePortfolioInput, cb)
 	assert(CreatePortfolioInput, "You must provide a CreatePortfolioInput")
 	local headers = {
@@ -13803,19 +13877,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePortfolioInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePortfolioSync(CreatePortfolioInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePortfolioAsync(CreatePortfolioInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePortfolioAsync(CreatePortfolioInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProvisioningParameters asynchronously, invoking a callback when done
 -- @param DescribeProvisioningParametersInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProvisioningParametersAsync(DescribeProvisioningParametersInput, cb)
 	assert(DescribeProvisioningParametersInput, "You must provide a DescribeProvisioningParametersInput")
 	local headers = {
@@ -13838,19 +13913,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProvisioningParametersInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProvisioningParametersSync(DescribeProvisioningParametersInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProvisioningParametersAsync(DescribeProvisioningParametersInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProvisioningParametersAsync(DescribeProvisioningParametersInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTagOption asynchronously, invoking a callback when done
 -- @param DescribeTagOptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagOptionAsync(DescribeTagOptionInput, cb)
 	assert(DescribeTagOptionInput, "You must provide a DescribeTagOptionInput")
 	local headers = {
@@ -13873,12 +13949,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagOptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagOptionSync(DescribeTagOptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagOptionAsync(DescribeTagOptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagOptionAsync(DescribeTagOptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/servicediscovery.lua
+++ b/aws-sdk/servicediscovery.lua
@@ -3359,7 +3359,7 @@ end
 --
 --- Call CreateService asynchronously, invoking a callback when done
 -- @param CreateServiceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateServiceAsync(CreateServiceRequest, cb)
 	assert(CreateServiceRequest, "You must provide a CreateServiceRequest")
 	local headers = {
@@ -3382,19 +3382,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateServiceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateServiceSync(CreateServiceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateServiceAsync(CreateServiceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateServiceAsync(CreateServiceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterInstance asynchronously, invoking a callback when done
 -- @param DeregisterInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterInstanceAsync(DeregisterInstanceRequest, cb)
 	assert(DeregisterInstanceRequest, "You must provide a DeregisterInstanceRequest")
 	local headers = {
@@ -3417,19 +3418,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterInstanceSync(DeregisterInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterInstanceAsync(DeregisterInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterInstanceAsync(DeregisterInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListServices asynchronously, invoking a callback when done
 -- @param ListServicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListServicesAsync(ListServicesRequest, cb)
 	assert(ListServicesRequest, "You must provide a ListServicesRequest")
 	local headers = {
@@ -3452,19 +3454,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListServicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListServicesSync(ListServicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListServicesAsync(ListServicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListServicesAsync(ListServicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstance asynchronously, invoking a callback when done
 -- @param GetInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstanceAsync(GetInstanceRequest, cb)
 	assert(GetInstanceRequest, "You must provide a GetInstanceRequest")
 	local headers = {
@@ -3487,19 +3490,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstanceSync(GetInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstanceAsync(GetInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstanceAsync(GetInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePublicDnsNamespace asynchronously, invoking a callback when done
 -- @param CreatePublicDnsNamespaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePublicDnsNamespaceAsync(CreatePublicDnsNamespaceRequest, cb)
 	assert(CreatePublicDnsNamespaceRequest, "You must provide a CreatePublicDnsNamespaceRequest")
 	local headers = {
@@ -3522,19 +3526,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePublicDnsNamespaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePublicDnsNamespaceSync(CreatePublicDnsNamespaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePublicDnsNamespaceAsync(CreatePublicDnsNamespaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePublicDnsNamespaceAsync(CreatePublicDnsNamespaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListNamespaces asynchronously, invoking a callback when done
 -- @param ListNamespacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListNamespacesAsync(ListNamespacesRequest, cb)
 	assert(ListNamespacesRequest, "You must provide a ListNamespacesRequest")
 	local headers = {
@@ -3557,19 +3562,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListNamespacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListNamespacesSync(ListNamespacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListNamespacesAsync(ListNamespacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListNamespacesAsync(ListNamespacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetOperation asynchronously, invoking a callback when done
 -- @param GetOperationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetOperationAsync(GetOperationRequest, cb)
 	assert(GetOperationRequest, "You must provide a GetOperationRequest")
 	local headers = {
@@ -3592,19 +3598,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetOperationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetOperationSync(GetOperationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetOperationAsync(GetOperationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetOperationAsync(GetOperationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetNamespace asynchronously, invoking a callback when done
 -- @param GetNamespaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetNamespaceAsync(GetNamespaceRequest, cb)
 	assert(GetNamespaceRequest, "You must provide a GetNamespaceRequest")
 	local headers = {
@@ -3627,19 +3634,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetNamespaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetNamespaceSync(GetNamespaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetNamespaceAsync(GetNamespaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetNamespaceAsync(GetNamespaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetService asynchronously, invoking a callback when done
 -- @param GetServiceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetServiceAsync(GetServiceRequest, cb)
 	assert(GetServiceRequest, "You must provide a GetServiceRequest")
 	local headers = {
@@ -3662,19 +3670,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetServiceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetServiceSync(GetServiceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetServiceAsync(GetServiceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetServiceAsync(GetServiceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePrivateDnsNamespace asynchronously, invoking a callback when done
 -- @param CreatePrivateDnsNamespaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePrivateDnsNamespaceAsync(CreatePrivateDnsNamespaceRequest, cb)
 	assert(CreatePrivateDnsNamespaceRequest, "You must provide a CreatePrivateDnsNamespaceRequest")
 	local headers = {
@@ -3697,19 +3706,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePrivateDnsNamespaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePrivateDnsNamespaceSync(CreatePrivateDnsNamespaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePrivateDnsNamespaceAsync(CreatePrivateDnsNamespaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePrivateDnsNamespaceAsync(CreatePrivateDnsNamespaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateInstanceCustomHealthStatus asynchronously, invoking a callback when done
 -- @param UpdateInstanceCustomHealthStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateInstanceCustomHealthStatusAsync(UpdateInstanceCustomHealthStatusRequest, cb)
 	assert(UpdateInstanceCustomHealthStatusRequest, "You must provide a UpdateInstanceCustomHealthStatusRequest")
 	local headers = {
@@ -3732,19 +3742,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateInstanceCustomHealthStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateInstanceCustomHealthStatusSync(UpdateInstanceCustomHealthStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateInstanceCustomHealthStatusAsync(UpdateInstanceCustomHealthStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateInstanceCustomHealthStatusAsync(UpdateInstanceCustomHealthStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInstancesHealthStatus asynchronously, invoking a callback when done
 -- @param GetInstancesHealthStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInstancesHealthStatusAsync(GetInstancesHealthStatusRequest, cb)
 	assert(GetInstancesHealthStatusRequest, "You must provide a GetInstancesHealthStatusRequest")
 	local headers = {
@@ -3767,19 +3778,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInstancesHealthStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInstancesHealthStatusSync(GetInstancesHealthStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInstancesHealthStatusAsync(GetInstancesHealthStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInstancesHealthStatusAsync(GetInstancesHealthStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInstances asynchronously, invoking a callback when done
 -- @param ListInstancesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInstancesAsync(ListInstancesRequest, cb)
 	assert(ListInstancesRequest, "You must provide a ListInstancesRequest")
 	local headers = {
@@ -3802,19 +3814,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInstancesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInstancesSync(ListInstancesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInstancesAsync(ListInstancesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInstancesAsync(ListInstancesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteService asynchronously, invoking a callback when done
 -- @param DeleteServiceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServiceAsync(DeleteServiceRequest, cb)
 	assert(DeleteServiceRequest, "You must provide a DeleteServiceRequest")
 	local headers = {
@@ -3837,19 +3850,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServiceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServiceSync(DeleteServiceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServiceAsync(DeleteServiceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServiceAsync(DeleteServiceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateService asynchronously, invoking a callback when done
 -- @param UpdateServiceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateServiceAsync(UpdateServiceRequest, cb)
 	assert(UpdateServiceRequest, "You must provide a UpdateServiceRequest")
 	local headers = {
@@ -3872,19 +3886,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateServiceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateServiceSync(UpdateServiceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateServiceAsync(UpdateServiceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateServiceAsync(UpdateServiceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterInstance asynchronously, invoking a callback when done
 -- @param RegisterInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterInstanceAsync(RegisterInstanceRequest, cb)
 	assert(RegisterInstanceRequest, "You must provide a RegisterInstanceRequest")
 	local headers = {
@@ -3907,19 +3922,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterInstanceSync(RegisterInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterInstanceAsync(RegisterInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterInstanceAsync(RegisterInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOperations asynchronously, invoking a callback when done
 -- @param ListOperationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOperationsAsync(ListOperationsRequest, cb)
 	assert(ListOperationsRequest, "You must provide a ListOperationsRequest")
 	local headers = {
@@ -3942,19 +3958,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOperationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOperationsSync(ListOperationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOperationsAsync(ListOperationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOperationsAsync(ListOperationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNamespace asynchronously, invoking a callback when done
 -- @param DeleteNamespaceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNamespaceAsync(DeleteNamespaceRequest, cb)
 	assert(DeleteNamespaceRequest, "You must provide a DeleteNamespaceRequest")
 	local headers = {
@@ -3977,12 +3994,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNamespaceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNamespaceSync(DeleteNamespaceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNamespaceAsync(DeleteNamespaceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNamespaceAsync(DeleteNamespaceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/shield.lua
+++ b/aws-sdk/shield.lua
@@ -2471,7 +2471,7 @@ end
 --
 --- Call DisassociateDRTRole asynchronously, invoking a callback when done
 -- @param DisassociateDRTRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateDRTRoleAsync(DisassociateDRTRoleRequest, cb)
 	assert(DisassociateDRTRoleRequest, "You must provide a DisassociateDRTRoleRequest")
 	local headers = {
@@ -2494,19 +2494,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateDRTRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateDRTRoleSync(DisassociateDRTRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateDRTRoleAsync(DisassociateDRTRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateDRTRoleAsync(DisassociateDRTRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteProtection asynchronously, invoking a callback when done
 -- @param DeleteProtectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteProtectionAsync(DeleteProtectionRequest, cb)
 	assert(DeleteProtectionRequest, "You must provide a DeleteProtectionRequest")
 	local headers = {
@@ -2529,19 +2530,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteProtectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteProtectionSync(DeleteProtectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteProtectionAsync(DeleteProtectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteProtectionAsync(DeleteProtectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateDRTLogBucket asynchronously, invoking a callback when done
 -- @param AssociateDRTLogBucketRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateDRTLogBucketAsync(AssociateDRTLogBucketRequest, cb)
 	assert(AssociateDRTLogBucketRequest, "You must provide a AssociateDRTLogBucketRequest")
 	local headers = {
@@ -2564,19 +2566,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateDRTLogBucketRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateDRTLogBucketSync(AssociateDRTLogBucketRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateDRTLogBucketAsync(AssociateDRTLogBucketRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateDRTLogBucketAsync(AssociateDRTLogBucketRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSubscriptionState asynchronously, invoking a callback when done
 -- @param GetSubscriptionStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSubscriptionStateAsync(GetSubscriptionStateRequest, cb)
 	assert(GetSubscriptionStateRequest, "You must provide a GetSubscriptionStateRequest")
 	local headers = {
@@ -2599,19 +2602,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSubscriptionStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSubscriptionStateSync(GetSubscriptionStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSubscriptionStateAsync(GetSubscriptionStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSubscriptionStateAsync(GetSubscriptionStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEmergencyContactSettings asynchronously, invoking a callback when done
 -- @param DescribeEmergencyContactSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEmergencyContactSettingsAsync(DescribeEmergencyContactSettingsRequest, cb)
 	assert(DescribeEmergencyContactSettingsRequest, "You must provide a DescribeEmergencyContactSettingsRequest")
 	local headers = {
@@ -2634,19 +2638,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEmergencyContactSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEmergencyContactSettingsSync(DescribeEmergencyContactSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEmergencyContactSettingsAsync(DescribeEmergencyContactSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEmergencyContactSettingsAsync(DescribeEmergencyContactSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateEmergencyContactSettings asynchronously, invoking a callback when done
 -- @param UpdateEmergencyContactSettingsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateEmergencyContactSettingsAsync(UpdateEmergencyContactSettingsRequest, cb)
 	assert(UpdateEmergencyContactSettingsRequest, "You must provide a UpdateEmergencyContactSettingsRequest")
 	local headers = {
@@ -2669,19 +2674,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateEmergencyContactSettingsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateEmergencyContactSettingsSync(UpdateEmergencyContactSettingsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateEmergencyContactSettingsAsync(UpdateEmergencyContactSettingsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateEmergencyContactSettingsAsync(UpdateEmergencyContactSettingsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSubscription asynchronously, invoking a callback when done
 -- @param DescribeSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSubscriptionAsync(DescribeSubscriptionRequest, cb)
 	assert(DescribeSubscriptionRequest, "You must provide a DescribeSubscriptionRequest")
 	local headers = {
@@ -2704,19 +2710,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSubscriptionSync(DescribeSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSubscriptionAsync(DescribeSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSubscriptionAsync(DescribeSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSubscription asynchronously, invoking a callback when done
 -- @param CreateSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSubscriptionAsync(CreateSubscriptionRequest, cb)
 	assert(CreateSubscriptionRequest, "You must provide a CreateSubscriptionRequest")
 	local headers = {
@@ -2739,19 +2746,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSubscriptionSync(CreateSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSubscriptionAsync(CreateSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSubscriptionAsync(CreateSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeProtection asynchronously, invoking a callback when done
 -- @param DescribeProtectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeProtectionAsync(DescribeProtectionRequest, cb)
 	assert(DescribeProtectionRequest, "You must provide a DescribeProtectionRequest")
 	local headers = {
@@ -2774,19 +2782,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeProtectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeProtectionSync(DescribeProtectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeProtectionAsync(DescribeProtectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeProtectionAsync(DescribeProtectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSubscription asynchronously, invoking a callback when done
 -- @param UpdateSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSubscriptionAsync(UpdateSubscriptionRequest, cb)
 	assert(UpdateSubscriptionRequest, "You must provide a UpdateSubscriptionRequest")
 	local headers = {
@@ -2809,19 +2818,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSubscriptionSync(UpdateSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSubscriptionAsync(UpdateSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSubscriptionAsync(UpdateSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDRTAccess asynchronously, invoking a callback when done
 -- @param DescribeDRTAccessRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDRTAccessAsync(DescribeDRTAccessRequest, cb)
 	assert(DescribeDRTAccessRequest, "You must provide a DescribeDRTAccessRequest")
 	local headers = {
@@ -2844,19 +2854,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDRTAccessRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDRTAccessSync(DescribeDRTAccessRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDRTAccessAsync(DescribeDRTAccessRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDRTAccessAsync(DescribeDRTAccessRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateDRTLogBucket asynchronously, invoking a callback when done
 -- @param DisassociateDRTLogBucketRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateDRTLogBucketAsync(DisassociateDRTLogBucketRequest, cb)
 	assert(DisassociateDRTLogBucketRequest, "You must provide a DisassociateDRTLogBucketRequest")
 	local headers = {
@@ -2879,19 +2890,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateDRTLogBucketRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateDRTLogBucketSync(DisassociateDRTLogBucketRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateDRTLogBucketAsync(DisassociateDRTLogBucketRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateDRTLogBucketAsync(DisassociateDRTLogBucketRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateProtection asynchronously, invoking a callback when done
 -- @param CreateProtectionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateProtectionAsync(CreateProtectionRequest, cb)
 	assert(CreateProtectionRequest, "You must provide a CreateProtectionRequest")
 	local headers = {
@@ -2914,19 +2926,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateProtectionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateProtectionSync(CreateProtectionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateProtectionAsync(CreateProtectionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateProtectionAsync(CreateProtectionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateDRTRole asynchronously, invoking a callback when done
 -- @param AssociateDRTRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateDRTRoleAsync(AssociateDRTRoleRequest, cb)
 	assert(AssociateDRTRoleRequest, "You must provide a AssociateDRTRoleRequest")
 	local headers = {
@@ -2949,19 +2962,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateDRTRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateDRTRoleSync(AssociateDRTRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateDRTRoleAsync(AssociateDRTRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateDRTRoleAsync(AssociateDRTRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListProtections asynchronously, invoking a callback when done
 -- @param ListProtectionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListProtectionsAsync(ListProtectionsRequest, cb)
 	assert(ListProtectionsRequest, "You must provide a ListProtectionsRequest")
 	local headers = {
@@ -2984,19 +2998,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListProtectionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListProtectionsSync(ListProtectionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListProtectionsAsync(ListProtectionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListProtectionsAsync(ListProtectionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAttacks asynchronously, invoking a callback when done
 -- @param ListAttacksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAttacksAsync(ListAttacksRequest, cb)
 	assert(ListAttacksRequest, "You must provide a ListAttacksRequest")
 	local headers = {
@@ -3019,19 +3034,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAttacksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAttacksSync(ListAttacksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAttacksAsync(ListAttacksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAttacksAsync(ListAttacksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAttack asynchronously, invoking a callback when done
 -- @param DescribeAttackRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAttackAsync(DescribeAttackRequest, cb)
 	assert(DescribeAttackRequest, "You must provide a DescribeAttackRequest")
 	local headers = {
@@ -3054,12 +3070,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAttackRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAttackSync(DescribeAttackRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAttackAsync(DescribeAttackRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAttackAsync(DescribeAttackRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/signer.lua
+++ b/aws-sdk/signer.lua
@@ -1980,7 +1980,7 @@ end
 --
 --- Call ListSigningJobs asynchronously, invoking a callback when done
 -- @param ListSigningJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSigningJobsAsync(ListSigningJobsRequest, cb)
 	assert(ListSigningJobsRequest, "You must provide a ListSigningJobsRequest")
 	local headers = {
@@ -2003,19 +2003,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSigningJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSigningJobsSync(ListSigningJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSigningJobsAsync(ListSigningJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSigningJobsAsync(ListSigningJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSigningJob asynchronously, invoking a callback when done
 -- @param DescribeSigningJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSigningJobAsync(DescribeSigningJobRequest, cb)
 	assert(DescribeSigningJobRequest, "You must provide a DescribeSigningJobRequest")
 	local headers = {
@@ -2038,19 +2039,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSigningJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSigningJobSync(DescribeSigningJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSigningJobAsync(DescribeSigningJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSigningJobAsync(DescribeSigningJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSigningProfile asynchronously, invoking a callback when done
 -- @param GetSigningProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSigningProfileAsync(GetSigningProfileRequest, cb)
 	assert(GetSigningProfileRequest, "You must provide a GetSigningProfileRequest")
 	local headers = {
@@ -2073,19 +2075,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSigningProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSigningProfileSync(GetSigningProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSigningProfileAsync(GetSigningProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSigningProfileAsync(GetSigningProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSigningProfiles asynchronously, invoking a callback when done
 -- @param ListSigningProfilesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSigningProfilesAsync(ListSigningProfilesRequest, cb)
 	assert(ListSigningProfilesRequest, "You must provide a ListSigningProfilesRequest")
 	local headers = {
@@ -2108,19 +2111,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSigningProfilesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSigningProfilesSync(ListSigningProfilesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSigningProfilesAsync(ListSigningProfilesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSigningProfilesAsync(ListSigningProfilesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelSigningProfile asynchronously, invoking a callback when done
 -- @param CancelSigningProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelSigningProfileAsync(CancelSigningProfileRequest, cb)
 	assert(CancelSigningProfileRequest, "You must provide a CancelSigningProfileRequest")
 	local headers = {
@@ -2143,19 +2147,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelSigningProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelSigningProfileSync(CancelSigningProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelSigningProfileAsync(CancelSigningProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelSigningProfileAsync(CancelSigningProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSigningPlatforms asynchronously, invoking a callback when done
 -- @param ListSigningPlatformsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSigningPlatformsAsync(ListSigningPlatformsRequest, cb)
 	assert(ListSigningPlatformsRequest, "You must provide a ListSigningPlatformsRequest")
 	local headers = {
@@ -2178,19 +2183,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSigningPlatformsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSigningPlatformsSync(ListSigningPlatformsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSigningPlatformsAsync(ListSigningPlatformsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSigningPlatformsAsync(ListSigningPlatformsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSigningJob asynchronously, invoking a callback when done
 -- @param StartSigningJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSigningJobAsync(StartSigningJobRequest, cb)
 	assert(StartSigningJobRequest, "You must provide a StartSigningJobRequest")
 	local headers = {
@@ -2213,19 +2219,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSigningJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSigningJobSync(StartSigningJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSigningJobAsync(StartSigningJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSigningJobAsync(StartSigningJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSigningPlatform asynchronously, invoking a callback when done
 -- @param GetSigningPlatformRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSigningPlatformAsync(GetSigningPlatformRequest, cb)
 	assert(GetSigningPlatformRequest, "You must provide a GetSigningPlatformRequest")
 	local headers = {
@@ -2248,19 +2255,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSigningPlatformRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSigningPlatformSync(GetSigningPlatformRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSigningPlatformAsync(GetSigningPlatformRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSigningPlatformAsync(GetSigningPlatformRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutSigningProfile asynchronously, invoking a callback when done
 -- @param PutSigningProfileRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutSigningProfileAsync(PutSigningProfileRequest, cb)
 	assert(PutSigningProfileRequest, "You must provide a PutSigningProfileRequest")
 	local headers = {
@@ -2283,12 +2291,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutSigningProfileRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutSigningProfileSync(PutSigningProfileRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutSigningProfileAsync(PutSigningProfileRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutSigningProfileAsync(PutSigningProfileRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/sms.lua
+++ b/aws-sdk/sms.lua
@@ -2078,7 +2078,7 @@ end
 --
 --- Call ImportServerCatalog asynchronously, invoking a callback when done
 -- @param ImportServerCatalogRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ImportServerCatalogAsync(ImportServerCatalogRequest, cb)
 	assert(ImportServerCatalogRequest, "You must provide a ImportServerCatalogRequest")
 	local headers = {
@@ -2101,19 +2101,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ImportServerCatalogRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ImportServerCatalogSync(ImportServerCatalogRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ImportServerCatalogAsync(ImportServerCatalogRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ImportServerCatalogAsync(ImportServerCatalogRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConnectors asynchronously, invoking a callback when done
 -- @param GetConnectorsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConnectorsAsync(GetConnectorsRequest, cb)
 	assert(GetConnectorsRequest, "You must provide a GetConnectorsRequest")
 	local headers = {
@@ -2136,19 +2137,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConnectorsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConnectorsSync(GetConnectorsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConnectorsAsync(GetConnectorsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConnectorsAsync(GetConnectorsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteReplicationJob asynchronously, invoking a callback when done
 -- @param DeleteReplicationJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteReplicationJobAsync(DeleteReplicationJobRequest, cb)
 	assert(DeleteReplicationJobRequest, "You must provide a DeleteReplicationJobRequest")
 	local headers = {
@@ -2171,19 +2173,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteReplicationJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteReplicationJobSync(DeleteReplicationJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteReplicationJobAsync(DeleteReplicationJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteReplicationJobAsync(DeleteReplicationJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartOnDemandReplicationRun asynchronously, invoking a callback when done
 -- @param StartOnDemandReplicationRunRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartOnDemandReplicationRunAsync(StartOnDemandReplicationRunRequest, cb)
 	assert(StartOnDemandReplicationRunRequest, "You must provide a StartOnDemandReplicationRunRequest")
 	local headers = {
@@ -2206,19 +2209,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartOnDemandReplicationRunRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartOnDemandReplicationRunSync(StartOnDemandReplicationRunRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartOnDemandReplicationRunAsync(StartOnDemandReplicationRunRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartOnDemandReplicationRunAsync(StartOnDemandReplicationRunRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetServers asynchronously, invoking a callback when done
 -- @param GetServersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetServersAsync(GetServersRequest, cb)
 	assert(GetServersRequest, "You must provide a GetServersRequest")
 	local headers = {
@@ -2241,19 +2245,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetServersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetServersSync(GetServersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetServersAsync(GetServersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetServersAsync(GetServersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReplicationRuns asynchronously, invoking a callback when done
 -- @param GetReplicationRunsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReplicationRunsAsync(GetReplicationRunsRequest, cb)
 	assert(GetReplicationRunsRequest, "You must provide a GetReplicationRunsRequest")
 	local headers = {
@@ -2276,19 +2281,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReplicationRunsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReplicationRunsSync(GetReplicationRunsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReplicationRunsAsync(GetReplicationRunsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReplicationRunsAsync(GetReplicationRunsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetReplicationJobs asynchronously, invoking a callback when done
 -- @param GetReplicationJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetReplicationJobsAsync(GetReplicationJobsRequest, cb)
 	assert(GetReplicationJobsRequest, "You must provide a GetReplicationJobsRequest")
 	local headers = {
@@ -2311,19 +2317,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetReplicationJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetReplicationJobsSync(GetReplicationJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetReplicationJobsAsync(GetReplicationJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetReplicationJobsAsync(GetReplicationJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateConnector asynchronously, invoking a callback when done
 -- @param DisassociateConnectorRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateConnectorAsync(DisassociateConnectorRequest, cb)
 	assert(DisassociateConnectorRequest, "You must provide a DisassociateConnectorRequest")
 	local headers = {
@@ -2346,19 +2353,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateConnectorRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateConnectorSync(DisassociateConnectorRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateConnectorAsync(DisassociateConnectorRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateConnectorAsync(DisassociateConnectorRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateReplicationJob asynchronously, invoking a callback when done
 -- @param CreateReplicationJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateReplicationJobAsync(CreateReplicationJobRequest, cb)
 	assert(CreateReplicationJobRequest, "You must provide a CreateReplicationJobRequest")
 	local headers = {
@@ -2381,19 +2389,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateReplicationJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateReplicationJobSync(CreateReplicationJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateReplicationJobAsync(CreateReplicationJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateReplicationJobAsync(CreateReplicationJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateReplicationJob asynchronously, invoking a callback when done
 -- @param UpdateReplicationJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateReplicationJobAsync(UpdateReplicationJobRequest, cb)
 	assert(UpdateReplicationJobRequest, "You must provide a UpdateReplicationJobRequest")
 	local headers = {
@@ -2416,19 +2425,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateReplicationJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateReplicationJobSync(UpdateReplicationJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateReplicationJobAsync(UpdateReplicationJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateReplicationJobAsync(UpdateReplicationJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteServerCatalog asynchronously, invoking a callback when done
 -- @param DeleteServerCatalogRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteServerCatalogAsync(DeleteServerCatalogRequest, cb)
 	assert(DeleteServerCatalogRequest, "You must provide a DeleteServerCatalogRequest")
 	local headers = {
@@ -2451,12 +2461,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteServerCatalogRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteServerCatalogSync(DeleteServerCatalogRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteServerCatalogAsync(DeleteServerCatalogRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteServerCatalogAsync(DeleteServerCatalogRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/snowball.lua
+++ b/aws-sdk/snowball.lua
@@ -2773,7 +2773,7 @@ end
 --
 --- Call ListJobs asynchronously, invoking a callback when done
 -- @param ListJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListJobsAsync(ListJobsRequest, cb)
 	assert(ListJobsRequest, "You must provide a ListJobsRequest")
 	local headers = {
@@ -2796,19 +2796,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListJobsSync(ListJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListJobsAsync(ListJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListJobsAsync(ListJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListClusterJobs asynchronously, invoking a callback when done
 -- @param ListClusterJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListClusterJobsAsync(ListClusterJobsRequest, cb)
 	assert(ListClusterJobsRequest, "You must provide a ListClusterJobsRequest")
 	local headers = {
@@ -2831,19 +2832,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListClusterJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListClusterJobsSync(ListClusterJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListClusterJobsAsync(ListClusterJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListClusterJobsAsync(ListClusterJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobUnlockCode asynchronously, invoking a callback when done
 -- @param GetJobUnlockCodeRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobUnlockCodeAsync(GetJobUnlockCodeRequest, cb)
 	assert(GetJobUnlockCodeRequest, "You must provide a GetJobUnlockCodeRequest")
 	local headers = {
@@ -2866,19 +2868,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobUnlockCodeRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobUnlockCodeSync(GetJobUnlockCodeRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobUnlockCodeAsync(GetJobUnlockCodeRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobUnlockCodeAsync(GetJobUnlockCodeRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateJob asynchronously, invoking a callback when done
 -- @param CreateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateJobAsync(CreateJobRequest, cb)
 	assert(CreateJobRequest, "You must provide a CreateJobRequest")
 	local headers = {
@@ -2901,19 +2904,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateJobSync(CreateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateJobAsync(CreateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateJobAsync(CreateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListClusters asynchronously, invoking a callback when done
 -- @param ListClustersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListClustersAsync(ListClustersRequest, cb)
 	assert(ListClustersRequest, "You must provide a ListClustersRequest")
 	local headers = {
@@ -2936,19 +2940,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListClustersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListClustersSync(ListClustersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListClustersAsync(ListClustersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListClustersAsync(ListClustersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCluster asynchronously, invoking a callback when done
 -- @param CreateClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateClusterAsync(CreateClusterRequest, cb)
 	assert(CreateClusterRequest, "You must provide a CreateClusterRequest")
 	local headers = {
@@ -2971,19 +2976,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateClusterSync(CreateClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateClusterAsync(CreateClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateClusterAsync(CreateClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateJob asynchronously, invoking a callback when done
 -- @param UpdateJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateJobAsync(UpdateJobRequest, cb)
 	assert(UpdateJobRequest, "You must provide a UpdateJobRequest")
 	local headers = {
@@ -3006,19 +3012,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateJobSync(UpdateJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateJobAsync(UpdateJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateJobAsync(UpdateJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCompatibleImages asynchronously, invoking a callback when done
 -- @param ListCompatibleImagesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCompatibleImagesAsync(ListCompatibleImagesRequest, cb)
 	assert(ListCompatibleImagesRequest, "You must provide a ListCompatibleImagesRequest")
 	local headers = {
@@ -3041,19 +3048,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCompatibleImagesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCompatibleImagesSync(ListCompatibleImagesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCompatibleImagesAsync(ListCompatibleImagesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCompatibleImagesAsync(ListCompatibleImagesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSnowballUsage asynchronously, invoking a callback when done
 -- @param GetSnowballUsageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSnowballUsageAsync(GetSnowballUsageRequest, cb)
 	assert(GetSnowballUsageRequest, "You must provide a GetSnowballUsageRequest")
 	local headers = {
@@ -3076,19 +3084,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSnowballUsageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSnowballUsageSync(GetSnowballUsageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSnowballUsageAsync(GetSnowballUsageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSnowballUsageAsync(GetSnowballUsageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetJobManifest asynchronously, invoking a callback when done
 -- @param GetJobManifestRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetJobManifestAsync(GetJobManifestRequest, cb)
 	assert(GetJobManifestRequest, "You must provide a GetJobManifestRequest")
 	local headers = {
@@ -3111,19 +3120,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetJobManifestRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetJobManifestSync(GetJobManifestRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetJobManifestAsync(GetJobManifestRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetJobManifestAsync(GetJobManifestRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAddress asynchronously, invoking a callback when done
 -- @param CreateAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAddressAsync(CreateAddressRequest, cb)
 	assert(CreateAddressRequest, "You must provide a CreateAddressRequest")
 	local headers = {
@@ -3146,19 +3156,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAddressSync(CreateAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAddressAsync(CreateAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAddressAsync(CreateAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAddress asynchronously, invoking a callback when done
 -- @param DescribeAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAddressAsync(DescribeAddressRequest, cb)
 	assert(DescribeAddressRequest, "You must provide a DescribeAddressRequest")
 	local headers = {
@@ -3181,19 +3192,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAddressSync(DescribeAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAddressAsync(DescribeAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAddressAsync(DescribeAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAddresses asynchronously, invoking a callback when done
 -- @param DescribeAddressesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAddressesAsync(DescribeAddressesRequest, cb)
 	assert(DescribeAddressesRequest, "You must provide a DescribeAddressesRequest")
 	local headers = {
@@ -3216,19 +3228,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAddressesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAddressesSync(DescribeAddressesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAddressesAsync(DescribeAddressesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAddressesAsync(DescribeAddressesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelJob asynchronously, invoking a callback when done
 -- @param CancelJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelJobAsync(CancelJobRequest, cb)
 	assert(CancelJobRequest, "You must provide a CancelJobRequest")
 	local headers = {
@@ -3251,19 +3264,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelJobSync(CancelJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelJobAsync(CancelJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelJobAsync(CancelJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelCluster asynchronously, invoking a callback when done
 -- @param CancelClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelClusterAsync(CancelClusterRequest, cb)
 	assert(CancelClusterRequest, "You must provide a CancelClusterRequest")
 	local headers = {
@@ -3286,19 +3300,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelClusterSync(CancelClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelClusterAsync(CancelClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelClusterAsync(CancelClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeJob asynchronously, invoking a callback when done
 -- @param DescribeJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeJobAsync(DescribeJobRequest, cb)
 	assert(DescribeJobRequest, "You must provide a DescribeJobRequest")
 	local headers = {
@@ -3321,19 +3336,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeJobSync(DescribeJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeJobAsync(DescribeJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeJobAsync(DescribeJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCluster asynchronously, invoking a callback when done
 -- @param DescribeClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeClusterAsync(DescribeClusterRequest, cb)
 	assert(DescribeClusterRequest, "You must provide a DescribeClusterRequest")
 	local headers = {
@@ -3356,19 +3372,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeClusterSync(DescribeClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeClusterAsync(DescribeClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeClusterAsync(DescribeClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateCluster asynchronously, invoking a callback when done
 -- @param UpdateClusterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateClusterAsync(UpdateClusterRequest, cb)
 	assert(UpdateClusterRequest, "You must provide a UpdateClusterRequest")
 	local headers = {
@@ -3391,12 +3408,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateClusterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateClusterSync(UpdateClusterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateClusterAsync(UpdateClusterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateClusterAsync(UpdateClusterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/sns.lua
+++ b/aws-sdk/sns.lua
@@ -3136,7 +3136,7 @@ end
 --
 --- Call ListPlatformApplications asynchronously, invoking a callback when done
 -- @param ListPlatformApplicationsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPlatformApplicationsAsync(ListPlatformApplicationsInput, cb)
 	assert(ListPlatformApplicationsInput, "You must provide a ListPlatformApplicationsInput")
 	local headers = {
@@ -3159,19 +3159,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPlatformApplicationsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPlatformApplicationsSync(ListPlatformApplicationsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPlatformApplicationsAsync(ListPlatformApplicationsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPlatformApplicationsAsync(ListPlatformApplicationsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetPlatformApplicationAttributes asynchronously, invoking a callback when done
 -- @param SetPlatformApplicationAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetPlatformApplicationAttributesAsync(SetPlatformApplicationAttributesInput, cb)
 	assert(SetPlatformApplicationAttributesInput, "You must provide a SetPlatformApplicationAttributesInput")
 	local headers = {
@@ -3194,19 +3195,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetPlatformApplicationAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetPlatformApplicationAttributesSync(SetPlatformApplicationAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetPlatformApplicationAttributesAsync(SetPlatformApplicationAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetPlatformApplicationAttributesAsync(SetPlatformApplicationAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSubscriptionsByTopic asynchronously, invoking a callback when done
 -- @param ListSubscriptionsByTopicInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSubscriptionsByTopicAsync(ListSubscriptionsByTopicInput, cb)
 	assert(ListSubscriptionsByTopicInput, "You must provide a ListSubscriptionsByTopicInput")
 	local headers = {
@@ -3229,19 +3231,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSubscriptionsByTopicInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSubscriptionsByTopicSync(ListSubscriptionsByTopicInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSubscriptionsByTopicAsync(ListSubscriptionsByTopicInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSubscriptionsByTopicAsync(ListSubscriptionsByTopicInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSubscriptions asynchronously, invoking a callback when done
 -- @param ListSubscriptionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSubscriptionsAsync(ListSubscriptionsInput, cb)
 	assert(ListSubscriptionsInput, "You must provide a ListSubscriptionsInput")
 	local headers = {
@@ -3264,19 +3267,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSubscriptionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSubscriptionsSync(ListSubscriptionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSubscriptionsAsync(ListSubscriptionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSubscriptionsAsync(ListSubscriptionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListPhoneNumbersOptedOut asynchronously, invoking a callback when done
 -- @param ListPhoneNumbersOptedOutInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListPhoneNumbersOptedOutAsync(ListPhoneNumbersOptedOutInput, cb)
 	assert(ListPhoneNumbersOptedOutInput, "You must provide a ListPhoneNumbersOptedOutInput")
 	local headers = {
@@ -3299,19 +3303,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListPhoneNumbersOptedOutInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListPhoneNumbersOptedOutSync(ListPhoneNumbersOptedOutInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListPhoneNumbersOptedOutAsync(ListPhoneNumbersOptedOutInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListPhoneNumbersOptedOutAsync(ListPhoneNumbersOptedOutInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ConfirmSubscription asynchronously, invoking a callback when done
 -- @param ConfirmSubscriptionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ConfirmSubscriptionAsync(ConfirmSubscriptionInput, cb)
 	assert(ConfirmSubscriptionInput, "You must provide a ConfirmSubscriptionInput")
 	local headers = {
@@ -3334,19 +3339,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ConfirmSubscriptionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ConfirmSubscriptionSync(ConfirmSubscriptionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ConfirmSubscriptionAsync(ConfirmSubscriptionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ConfirmSubscriptionAsync(ConfirmSubscriptionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetTopicAttributes asynchronously, invoking a callback when done
 -- @param SetTopicAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetTopicAttributesAsync(SetTopicAttributesInput, cb)
 	assert(SetTopicAttributesInput, "You must provide a SetTopicAttributesInput")
 	local headers = {
@@ -3369,19 +3375,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetTopicAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetTopicAttributesSync(SetTopicAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetTopicAttributesAsync(SetTopicAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetTopicAttributesAsync(SetTopicAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetEndpointAttributes asynchronously, invoking a callback when done
 -- @param SetEndpointAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetEndpointAttributesAsync(SetEndpointAttributesInput, cb)
 	assert(SetEndpointAttributesInput, "You must provide a SetEndpointAttributesInput")
 	local headers = {
@@ -3404,19 +3411,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetEndpointAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetEndpointAttributesSync(SetEndpointAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetEndpointAttributesAsync(SetEndpointAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetEndpointAttributesAsync(SetEndpointAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CheckIfPhoneNumberIsOptedOut asynchronously, invoking a callback when done
 -- @param CheckIfPhoneNumberIsOptedOutInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CheckIfPhoneNumberIsOptedOutAsync(CheckIfPhoneNumberIsOptedOutInput, cb)
 	assert(CheckIfPhoneNumberIsOptedOutInput, "You must provide a CheckIfPhoneNumberIsOptedOutInput")
 	local headers = {
@@ -3439,19 +3447,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CheckIfPhoneNumberIsOptedOutInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CheckIfPhoneNumberIsOptedOutSync(CheckIfPhoneNumberIsOptedOutInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CheckIfPhoneNumberIsOptedOutAsync(CheckIfPhoneNumberIsOptedOutInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CheckIfPhoneNumberIsOptedOutAsync(CheckIfPhoneNumberIsOptedOutInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddPermission asynchronously, invoking a callback when done
 -- @param AddPermissionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddPermissionAsync(AddPermissionInput, cb)
 	assert(AddPermissionInput, "You must provide a AddPermissionInput")
 	local headers = {
@@ -3474,19 +3483,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddPermissionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddPermissionSync(AddPermissionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddPermissionAsync(AddPermissionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddPermissionAsync(AddPermissionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Unsubscribe asynchronously, invoking a callback when done
 -- @param UnsubscribeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UnsubscribeAsync(UnsubscribeInput, cb)
 	assert(UnsubscribeInput, "You must provide a UnsubscribeInput")
 	local headers = {
@@ -3509,19 +3519,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UnsubscribeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UnsubscribeSync(UnsubscribeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UnsubscribeAsync(UnsubscribeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UnsubscribeAsync(UnsubscribeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSubscriptionAttributes asynchronously, invoking a callback when done
 -- @param GetSubscriptionAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSubscriptionAttributesAsync(GetSubscriptionAttributesInput, cb)
 	assert(GetSubscriptionAttributesInput, "You must provide a GetSubscriptionAttributesInput")
 	local headers = {
@@ -3544,19 +3555,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSubscriptionAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSubscriptionAttributesSync(GetSubscriptionAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSubscriptionAttributesAsync(GetSubscriptionAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSubscriptionAttributesAsync(GetSubscriptionAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePlatformEndpoint asynchronously, invoking a callback when done
 -- @param CreatePlatformEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePlatformEndpointAsync(CreatePlatformEndpointInput, cb)
 	assert(CreatePlatformEndpointInput, "You must provide a CreatePlatformEndpointInput")
 	local headers = {
@@ -3579,19 +3591,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePlatformEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePlatformEndpointSync(CreatePlatformEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePlatformEndpointAsync(CreatePlatformEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePlatformEndpointAsync(CreatePlatformEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemovePermission asynchronously, invoking a callback when done
 -- @param RemovePermissionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemovePermissionAsync(RemovePermissionInput, cb)
 	assert(RemovePermissionInput, "You must provide a RemovePermissionInput")
 	local headers = {
@@ -3614,19 +3627,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemovePermissionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemovePermissionSync(RemovePermissionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemovePermissionAsync(RemovePermissionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemovePermissionAsync(RemovePermissionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTopic asynchronously, invoking a callback when done
 -- @param CreateTopicInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTopicAsync(CreateTopicInput, cb)
 	assert(CreateTopicInput, "You must provide a CreateTopicInput")
 	local headers = {
@@ -3649,19 +3663,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTopicInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTopicSync(CreateTopicInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTopicAsync(CreateTopicInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTopicAsync(CreateTopicInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetSubscriptionAttributes asynchronously, invoking a callback when done
 -- @param SetSubscriptionAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetSubscriptionAttributesAsync(SetSubscriptionAttributesInput, cb)
 	assert(SetSubscriptionAttributesInput, "You must provide a SetSubscriptionAttributesInput")
 	local headers = {
@@ -3684,19 +3699,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetSubscriptionAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetSubscriptionAttributesSync(SetSubscriptionAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetSubscriptionAttributesAsync(SetSubscriptionAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetSubscriptionAttributesAsync(SetSubscriptionAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePlatformApplication asynchronously, invoking a callback when done
 -- @param CreatePlatformApplicationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePlatformApplicationAsync(CreatePlatformApplicationInput, cb)
 	assert(CreatePlatformApplicationInput, "You must provide a CreatePlatformApplicationInput")
 	local headers = {
@@ -3719,19 +3735,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePlatformApplicationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePlatformApplicationSync(CreatePlatformApplicationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePlatformApplicationAsync(CreatePlatformApplicationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePlatformApplicationAsync(CreatePlatformApplicationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPlatformApplicationAttributes asynchronously, invoking a callback when done
 -- @param GetPlatformApplicationAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPlatformApplicationAttributesAsync(GetPlatformApplicationAttributesInput, cb)
 	assert(GetPlatformApplicationAttributesInput, "You must provide a GetPlatformApplicationAttributesInput")
 	local headers = {
@@ -3754,19 +3771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPlatformApplicationAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPlatformApplicationAttributesSync(GetPlatformApplicationAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPlatformApplicationAttributesAsync(GetPlatformApplicationAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPlatformApplicationAttributesAsync(GetPlatformApplicationAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSMSAttributes asynchronously, invoking a callback when done
 -- @param GetSMSAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSMSAttributesAsync(GetSMSAttributesInput, cb)
 	assert(GetSMSAttributesInput, "You must provide a GetSMSAttributesInput")
 	local headers = {
@@ -3789,19 +3807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSMSAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSMSAttributesSync(GetSMSAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSMSAttributesAsync(GetSMSAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSMSAttributesAsync(GetSMSAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Publish asynchronously, invoking a callback when done
 -- @param PublishInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PublishAsync(PublishInput, cb)
 	assert(PublishInput, "You must provide a PublishInput")
 	local headers = {
@@ -3824,19 +3843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PublishInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PublishSync(PublishInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PublishAsync(PublishInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PublishAsync(PublishInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetSMSAttributes asynchronously, invoking a callback when done
 -- @param SetSMSAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetSMSAttributesAsync(SetSMSAttributesInput, cb)
 	assert(SetSMSAttributesInput, "You must provide a SetSMSAttributesInput")
 	local headers = {
@@ -3859,19 +3879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetSMSAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetSMSAttributesSync(SetSMSAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetSMSAttributesAsync(SetSMSAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetSMSAttributesAsync(SetSMSAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListEndpointsByPlatformApplication asynchronously, invoking a callback when done
 -- @param ListEndpointsByPlatformApplicationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListEndpointsByPlatformApplicationAsync(ListEndpointsByPlatformApplicationInput, cb)
 	assert(ListEndpointsByPlatformApplicationInput, "You must provide a ListEndpointsByPlatformApplicationInput")
 	local headers = {
@@ -3894,19 +3915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListEndpointsByPlatformApplicationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListEndpointsByPlatformApplicationSync(ListEndpointsByPlatformApplicationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListEndpointsByPlatformApplicationAsync(ListEndpointsByPlatformApplicationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListEndpointsByPlatformApplicationAsync(ListEndpointsByPlatformApplicationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEndpointAttributes asynchronously, invoking a callback when done
 -- @param GetEndpointAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEndpointAttributesAsync(GetEndpointAttributesInput, cb)
 	assert(GetEndpointAttributesInput, "You must provide a GetEndpointAttributesInput")
 	local headers = {
@@ -3929,19 +3951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEndpointAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEndpointAttributesSync(GetEndpointAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEndpointAttributesAsync(GetEndpointAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEndpointAttributesAsync(GetEndpointAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteEndpoint asynchronously, invoking a callback when done
 -- @param DeleteEndpointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteEndpointAsync(DeleteEndpointInput, cb)
 	assert(DeleteEndpointInput, "You must provide a DeleteEndpointInput")
 	local headers = {
@@ -3964,19 +3987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteEndpointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteEndpointSync(DeleteEndpointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteEndpointAsync(DeleteEndpointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteEndpointAsync(DeleteEndpointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePlatformApplication asynchronously, invoking a callback when done
 -- @param DeletePlatformApplicationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePlatformApplicationAsync(DeletePlatformApplicationInput, cb)
 	assert(DeletePlatformApplicationInput, "You must provide a DeletePlatformApplicationInput")
 	local headers = {
@@ -3999,19 +4023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePlatformApplicationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePlatformApplicationSync(DeletePlatformApplicationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePlatformApplicationAsync(DeletePlatformApplicationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePlatformApplicationAsync(DeletePlatformApplicationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTopicAttributes asynchronously, invoking a callback when done
 -- @param GetTopicAttributesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTopicAttributesAsync(GetTopicAttributesInput, cb)
 	assert(GetTopicAttributesInput, "You must provide a GetTopicAttributesInput")
 	local headers = {
@@ -4034,19 +4059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTopicAttributesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTopicAttributesSync(GetTopicAttributesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTopicAttributesAsync(GetTopicAttributesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTopicAttributesAsync(GetTopicAttributesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call Subscribe asynchronously, invoking a callback when done
 -- @param SubscribeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SubscribeAsync(SubscribeInput, cb)
 	assert(SubscribeInput, "You must provide a SubscribeInput")
 	local headers = {
@@ -4069,19 +4095,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SubscribeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SubscribeSync(SubscribeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SubscribeAsync(SubscribeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SubscribeAsync(SubscribeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTopic asynchronously, invoking a callback when done
 -- @param DeleteTopicInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTopicAsync(DeleteTopicInput, cb)
 	assert(DeleteTopicInput, "You must provide a DeleteTopicInput")
 	local headers = {
@@ -4104,19 +4131,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTopicInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTopicSync(DeleteTopicInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTopicAsync(DeleteTopicInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTopicAsync(DeleteTopicInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call OptInPhoneNumber asynchronously, invoking a callback when done
 -- @param OptInPhoneNumberInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.OptInPhoneNumberAsync(OptInPhoneNumberInput, cb)
 	assert(OptInPhoneNumberInput, "You must provide a OptInPhoneNumberInput")
 	local headers = {
@@ -4139,19 +4167,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param OptInPhoneNumberInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.OptInPhoneNumberSync(OptInPhoneNumberInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.OptInPhoneNumberAsync(OptInPhoneNumberInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.OptInPhoneNumberAsync(OptInPhoneNumberInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTopics asynchronously, invoking a callback when done
 -- @param ListTopicsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTopicsAsync(ListTopicsInput, cb)
 	assert(ListTopicsInput, "You must provide a ListTopicsInput")
 	local headers = {
@@ -4174,12 +4203,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTopicsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTopicsSync(ListTopicsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTopicsAsync(ListTopicsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTopicsAsync(ListTopicsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/sqs.lua
+++ b/aws-sdk/sqs.lua
@@ -2223,7 +2223,7 @@ end
 --
 --- Call CreateQueue asynchronously, invoking a callback when done
 -- @param CreateQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateQueueAsync(CreateQueueRequest, cb)
 	assert(CreateQueueRequest, "You must provide a CreateQueueRequest")
 	local headers = {
@@ -2246,19 +2246,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateQueueSync(CreateQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateQueueAsync(CreateQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateQueueAsync(CreateQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQueueAttributes asynchronously, invoking a callback when done
 -- @param GetQueueAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQueueAttributesAsync(GetQueueAttributesRequest, cb)
 	assert(GetQueueAttributesRequest, "You must provide a GetQueueAttributesRequest")
 	local headers = {
@@ -2281,19 +2282,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQueueAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQueueAttributesSync(GetQueueAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQueueAttributesAsync(GetQueueAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQueueAttributesAsync(GetQueueAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetQueueAttributes asynchronously, invoking a callback when done
 -- @param SetQueueAttributesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetQueueAttributesAsync(SetQueueAttributesRequest, cb)
 	assert(SetQueueAttributesRequest, "You must provide a SetQueueAttributesRequest")
 	local headers = {
@@ -2316,19 +2318,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetQueueAttributesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetQueueAttributesSync(SetQueueAttributesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetQueueAttributesAsync(SetQueueAttributesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetQueueAttributesAsync(SetQueueAttributesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetQueueUrl asynchronously, invoking a callback when done
 -- @param GetQueueUrlRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetQueueUrlAsync(GetQueueUrlRequest, cb)
 	assert(GetQueueUrlRequest, "You must provide a GetQueueUrlRequest")
 	local headers = {
@@ -2351,19 +2354,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetQueueUrlRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetQueueUrlSync(GetQueueUrlRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetQueueUrlAsync(GetQueueUrlRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetQueueUrlAsync(GetQueueUrlRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMessageBatch asynchronously, invoking a callback when done
 -- @param DeleteMessageBatchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMessageBatchAsync(DeleteMessageBatchRequest, cb)
 	assert(DeleteMessageBatchRequest, "You must provide a DeleteMessageBatchRequest")
 	local headers = {
@@ -2386,19 +2390,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMessageBatchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMessageBatchSync(DeleteMessageBatchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMessageBatchAsync(DeleteMessageBatchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMessageBatchAsync(DeleteMessageBatchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendMessageBatch asynchronously, invoking a callback when done
 -- @param SendMessageBatchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendMessageBatchAsync(SendMessageBatchRequest, cb)
 	assert(SendMessageBatchRequest, "You must provide a SendMessageBatchRequest")
 	local headers = {
@@ -2421,19 +2426,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendMessageBatchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendMessageBatchSync(SendMessageBatchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendMessageBatchAsync(SendMessageBatchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendMessageBatchAsync(SendMessageBatchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagQueue asynchronously, invoking a callback when done
 -- @param UntagQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagQueueAsync(UntagQueueRequest, cb)
 	assert(UntagQueueRequest, "You must provide a UntagQueueRequest")
 	local headers = {
@@ -2456,19 +2462,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagQueueSync(UntagQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagQueueAsync(UntagQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagQueueAsync(UntagQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDeadLetterSourceQueues asynchronously, invoking a callback when done
 -- @param ListDeadLetterSourceQueuesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDeadLetterSourceQueuesAsync(ListDeadLetterSourceQueuesRequest, cb)
 	assert(ListDeadLetterSourceQueuesRequest, "You must provide a ListDeadLetterSourceQueuesRequest")
 	local headers = {
@@ -2491,19 +2498,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDeadLetterSourceQueuesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDeadLetterSourceQueuesSync(ListDeadLetterSourceQueuesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDeadLetterSourceQueuesAsync(ListDeadLetterSourceQueuesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDeadLetterSourceQueuesAsync(ListDeadLetterSourceQueuesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagQueue asynchronously, invoking a callback when done
 -- @param TagQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagQueueAsync(TagQueueRequest, cb)
 	assert(TagQueueRequest, "You must provide a TagQueueRequest")
 	local headers = {
@@ -2526,19 +2534,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagQueueSync(TagQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagQueueAsync(TagQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagQueueAsync(TagQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ChangeMessageVisibility asynchronously, invoking a callback when done
 -- @param ChangeMessageVisibilityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ChangeMessageVisibilityAsync(ChangeMessageVisibilityRequest, cb)
 	assert(ChangeMessageVisibilityRequest, "You must provide a ChangeMessageVisibilityRequest")
 	local headers = {
@@ -2561,19 +2570,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ChangeMessageVisibilityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ChangeMessageVisibilitySync(ChangeMessageVisibilityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ChangeMessageVisibilityAsync(ChangeMessageVisibilityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ChangeMessageVisibilityAsync(ChangeMessageVisibilityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddPermission asynchronously, invoking a callback when done
 -- @param AddPermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddPermissionAsync(AddPermissionRequest, cb)
 	assert(AddPermissionRequest, "You must provide a AddPermissionRequest")
 	local headers = {
@@ -2596,19 +2606,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddPermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddPermissionSync(AddPermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddPermissionAsync(AddPermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddPermissionAsync(AddPermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ChangeMessageVisibilityBatch asynchronously, invoking a callback when done
 -- @param ChangeMessageVisibilityBatchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ChangeMessageVisibilityBatchAsync(ChangeMessageVisibilityBatchRequest, cb)
 	assert(ChangeMessageVisibilityBatchRequest, "You must provide a ChangeMessageVisibilityBatchRequest")
 	local headers = {
@@ -2631,19 +2642,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ChangeMessageVisibilityBatchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ChangeMessageVisibilityBatchSync(ChangeMessageVisibilityBatchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ChangeMessageVisibilityBatchAsync(ChangeMessageVisibilityBatchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ChangeMessageVisibilityBatchAsync(ChangeMessageVisibilityBatchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendMessage asynchronously, invoking a callback when done
 -- @param SendMessageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendMessageAsync(SendMessageRequest, cb)
 	assert(SendMessageRequest, "You must provide a SendMessageRequest")
 	local headers = {
@@ -2666,19 +2678,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendMessageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendMessageSync(SendMessageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendMessageAsync(SendMessageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendMessageAsync(SendMessageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteQueue asynchronously, invoking a callback when done
 -- @param DeleteQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteQueueAsync(DeleteQueueRequest, cb)
 	assert(DeleteQueueRequest, "You must provide a DeleteQueueRequest")
 	local headers = {
@@ -2701,19 +2714,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteQueueSync(DeleteQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteQueueAsync(DeleteQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteQueueAsync(DeleteQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PurgeQueue asynchronously, invoking a callback when done
 -- @param PurgeQueueRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PurgeQueueAsync(PurgeQueueRequest, cb)
 	assert(PurgeQueueRequest, "You must provide a PurgeQueueRequest")
 	local headers = {
@@ -2736,19 +2750,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PurgeQueueRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PurgeQueueSync(PurgeQueueRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PurgeQueueAsync(PurgeQueueRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PurgeQueueAsync(PurgeQueueRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListQueueTags asynchronously, invoking a callback when done
 -- @param ListQueueTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListQueueTagsAsync(ListQueueTagsRequest, cb)
 	assert(ListQueueTagsRequest, "You must provide a ListQueueTagsRequest")
 	local headers = {
@@ -2771,19 +2786,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListQueueTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListQueueTagsSync(ListQueueTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListQueueTagsAsync(ListQueueTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListQueueTagsAsync(ListQueueTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMessage asynchronously, invoking a callback when done
 -- @param DeleteMessageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMessageAsync(DeleteMessageRequest, cb)
 	assert(DeleteMessageRequest, "You must provide a DeleteMessageRequest")
 	local headers = {
@@ -2806,19 +2822,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMessageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMessageSync(DeleteMessageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMessageAsync(DeleteMessageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMessageAsync(DeleteMessageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ReceiveMessage asynchronously, invoking a callback when done
 -- @param ReceiveMessageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ReceiveMessageAsync(ReceiveMessageRequest, cb)
 	assert(ReceiveMessageRequest, "You must provide a ReceiveMessageRequest")
 	local headers = {
@@ -2841,19 +2858,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ReceiveMessageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ReceiveMessageSync(ReceiveMessageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ReceiveMessageAsync(ReceiveMessageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ReceiveMessageAsync(ReceiveMessageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListQueues asynchronously, invoking a callback when done
 -- @param ListQueuesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListQueuesAsync(ListQueuesRequest, cb)
 	assert(ListQueuesRequest, "You must provide a ListQueuesRequest")
 	local headers = {
@@ -2876,19 +2894,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListQueuesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListQueuesSync(ListQueuesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListQueuesAsync(ListQueuesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListQueuesAsync(ListQueuesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemovePermission asynchronously, invoking a callback when done
 -- @param RemovePermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemovePermissionAsync(RemovePermissionRequest, cb)
 	assert(RemovePermissionRequest, "You must provide a RemovePermissionRequest")
 	local headers = {
@@ -2911,12 +2930,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemovePermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemovePermissionSync(RemovePermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemovePermissionAsync(RemovePermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemovePermissionAsync(RemovePermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/ssm.lua
+++ b/aws-sdk/ssm.lua
@@ -21345,7 +21345,7 @@ end
 --
 --- Call DescribeInventoryDeletions asynchronously, invoking a callback when done
 -- @param DescribeInventoryDeletionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInventoryDeletionsAsync(DescribeInventoryDeletionsRequest, cb)
 	assert(DescribeInventoryDeletionsRequest, "You must provide a DescribeInventoryDeletionsRequest")
 	local headers = {
@@ -21368,19 +21368,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInventoryDeletionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInventoryDeletionsSync(DescribeInventoryDeletionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInventoryDeletionsAsync(DescribeInventoryDeletionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInventoryDeletionsAsync(DescribeInventoryDeletionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPatchBaselineForPatchGroup asynchronously, invoking a callback when done
 -- @param GetPatchBaselineForPatchGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPatchBaselineForPatchGroupAsync(GetPatchBaselineForPatchGroupRequest, cb)
 	assert(GetPatchBaselineForPatchGroupRequest, "You must provide a GetPatchBaselineForPatchGroupRequest")
 	local headers = {
@@ -21403,19 +21404,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPatchBaselineForPatchGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPatchBaselineForPatchGroupSync(GetPatchBaselineForPatchGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPatchBaselineForPatchGroupAsync(GetPatchBaselineForPatchGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPatchBaselineForPatchGroupAsync(GetPatchBaselineForPatchGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAssociation asynchronously, invoking a callback when done
 -- @param DescribeAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAssociationAsync(DescribeAssociationRequest, cb)
 	assert(DescribeAssociationRequest, "You must provide a DescribeAssociationRequest")
 	local headers = {
@@ -21438,19 +21440,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAssociationSync(DescribeAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAssociationAsync(DescribeAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAssociationAsync(DescribeAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAssociationExecutionTargets asynchronously, invoking a callback when done
 -- @param DescribeAssociationExecutionTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAssociationExecutionTargetsAsync(DescribeAssociationExecutionTargetsRequest, cb)
 	assert(DescribeAssociationExecutionTargetsRequest, "You must provide a DescribeAssociationExecutionTargetsRequest")
 	local headers = {
@@ -21473,19 +21476,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAssociationExecutionTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAssociationExecutionTargetsSync(DescribeAssociationExecutionTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAssociationExecutionTargetsAsync(DescribeAssociationExecutionTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAssociationExecutionTargetsAsync(DescribeAssociationExecutionTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstancePatchStatesForPatchGroup asynchronously, invoking a callback when done
 -- @param DescribeInstancePatchStatesForPatchGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstancePatchStatesForPatchGroupAsync(DescribeInstancePatchStatesForPatchGroupRequest, cb)
 	assert(DescribeInstancePatchStatesForPatchGroupRequest, "You must provide a DescribeInstancePatchStatesForPatchGroupRequest")
 	local headers = {
@@ -21508,19 +21512,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstancePatchStatesForPatchGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstancePatchStatesForPatchGroupSync(DescribeInstancePatchStatesForPatchGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstancePatchStatesForPatchGroupAsync(DescribeInstancePatchStatesForPatchGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstancePatchStatesForPatchGroupAsync(DescribeInstancePatchStatesForPatchGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDefaultPatchBaseline asynchronously, invoking a callback when done
 -- @param GetDefaultPatchBaselineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDefaultPatchBaselineAsync(GetDefaultPatchBaselineRequest, cb)
 	assert(GetDefaultPatchBaselineRequest, "You must provide a GetDefaultPatchBaselineRequest")
 	local headers = {
@@ -21543,19 +21548,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDefaultPatchBaselineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDefaultPatchBaselineSync(GetDefaultPatchBaselineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDefaultPatchBaselineAsync(GetDefaultPatchBaselineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDefaultPatchBaselineAsync(GetDefaultPatchBaselineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocument asynchronously, invoking a callback when done
 -- @param GetDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentAsync(GetDocumentRequest, cb)
 	assert(GetDocumentRequest, "You must provide a GetDocumentRequest")
 	local headers = {
@@ -21578,19 +21584,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentSync(GetDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentAsync(GetDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentAsync(GetDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateDocument asynchronously, invoking a callback when done
 -- @param CreateDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateDocumentAsync(CreateDocumentRequest, cb)
 	assert(CreateDocumentRequest, "You must provide a CreateDocumentRequest")
 	local headers = {
@@ -21613,19 +21620,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateDocumentSync(CreateDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateDocumentAsync(CreateDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateDocumentAsync(CreateDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAssociation asynchronously, invoking a callback when done
 -- @param DeleteAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAssociationAsync(DeleteAssociationRequest, cb)
 	assert(DeleteAssociationRequest, "You must provide a DeleteAssociationRequest")
 	local headers = {
@@ -21648,19 +21656,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAssociationSync(DeleteAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAssociationAsync(DeleteAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAssociationAsync(DeleteAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreatePatchBaseline asynchronously, invoking a callback when done
 -- @param CreatePatchBaselineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreatePatchBaselineAsync(CreatePatchBaselineRequest, cb)
 	assert(CreatePatchBaselineRequest, "You must provide a CreatePatchBaselineRequest")
 	local headers = {
@@ -21683,19 +21692,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreatePatchBaselineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreatePatchBaselineSync(CreatePatchBaselineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreatePatchBaselineAsync(CreatePatchBaselineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreatePatchBaselineAsync(CreatePatchBaselineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceComplianceSummaries asynchronously, invoking a callback when done
 -- @param ListResourceComplianceSummariesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceComplianceSummariesAsync(ListResourceComplianceSummariesRequest, cb)
 	assert(ListResourceComplianceSummariesRequest, "You must provide a ListResourceComplianceSummariesRequest")
 	local headers = {
@@ -21718,19 +21728,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceComplianceSummariesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceComplianceSummariesSync(ListResourceComplianceSummariesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceComplianceSummariesAsync(ListResourceComplianceSummariesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceComplianceSummariesAsync(ListResourceComplianceSummariesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterTargetFromMaintenanceWindow asynchronously, invoking a callback when done
 -- @param DeregisterTargetFromMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterTargetFromMaintenanceWindowAsync(DeregisterTargetFromMaintenanceWindowRequest, cb)
 	assert(DeregisterTargetFromMaintenanceWindowRequest, "You must provide a DeregisterTargetFromMaintenanceWindowRequest")
 	local headers = {
@@ -21753,19 +21764,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterTargetFromMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterTargetFromMaintenanceWindowSync(DeregisterTargetFromMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterTargetFromMaintenanceWindowAsync(DeregisterTargetFromMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterTargetFromMaintenanceWindowAsync(DeregisterTargetFromMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateSession asynchronously, invoking a callback when done
 -- @param TerminateSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateSessionAsync(TerminateSessionRequest, cb)
 	assert(TerminateSessionRequest, "You must provide a TerminateSessionRequest")
 	local headers = {
@@ -21788,19 +21800,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateSessionSync(TerminateSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateSessionAsync(TerminateSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateSessionAsync(TerminateSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListComplianceSummaries asynchronously, invoking a callback when done
 -- @param ListComplianceSummariesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListComplianceSummariesAsync(ListComplianceSummariesRequest, cb)
 	assert(ListComplianceSummariesRequest, "You must provide a ListComplianceSummariesRequest")
 	local headers = {
@@ -21823,19 +21836,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListComplianceSummariesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListComplianceSummariesSync(ListComplianceSummariesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListComplianceSummariesAsync(ListComplianceSummariesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListComplianceSummariesAsync(ListComplianceSummariesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetParameter asynchronously, invoking a callback when done
 -- @param GetParameterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetParameterAsync(GetParameterRequest, cb)
 	assert(GetParameterRequest, "You must provide a GetParameterRequest")
 	local headers = {
@@ -21858,19 +21872,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetParameterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetParameterSync(GetParameterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetParameterAsync(GetParameterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetParameterAsync(GetParameterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartAssociationsOnce asynchronously, invoking a callback when done
 -- @param StartAssociationsOnceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartAssociationsOnceAsync(StartAssociationsOnceRequest, cb)
 	assert(StartAssociationsOnceRequest, "You must provide a StartAssociationsOnceRequest")
 	local headers = {
@@ -21893,19 +21908,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartAssociationsOnceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartAssociationsOnceSync(StartAssociationsOnceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartAssociationsOnceAsync(StartAssociationsOnceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartAssociationsOnceAsync(StartAssociationsOnceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindowTasks asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowTasksAsync(DescribeMaintenanceWindowTasksRequest, cb)
 	assert(DescribeMaintenanceWindowTasksRequest, "You must provide a DescribeMaintenanceWindowTasksRequest")
 	local headers = {
@@ -21928,19 +21944,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowTasksSync(DescribeMaintenanceWindowTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowTasksAsync(DescribeMaintenanceWindowTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowTasksAsync(DescribeMaintenanceWindowTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetConnectionStatus asynchronously, invoking a callback when done
 -- @param GetConnectionStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetConnectionStatusAsync(GetConnectionStatusRequest, cb)
 	assert(GetConnectionStatusRequest, "You must provide a GetConnectionStatusRequest")
 	local headers = {
@@ -21963,19 +21980,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetConnectionStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetConnectionStatusSync(GetConnectionStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetConnectionStatusAsync(GetConnectionStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetConnectionStatusAsync(GetConnectionStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateActivation asynchronously, invoking a callback when done
 -- @param CreateActivationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateActivationAsync(CreateActivationRequest, cb)
 	assert(CreateActivationRequest, "You must provide a CreateActivationRequest")
 	local headers = {
@@ -21998,19 +22016,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateActivationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateActivationSync(CreateActivationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateActivationAsync(CreateActivationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateActivationAsync(CreateActivationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDocument asynchronously, invoking a callback when done
 -- @param UpdateDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDocumentAsync(UpdateDocumentRequest, cb)
 	assert(UpdateDocumentRequest, "You must provide a UpdateDocumentRequest")
 	local headers = {
@@ -22033,19 +22052,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDocumentSync(UpdateDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDocumentAsync(UpdateDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDocumentAsync(UpdateDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDocumentPermission asynchronously, invoking a callback when done
 -- @param DescribeDocumentPermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDocumentPermissionAsync(DescribeDocumentPermissionRequest, cb)
 	assert(DescribeDocumentPermissionRequest, "You must provide a DescribeDocumentPermissionRequest")
 	local headers = {
@@ -22068,19 +22088,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDocumentPermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDocumentPermissionSync(DescribeDocumentPermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDocumentPermissionAsync(DescribeDocumentPermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDocumentPermissionAsync(DescribeDocumentPermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCommandInvocations asynchronously, invoking a callback when done
 -- @param ListCommandInvocationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCommandInvocationsAsync(ListCommandInvocationsRequest, cb)
 	assert(ListCommandInvocationsRequest, "You must provide a ListCommandInvocationsRequest")
 	local headers = {
@@ -22103,19 +22124,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCommandInvocationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCommandInvocationsSync(ListCommandInvocationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCommandInvocationsAsync(ListCommandInvocationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCommandInvocationsAsync(ListCommandInvocationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMaintenanceWindowTarget asynchronously, invoking a callback when done
 -- @param UpdateMaintenanceWindowTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMaintenanceWindowTargetAsync(UpdateMaintenanceWindowTargetRequest, cb)
 	assert(UpdateMaintenanceWindowTargetRequest, "You must provide a UpdateMaintenanceWindowTargetRequest")
 	local headers = {
@@ -22138,19 +22160,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMaintenanceWindowTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMaintenanceWindowTargetSync(UpdateMaintenanceWindowTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMaintenanceWindowTargetAsync(UpdateMaintenanceWindowTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMaintenanceWindowTargetAsync(UpdateMaintenanceWindowTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDocument asynchronously, invoking a callback when done
 -- @param DeleteDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDocumentAsync(DeleteDocumentRequest, cb)
 	assert(DeleteDocumentRequest, "You must provide a DeleteDocumentRequest")
 	local headers = {
@@ -22173,19 +22196,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDocumentSync(DeleteDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDocumentAsync(DeleteDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDocumentAsync(DeleteDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindowExecutions asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowExecutionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowExecutionsAsync(DescribeMaintenanceWindowExecutionsRequest, cb)
 	assert(DescribeMaintenanceWindowExecutionsRequest, "You must provide a DescribeMaintenanceWindowExecutionsRequest")
 	local headers = {
@@ -22208,19 +22232,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowExecutionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowExecutionsSync(DescribeMaintenanceWindowExecutionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowExecutionsAsync(DescribeMaintenanceWindowExecutionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowExecutionsAsync(DescribeMaintenanceWindowExecutionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindowSchedule asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowScheduleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowScheduleAsync(DescribeMaintenanceWindowScheduleRequest, cb)
 	assert(DescribeMaintenanceWindowScheduleRequest, "You must provide a DescribeMaintenanceWindowScheduleRequest")
 	local headers = {
@@ -22243,19 +22268,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowScheduleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowScheduleSync(DescribeMaintenanceWindowScheduleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowScheduleAsync(DescribeMaintenanceWindowScheduleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowScheduleAsync(DescribeMaintenanceWindowScheduleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListInventoryEntries asynchronously, invoking a callback when done
 -- @param ListInventoryEntriesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListInventoryEntriesAsync(ListInventoryEntriesRequest, cb)
 	assert(ListInventoryEntriesRequest, "You must provide a ListInventoryEntriesRequest")
 	local headers = {
@@ -22278,19 +22304,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListInventoryEntriesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListInventoryEntriesSync(ListInventoryEntriesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListInventoryEntriesAsync(ListInventoryEntriesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListInventoryEntriesAsync(ListInventoryEntriesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterPatchBaselineForPatchGroup asynchronously, invoking a callback when done
 -- @param DeregisterPatchBaselineForPatchGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterPatchBaselineForPatchGroupAsync(DeregisterPatchBaselineForPatchGroupRequest, cb)
 	assert(DeregisterPatchBaselineForPatchGroupRequest, "You must provide a DeregisterPatchBaselineForPatchGroupRequest")
 	local headers = {
@@ -22313,19 +22340,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterPatchBaselineForPatchGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterPatchBaselineForPatchGroupSync(DeregisterPatchBaselineForPatchGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterPatchBaselineForPatchGroupAsync(DeregisterPatchBaselineForPatchGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterPatchBaselineForPatchGroupAsync(DeregisterPatchBaselineForPatchGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceRequest, cb)
 	assert(ListTagsForResourceRequest, "You must provide a ListTagsForResourceRequest")
 	local headers = {
@@ -22348,19 +22376,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartAutomationExecution asynchronously, invoking a callback when done
 -- @param StartAutomationExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartAutomationExecutionAsync(StartAutomationExecutionRequest, cb)
 	assert(StartAutomationExecutionRequest, "You must provide a StartAutomationExecutionRequest")
 	local headers = {
@@ -22383,19 +22412,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartAutomationExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartAutomationExecutionSync(StartAutomationExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartAutomationExecutionAsync(StartAutomationExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartAutomationExecutionAsync(StartAutomationExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDeployablePatchSnapshotForInstance asynchronously, invoking a callback when done
 -- @param GetDeployablePatchSnapshotForInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDeployablePatchSnapshotForInstanceAsync(GetDeployablePatchSnapshotForInstanceRequest, cb)
 	assert(GetDeployablePatchSnapshotForInstanceRequest, "You must provide a GetDeployablePatchSnapshotForInstanceRequest")
 	local headers = {
@@ -22418,19 +22448,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDeployablePatchSnapshotForInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDeployablePatchSnapshotForInstanceSync(GetDeployablePatchSnapshotForInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDeployablePatchSnapshotForInstanceAsync(GetDeployablePatchSnapshotForInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDeployablePatchSnapshotForInstanceAsync(GetDeployablePatchSnapshotForInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendAutomationSignal asynchronously, invoking a callback when done
 -- @param SendAutomationSignalRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendAutomationSignalAsync(SendAutomationSignalRequest, cb)
 	assert(SendAutomationSignalRequest, "You must provide a SendAutomationSignalRequest")
 	local headers = {
@@ -22453,19 +22484,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendAutomationSignalRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendAutomationSignalSync(SendAutomationSignalRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendAutomationSignalAsync(SendAutomationSignalRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendAutomationSignalAsync(SendAutomationSignalRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterDefaultPatchBaseline asynchronously, invoking a callback when done
 -- @param RegisterDefaultPatchBaselineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterDefaultPatchBaselineAsync(RegisterDefaultPatchBaselineRequest, cb)
 	assert(RegisterDefaultPatchBaselineRequest, "You must provide a RegisterDefaultPatchBaselineRequest")
 	local headers = {
@@ -22488,19 +22520,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterDefaultPatchBaselineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterDefaultPatchBaselineSync(RegisterDefaultPatchBaselineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterDefaultPatchBaselineAsync(RegisterDefaultPatchBaselineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterDefaultPatchBaselineAsync(RegisterDefaultPatchBaselineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetParametersByPath asynchronously, invoking a callback when done
 -- @param GetParametersByPathRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetParametersByPathAsync(GetParametersByPathRequest, cb)
 	assert(GetParametersByPathRequest, "You must provide a GetParametersByPathRequest")
 	local headers = {
@@ -22523,19 +22556,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetParametersByPathRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetParametersByPathSync(GetParametersByPathRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetParametersByPathAsync(GetParametersByPathRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetParametersByPathAsync(GetParametersByPathRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAssociationStatus asynchronously, invoking a callback when done
 -- @param UpdateAssociationStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAssociationStatusAsync(UpdateAssociationStatusRequest, cb)
 	assert(UpdateAssociationStatusRequest, "You must provide a UpdateAssociationStatusRequest")
 	local headers = {
@@ -22558,19 +22592,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAssociationStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAssociationStatusSync(UpdateAssociationStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAssociationStatusAsync(UpdateAssociationStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAssociationStatusAsync(UpdateAssociationStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToResource asynchronously, invoking a callback when done
 -- @param AddTagsToResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToResourceAsync(AddTagsToResourceRequest, cb)
 	assert(AddTagsToResourceRequest, "You must provide a AddTagsToResourceRequest")
 	local headers = {
@@ -22593,19 +22628,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToResourceSync(AddTagsToResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToResourceAsync(AddTagsToResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToResourceAsync(AddTagsToResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInventory asynchronously, invoking a callback when done
 -- @param GetInventoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInventoryAsync(GetInventoryRequest, cb)
 	assert(GetInventoryRequest, "You must provide a GetInventoryRequest")
 	local headers = {
@@ -22628,19 +22664,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInventoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInventorySync(GetInventoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInventoryAsync(GetInventoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInventoryAsync(GetInventoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromResource asynchronously, invoking a callback when done
 -- @param RemoveTagsFromResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, cb)
 	assert(RemoveTagsFromResourceRequest, "You must provide a RemoveTagsFromResourceRequest")
 	local headers = {
@@ -22663,19 +22700,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromResourceSync(RemoveTagsFromResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstanceAssociationsStatus asynchronously, invoking a callback when done
 -- @param DescribeInstanceAssociationsStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstanceAssociationsStatusAsync(DescribeInstanceAssociationsStatusRequest, cb)
 	assert(DescribeInstanceAssociationsStatusRequest, "You must provide a DescribeInstanceAssociationsStatusRequest")
 	local headers = {
@@ -22698,19 +22736,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstanceAssociationsStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstanceAssociationsStatusSync(DescribeInstanceAssociationsStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstanceAssociationsStatusAsync(DescribeInstanceAssociationsStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstanceAssociationsStatusAsync(DescribeInstanceAssociationsStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindowsForTarget asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowsForTargetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowsForTargetAsync(DescribeMaintenanceWindowsForTargetRequest, cb)
 	assert(DescribeMaintenanceWindowsForTargetRequest, "You must provide a DescribeMaintenanceWindowsForTargetRequest")
 	local headers = {
@@ -22733,19 +22772,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowsForTargetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowsForTargetSync(DescribeMaintenanceWindowsForTargetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowsForTargetAsync(DescribeMaintenanceWindowsForTargetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowsForTargetAsync(DescribeMaintenanceWindowsForTargetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetInventorySchema asynchronously, invoking a callback when done
 -- @param GetInventorySchemaRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetInventorySchemaAsync(GetInventorySchemaRequest, cb)
 	assert(GetInventorySchemaRequest, "You must provide a GetInventorySchemaRequest")
 	local headers = {
@@ -22768,19 +22808,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetInventorySchemaRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetInventorySchemaSync(GetInventorySchemaRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetInventorySchemaAsync(GetInventorySchemaRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetInventorySchemaAsync(GetInventorySchemaRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call LabelParameterVersion asynchronously, invoking a callback when done
 -- @param LabelParameterVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.LabelParameterVersionAsync(LabelParameterVersionRequest, cb)
 	assert(LabelParameterVersionRequest, "You must provide a LabelParameterVersionRequest")
 	local headers = {
@@ -22803,19 +22844,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param LabelParameterVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.LabelParameterVersionSync(LabelParameterVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.LabelParameterVersionAsync(LabelParameterVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.LabelParameterVersionAsync(LabelParameterVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeParameters asynchronously, invoking a callback when done
 -- @param DescribeParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeParametersAsync(DescribeParametersRequest, cb)
 	assert(DescribeParametersRequest, "You must provide a DescribeParametersRequest")
 	local headers = {
@@ -22838,19 +22880,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeParametersSync(DescribeParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeParametersAsync(DescribeParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeParametersAsync(DescribeParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMaintenanceWindowExecutionTaskInvocation asynchronously, invoking a callback when done
 -- @param GetMaintenanceWindowExecutionTaskInvocationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMaintenanceWindowExecutionTaskInvocationAsync(GetMaintenanceWindowExecutionTaskInvocationRequest, cb)
 	assert(GetMaintenanceWindowExecutionTaskInvocationRequest, "You must provide a GetMaintenanceWindowExecutionTaskInvocationRequest")
 	local headers = {
@@ -22873,19 +22916,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMaintenanceWindowExecutionTaskInvocationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMaintenanceWindowExecutionTaskInvocationSync(GetMaintenanceWindowExecutionTaskInvocationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMaintenanceWindowExecutionTaskInvocationAsync(GetMaintenanceWindowExecutionTaskInvocationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMaintenanceWindowExecutionTaskInvocationAsync(GetMaintenanceWindowExecutionTaskInvocationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteInventory asynchronously, invoking a callback when done
 -- @param DeleteInventoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteInventoryAsync(DeleteInventoryRequest, cb)
 	assert(DeleteInventoryRequest, "You must provide a DeleteInventoryRequest")
 	local headers = {
@@ -22908,19 +22952,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteInventoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteInventorySync(DeleteInventoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteInventoryAsync(DeleteInventoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteInventoryAsync(DeleteInventoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAutomationStepExecutions asynchronously, invoking a callback when done
 -- @param DescribeAutomationStepExecutionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAutomationStepExecutionsAsync(DescribeAutomationStepExecutionsRequest, cb)
 	assert(DescribeAutomationStepExecutionsRequest, "You must provide a DescribeAutomationStepExecutionsRequest")
 	local headers = {
@@ -22943,19 +22988,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAutomationStepExecutionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAutomationStepExecutionsSync(DescribeAutomationStepExecutionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAutomationStepExecutionsAsync(DescribeAutomationStepExecutionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAutomationStepExecutionsAsync(DescribeAutomationStepExecutionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEffectiveInstanceAssociations asynchronously, invoking a callback when done
 -- @param DescribeEffectiveInstanceAssociationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEffectiveInstanceAssociationsAsync(DescribeEffectiveInstanceAssociationsRequest, cb)
 	assert(DescribeEffectiveInstanceAssociationsRequest, "You must provide a DescribeEffectiveInstanceAssociationsRequest")
 	local headers = {
@@ -22978,19 +23024,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEffectiveInstanceAssociationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEffectiveInstanceAssociationsSync(DescribeEffectiveInstanceAssociationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEffectiveInstanceAssociationsAsync(DescribeEffectiveInstanceAssociationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEffectiveInstanceAssociationsAsync(DescribeEffectiveInstanceAssociationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelMaintenanceWindowExecution asynchronously, invoking a callback when done
 -- @param CancelMaintenanceWindowExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelMaintenanceWindowExecutionAsync(CancelMaintenanceWindowExecutionRequest, cb)
 	assert(CancelMaintenanceWindowExecutionRequest, "You must provide a CancelMaintenanceWindowExecutionRequest")
 	local headers = {
@@ -23013,19 +23060,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelMaintenanceWindowExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelMaintenanceWindowExecutionSync(CancelMaintenanceWindowExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelMaintenanceWindowExecutionAsync(CancelMaintenanceWindowExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelMaintenanceWindowExecutionAsync(CancelMaintenanceWindowExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindowExecutionTaskInvocations asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowExecutionTaskInvocationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowExecutionTaskInvocationsAsync(DescribeMaintenanceWindowExecutionTaskInvocationsRequest, cb)
 	assert(DescribeMaintenanceWindowExecutionTaskInvocationsRequest, "You must provide a DescribeMaintenanceWindowExecutionTaskInvocationsRequest")
 	local headers = {
@@ -23048,19 +23096,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowExecutionTaskInvocationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowExecutionTaskInvocationsSync(DescribeMaintenanceWindowExecutionTaskInvocationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowExecutionTaskInvocationsAsync(DescribeMaintenanceWindowExecutionTaskInvocationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowExecutionTaskInvocationsAsync(DescribeMaintenanceWindowExecutionTaskInvocationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDocumentDefaultVersion asynchronously, invoking a callback when done
 -- @param UpdateDocumentDefaultVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDocumentDefaultVersionAsync(UpdateDocumentDefaultVersionRequest, cb)
 	assert(UpdateDocumentDefaultVersionRequest, "You must provide a UpdateDocumentDefaultVersionRequest")
 	local headers = {
@@ -23083,19 +23132,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDocumentDefaultVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDocumentDefaultVersionSync(UpdateDocumentDefaultVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDocumentDefaultVersionAsync(UpdateDocumentDefaultVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDocumentDefaultVersionAsync(UpdateDocumentDefaultVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListComplianceItems asynchronously, invoking a callback when done
 -- @param ListComplianceItemsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListComplianceItemsAsync(ListComplianceItemsRequest, cb)
 	assert(ListComplianceItemsRequest, "You must provide a ListComplianceItemsRequest")
 	local headers = {
@@ -23118,19 +23168,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListComplianceItemsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListComplianceItemsSync(ListComplianceItemsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListComplianceItemsAsync(ListComplianceItemsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListComplianceItemsAsync(ListComplianceItemsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssociationVersions asynchronously, invoking a callback when done
 -- @param ListAssociationVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssociationVersionsAsync(ListAssociationVersionsRequest, cb)
 	assert(ListAssociationVersionsRequest, "You must provide a ListAssociationVersionsRequest")
 	local headers = {
@@ -23153,19 +23204,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssociationVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssociationVersionsSync(ListAssociationVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssociationVersionsAsync(ListAssociationVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssociationVersionsAsync(ListAssociationVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDocuments asynchronously, invoking a callback when done
 -- @param ListDocumentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDocumentsAsync(ListDocumentsRequest, cb)
 	assert(ListDocumentsRequest, "You must provide a ListDocumentsRequest")
 	local headers = {
@@ -23188,19 +23240,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDocumentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDocumentsSync(ListDocumentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDocumentsAsync(ListDocumentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDocumentsAsync(ListDocumentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteActivation asynchronously, invoking a callback when done
 -- @param DeleteActivationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteActivationAsync(DeleteActivationRequest, cb)
 	assert(DeleteActivationRequest, "You must provide a DeleteActivationRequest")
 	local headers = {
@@ -23223,19 +23276,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteActivationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteActivationSync(DeleteActivationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteActivationAsync(DeleteActivationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteActivationAsync(DeleteActivationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAvailablePatches asynchronously, invoking a callback when done
 -- @param DescribeAvailablePatchesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAvailablePatchesAsync(DescribeAvailablePatchesRequest, cb)
 	assert(DescribeAvailablePatchesRequest, "You must provide a DescribeAvailablePatchesRequest")
 	local headers = {
@@ -23258,19 +23312,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAvailablePatchesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAvailablePatchesSync(DescribeAvailablePatchesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAvailablePatchesAsync(DescribeAvailablePatchesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAvailablePatchesAsync(DescribeAvailablePatchesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstancePatches asynchronously, invoking a callback when done
 -- @param DescribeInstancePatchesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstancePatchesAsync(DescribeInstancePatchesRequest, cb)
 	assert(DescribeInstancePatchesRequest, "You must provide a DescribeInstancePatchesRequest")
 	local headers = {
@@ -23293,19 +23348,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstancePatchesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstancePatchesSync(DescribeInstancePatchesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstancePatchesAsync(DescribeInstancePatchesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstancePatchesAsync(DescribeInstancePatchesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstancePatchStates asynchronously, invoking a callback when done
 -- @param DescribeInstancePatchStatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstancePatchStatesAsync(DescribeInstancePatchStatesRequest, cb)
 	assert(DescribeInstancePatchStatesRequest, "You must provide a DescribeInstancePatchStatesRequest")
 	local headers = {
@@ -23328,19 +23384,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstancePatchStatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstancePatchStatesSync(DescribeInstancePatchStatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstancePatchStatesAsync(DescribeInstancePatchStatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstancePatchStatesAsync(DescribeInstancePatchStatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyDocumentPermission asynchronously, invoking a callback when done
 -- @param ModifyDocumentPermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyDocumentPermissionAsync(ModifyDocumentPermissionRequest, cb)
 	assert(ModifyDocumentPermissionRequest, "You must provide a ModifyDocumentPermissionRequest")
 	local headers = {
@@ -23363,19 +23420,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyDocumentPermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyDocumentPermissionSync(ModifyDocumentPermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyDocumentPermissionAsync(ModifyDocumentPermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyDocumentPermissionAsync(ModifyDocumentPermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutComplianceItems asynchronously, invoking a callback when done
 -- @param PutComplianceItemsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutComplianceItemsAsync(PutComplianceItemsRequest, cb)
 	assert(PutComplianceItemsRequest, "You must provide a PutComplianceItemsRequest")
 	local headers = {
@@ -23398,19 +23456,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutComplianceItemsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutComplianceItemsSync(PutComplianceItemsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutComplianceItemsAsync(PutComplianceItemsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutComplianceItemsAsync(PutComplianceItemsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateManagedInstanceRole asynchronously, invoking a callback when done
 -- @param UpdateManagedInstanceRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateManagedInstanceRoleAsync(UpdateManagedInstanceRoleRequest, cb)
 	assert(UpdateManagedInstanceRoleRequest, "You must provide a UpdateManagedInstanceRoleRequest")
 	local headers = {
@@ -23433,19 +23492,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateManagedInstanceRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateManagedInstanceRoleSync(UpdateManagedInstanceRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateManagedInstanceRoleAsync(UpdateManagedInstanceRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateManagedInstanceRoleAsync(UpdateManagedInstanceRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAssociationExecutions asynchronously, invoking a callback when done
 -- @param DescribeAssociationExecutionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAssociationExecutionsAsync(DescribeAssociationExecutionsRequest, cb)
 	assert(DescribeAssociationExecutionsRequest, "You must provide a DescribeAssociationExecutionsRequest")
 	local headers = {
@@ -23468,19 +23528,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAssociationExecutionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAssociationExecutionsSync(DescribeAssociationExecutionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAssociationExecutionsAsync(DescribeAssociationExecutionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAssociationExecutionsAsync(DescribeAssociationExecutionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopAutomationExecution asynchronously, invoking a callback when done
 -- @param StopAutomationExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopAutomationExecutionAsync(StopAutomationExecutionRequest, cb)
 	assert(StopAutomationExecutionRequest, "You must provide a StopAutomationExecutionRequest")
 	local headers = {
@@ -23503,19 +23564,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopAutomationExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopAutomationExecutionSync(StopAutomationExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopAutomationExecutionAsync(StopAutomationExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopAutomationExecutionAsync(StopAutomationExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartSession asynchronously, invoking a callback when done
 -- @param StartSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartSessionAsync(StartSessionRequest, cb)
 	assert(StartSessionRequest, "You must provide a StartSessionRequest")
 	local headers = {
@@ -23538,19 +23600,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartSessionSync(StartSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartSessionAsync(StartSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartSessionAsync(StartSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendCommand asynchronously, invoking a callback when done
 -- @param SendCommandRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendCommandAsync(SendCommandRequest, cb)
 	assert(SendCommandRequest, "You must provide a SendCommandRequest")
 	local headers = {
@@ -23573,19 +23636,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendCommandRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendCommandSync(SendCommandRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendCommandAsync(SendCommandRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendCommandAsync(SendCommandRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPatchBaseline asynchronously, invoking a callback when done
 -- @param GetPatchBaselineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPatchBaselineAsync(GetPatchBaselineRequest, cb)
 	assert(GetPatchBaselineRequest, "You must provide a GetPatchBaselineRequest")
 	local headers = {
@@ -23608,19 +23672,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPatchBaselineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPatchBaselineSync(GetPatchBaselineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPatchBaselineAsync(GetPatchBaselineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPatchBaselineAsync(GetPatchBaselineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePatchBaseline asynchronously, invoking a callback when done
 -- @param UpdatePatchBaselineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePatchBaselineAsync(UpdatePatchBaselineRequest, cb)
 	assert(UpdatePatchBaselineRequest, "You must provide a UpdatePatchBaselineRequest")
 	local headers = {
@@ -23643,19 +23708,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePatchBaselineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePatchBaselineSync(UpdatePatchBaselineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePatchBaselineAsync(UpdatePatchBaselineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePatchBaselineAsync(UpdatePatchBaselineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePatchGroupState asynchronously, invoking a callback when done
 -- @param DescribePatchGroupStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePatchGroupStateAsync(DescribePatchGroupStateRequest, cb)
 	assert(DescribePatchGroupStateRequest, "You must provide a DescribePatchGroupStateRequest")
 	local headers = {
@@ -23678,19 +23744,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePatchGroupStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePatchGroupStateSync(DescribePatchGroupStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePatchGroupStateAsync(DescribePatchGroupStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePatchGroupStateAsync(DescribePatchGroupStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateAssociation asynchronously, invoking a callback when done
 -- @param UpdateAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateAssociationAsync(UpdateAssociationRequest, cb)
 	assert(UpdateAssociationRequest, "You must provide a UpdateAssociationRequest")
 	local headers = {
@@ -23713,19 +23780,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateAssociationSync(UpdateAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateAssociationAsync(UpdateAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateAssociationAsync(UpdateAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSessions asynchronously, invoking a callback when done
 -- @param DescribeSessionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSessionsAsync(DescribeSessionsRequest, cb)
 	assert(DescribeSessionsRequest, "You must provide a DescribeSessionsRequest")
 	local headers = {
@@ -23748,19 +23816,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSessionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSessionsSync(DescribeSessionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSessionsAsync(DescribeSessionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSessionsAsync(DescribeSessionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDocumentVersions asynchronously, invoking a callback when done
 -- @param ListDocumentVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDocumentVersionsAsync(ListDocumentVersionsRequest, cb)
 	assert(ListDocumentVersionsRequest, "You must provide a ListDocumentVersionsRequest")
 	local headers = {
@@ -23783,19 +23852,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDocumentVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDocumentVersionsSync(ListDocumentVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDocumentVersionsAsync(ListDocumentVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDocumentVersionsAsync(ListDocumentVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindowExecutionTasks asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowExecutionTasksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowExecutionTasksAsync(DescribeMaintenanceWindowExecutionTasksRequest, cb)
 	assert(DescribeMaintenanceWindowExecutionTasksRequest, "You must provide a DescribeMaintenanceWindowExecutionTasksRequest")
 	local headers = {
@@ -23818,19 +23888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowExecutionTasksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowExecutionTasksSync(DescribeMaintenanceWindowExecutionTasksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowExecutionTasksAsync(DescribeMaintenanceWindowExecutionTasksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowExecutionTasksAsync(DescribeMaintenanceWindowExecutionTasksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMaintenanceWindow asynchronously, invoking a callback when done
 -- @param GetMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMaintenanceWindowAsync(GetMaintenanceWindowRequest, cb)
 	assert(GetMaintenanceWindowRequest, "You must provide a GetMaintenanceWindowRequest")
 	local headers = {
@@ -23853,19 +23924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMaintenanceWindowSync(GetMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMaintenanceWindowAsync(GetMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMaintenanceWindowAsync(GetMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteParameters asynchronously, invoking a callback when done
 -- @param DeleteParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteParametersAsync(DeleteParametersRequest, cb)
 	assert(DeleteParametersRequest, "You must provide a DeleteParametersRequest")
 	local headers = {
@@ -23888,19 +23960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteParametersSync(DeleteParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteParametersAsync(DeleteParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteParametersAsync(DeleteParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindowTargets asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowTargetsAsync(DescribeMaintenanceWindowTargetsRequest, cb)
 	assert(DescribeMaintenanceWindowTargetsRequest, "You must provide a DescribeMaintenanceWindowTargetsRequest")
 	local headers = {
@@ -23923,19 +23996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowTargetsSync(DescribeMaintenanceWindowTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowTargetsAsync(DescribeMaintenanceWindowTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowTargetsAsync(DescribeMaintenanceWindowTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeInstanceInformation asynchronously, invoking a callback when done
 -- @param DescribeInstanceInformationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeInstanceInformationAsync(DescribeInstanceInformationRequest, cb)
 	assert(DescribeInstanceInformationRequest, "You must provide a DescribeInstanceInformationRequest")
 	local headers = {
@@ -23958,19 +24032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeInstanceInformationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeInstanceInformationSync(DescribeInstanceInformationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeInstanceInformationAsync(DescribeInstanceInformationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeInstanceInformationAsync(DescribeInstanceInformationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAssociations asynchronously, invoking a callback when done
 -- @param ListAssociationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAssociationsAsync(ListAssociationsRequest, cb)
 	assert(ListAssociationsRequest, "You must provide a ListAssociationsRequest")
 	local headers = {
@@ -23993,19 +24068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAssociationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAssociationsSync(ListAssociationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAssociationsAsync(ListAssociationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAssociationsAsync(ListAssociationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMaintenanceWindow asynchronously, invoking a callback when done
 -- @param DeleteMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMaintenanceWindowAsync(DeleteMaintenanceWindowRequest, cb)
 	assert(DeleteMaintenanceWindowRequest, "You must provide a DeleteMaintenanceWindowRequest")
 	local headers = {
@@ -24028,19 +24104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMaintenanceWindowSync(DeleteMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMaintenanceWindowAsync(DeleteMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMaintenanceWindowAsync(DeleteMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDocument asynchronously, invoking a callback when done
 -- @param DescribeDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDocumentAsync(DescribeDocumentRequest, cb)
 	assert(DescribeDocumentRequest, "You must provide a DescribeDocumentRequest")
 	local headers = {
@@ -24063,19 +24140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDocumentSync(DescribeDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDocumentAsync(DescribeDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDocumentAsync(DescribeDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePatchBaseline asynchronously, invoking a callback when done
 -- @param DeletePatchBaselineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePatchBaselineAsync(DeletePatchBaselineRequest, cb)
 	assert(DeletePatchBaselineRequest, "You must provide a DeletePatchBaselineRequest")
 	local headers = {
@@ -24098,19 +24176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePatchBaselineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePatchBaselineSync(DeletePatchBaselineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePatchBaselineAsync(DeletePatchBaselineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePatchBaselineAsync(DeletePatchBaselineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterTaskWithMaintenanceWindow asynchronously, invoking a callback when done
 -- @param RegisterTaskWithMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterTaskWithMaintenanceWindowAsync(RegisterTaskWithMaintenanceWindowRequest, cb)
 	assert(RegisterTaskWithMaintenanceWindowRequest, "You must provide a RegisterTaskWithMaintenanceWindowRequest")
 	local headers = {
@@ -24133,19 +24212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterTaskWithMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterTaskWithMaintenanceWindowSync(RegisterTaskWithMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterTaskWithMaintenanceWindowAsync(RegisterTaskWithMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterTaskWithMaintenanceWindowAsync(RegisterTaskWithMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetParameters asynchronously, invoking a callback when done
 -- @param GetParametersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetParametersAsync(GetParametersRequest, cb)
 	assert(GetParametersRequest, "You must provide a GetParametersRequest")
 	local headers = {
@@ -24168,19 +24248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetParametersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetParametersSync(GetParametersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetParametersAsync(GetParametersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetParametersAsync(GetParametersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterManagedInstance asynchronously, invoking a callback when done
 -- @param DeregisterManagedInstanceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterManagedInstanceAsync(DeregisterManagedInstanceRequest, cb)
 	assert(DeregisterManagedInstanceRequest, "You must provide a DeregisterManagedInstanceRequest")
 	local headers = {
@@ -24203,19 +24284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterManagedInstanceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterManagedInstanceSync(DeregisterManagedInstanceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterManagedInstanceAsync(DeregisterManagedInstanceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterManagedInstanceAsync(DeregisterManagedInstanceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResumeSession asynchronously, invoking a callback when done
 -- @param ResumeSessionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResumeSessionAsync(ResumeSessionRequest, cb)
 	assert(ResumeSessionRequest, "You must provide a ResumeSessionRequest")
 	local headers = {
@@ -24238,19 +24320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResumeSessionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResumeSessionSync(ResumeSessionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResumeSessionAsync(ResumeSessionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResumeSessionAsync(ResumeSessionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateMaintenanceWindow asynchronously, invoking a callback when done
 -- @param CreateMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateMaintenanceWindowAsync(CreateMaintenanceWindowRequest, cb)
 	assert(CreateMaintenanceWindowRequest, "You must provide a CreateMaintenanceWindowRequest")
 	local headers = {
@@ -24273,19 +24356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateMaintenanceWindowSync(CreateMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateMaintenanceWindowAsync(CreateMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateMaintenanceWindowAsync(CreateMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceDataSync asynchronously, invoking a callback when done
 -- @param ListResourceDataSyncRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceDataSyncAsync(ListResourceDataSyncRequest, cb)
 	assert(ListResourceDataSyncRequest, "You must provide a ListResourceDataSyncRequest")
 	local headers = {
@@ -24308,19 +24392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceDataSyncRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceDataSyncSync(ListResourceDataSyncRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceDataSyncAsync(ListResourceDataSyncRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceDataSyncAsync(ListResourceDataSyncRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMaintenanceWindow asynchronously, invoking a callback when done
 -- @param UpdateMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMaintenanceWindowAsync(UpdateMaintenanceWindowRequest, cb)
 	assert(UpdateMaintenanceWindowRequest, "You must provide a UpdateMaintenanceWindowRequest")
 	local headers = {
@@ -24343,19 +24428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMaintenanceWindowSync(UpdateMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMaintenanceWindowAsync(UpdateMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMaintenanceWindowAsync(UpdateMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeEffectivePatchesForPatchBaseline asynchronously, invoking a callback when done
 -- @param DescribeEffectivePatchesForPatchBaselineRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeEffectivePatchesForPatchBaselineAsync(DescribeEffectivePatchesForPatchBaselineRequest, cb)
 	assert(DescribeEffectivePatchesForPatchBaselineRequest, "You must provide a DescribeEffectivePatchesForPatchBaselineRequest")
 	local headers = {
@@ -24378,19 +24464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeEffectivePatchesForPatchBaselineRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeEffectivePatchesForPatchBaselineSync(DescribeEffectivePatchesForPatchBaselineRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeEffectivePatchesForPatchBaselineAsync(DescribeEffectivePatchesForPatchBaselineRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeEffectivePatchesForPatchBaselineAsync(DescribeEffectivePatchesForPatchBaselineRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResourceDataSync asynchronously, invoking a callback when done
 -- @param CreateResourceDataSyncRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResourceDataSyncAsync(CreateResourceDataSyncRequest, cb)
 	assert(CreateResourceDataSyncRequest, "You must provide a CreateResourceDataSyncRequest")
 	local headers = {
@@ -24413,19 +24500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResourceDataSyncRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResourceDataSyncSync(CreateResourceDataSyncRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResourceDataSyncAsync(CreateResourceDataSyncRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResourceDataSyncAsync(CreateResourceDataSyncRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutParameter asynchronously, invoking a callback when done
 -- @param PutParameterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutParameterAsync(PutParameterRequest, cb)
 	assert(PutParameterRequest, "You must provide a PutParameterRequest")
 	local headers = {
@@ -24448,19 +24536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutParameterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutParameterSync(PutParameterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutParameterAsync(PutParameterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutParameterAsync(PutParameterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetAutomationExecution asynchronously, invoking a callback when done
 -- @param GetAutomationExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetAutomationExecutionAsync(GetAutomationExecutionRequest, cb)
 	assert(GetAutomationExecutionRequest, "You must provide a GetAutomationExecutionRequest")
 	local headers = {
@@ -24483,19 +24572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetAutomationExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetAutomationExecutionSync(GetAutomationExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetAutomationExecutionAsync(GetAutomationExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetAutomationExecutionAsync(GetAutomationExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutInventory asynchronously, invoking a callback when done
 -- @param PutInventoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutInventoryAsync(PutInventoryRequest, cb)
 	assert(PutInventoryRequest, "You must provide a PutInventoryRequest")
 	local headers = {
@@ -24518,19 +24608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutInventoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutInventorySync(PutInventoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutInventoryAsync(PutInventoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutInventoryAsync(PutInventoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAutomationExecutions asynchronously, invoking a callback when done
 -- @param DescribeAutomationExecutionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAutomationExecutionsAsync(DescribeAutomationExecutionsRequest, cb)
 	assert(DescribeAutomationExecutionsRequest, "You must provide a DescribeAutomationExecutionsRequest")
 	local headers = {
@@ -24553,19 +24644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAutomationExecutionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAutomationExecutionsSync(DescribeAutomationExecutionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAutomationExecutionsAsync(DescribeAutomationExecutionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAutomationExecutionsAsync(DescribeAutomationExecutionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMaintenanceWindowTask asynchronously, invoking a callback when done
 -- @param GetMaintenanceWindowTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMaintenanceWindowTaskAsync(GetMaintenanceWindowTaskRequest, cb)
 	assert(GetMaintenanceWindowTaskRequest, "You must provide a GetMaintenanceWindowTaskRequest")
 	local headers = {
@@ -24588,19 +24680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMaintenanceWindowTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMaintenanceWindowTaskSync(GetMaintenanceWindowTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMaintenanceWindowTaskAsync(GetMaintenanceWindowTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMaintenanceWindowTaskAsync(GetMaintenanceWindowTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePatchBaselines asynchronously, invoking a callback when done
 -- @param DescribePatchBaselinesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePatchBaselinesAsync(DescribePatchBaselinesRequest, cb)
 	assert(DescribePatchBaselinesRequest, "You must provide a DescribePatchBaselinesRequest")
 	local headers = {
@@ -24623,19 +24716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePatchBaselinesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePatchBaselinesSync(DescribePatchBaselinesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePatchBaselinesAsync(DescribePatchBaselinesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePatchBaselinesAsync(DescribePatchBaselinesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAssociationBatch asynchronously, invoking a callback when done
 -- @param CreateAssociationBatchRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAssociationBatchAsync(CreateAssociationBatchRequest, cb)
 	assert(CreateAssociationBatchRequest, "You must provide a CreateAssociationBatchRequest")
 	local headers = {
@@ -24658,19 +24752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAssociationBatchRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAssociationBatchSync(CreateAssociationBatchRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAssociationBatchAsync(CreateAssociationBatchRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAssociationBatchAsync(CreateAssociationBatchRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResourceDataSync asynchronously, invoking a callback when done
 -- @param DeleteResourceDataSyncRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourceDataSyncAsync(DeleteResourceDataSyncRequest, cb)
 	assert(DeleteResourceDataSyncRequest, "You must provide a DeleteResourceDataSyncRequest")
 	local headers = {
@@ -24693,19 +24788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourceDataSyncRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourceDataSyncSync(DeleteResourceDataSyncRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourceDataSyncAsync(DeleteResourceDataSyncRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourceDataSyncAsync(DeleteResourceDataSyncRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMaintenanceWindowExecutionTask asynchronously, invoking a callback when done
 -- @param GetMaintenanceWindowExecutionTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMaintenanceWindowExecutionTaskAsync(GetMaintenanceWindowExecutionTaskRequest, cb)
 	assert(GetMaintenanceWindowExecutionTaskRequest, "You must provide a GetMaintenanceWindowExecutionTaskRequest")
 	local headers = {
@@ -24728,19 +24824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMaintenanceWindowExecutionTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMaintenanceWindowExecutionTaskSync(GetMaintenanceWindowExecutionTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMaintenanceWindowExecutionTaskAsync(GetMaintenanceWindowExecutionTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMaintenanceWindowExecutionTaskAsync(GetMaintenanceWindowExecutionTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelCommand asynchronously, invoking a callback when done
 -- @param CancelCommandRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelCommandAsync(CancelCommandRequest, cb)
 	assert(CancelCommandRequest, "You must provide a CancelCommandRequest")
 	local headers = {
@@ -24763,19 +24860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelCommandRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelCommandSync(CancelCommandRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelCommandAsync(CancelCommandRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelCommandAsync(CancelCommandRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCommandInvocation asynchronously, invoking a callback when done
 -- @param GetCommandInvocationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCommandInvocationAsync(GetCommandInvocationRequest, cb)
 	assert(GetCommandInvocationRequest, "You must provide a GetCommandInvocationRequest")
 	local headers = {
@@ -24798,19 +24896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCommandInvocationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCommandInvocationSync(GetCommandInvocationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCommandInvocationAsync(GetCommandInvocationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCommandInvocationAsync(GetCommandInvocationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetParameterHistory asynchronously, invoking a callback when done
 -- @param GetParameterHistoryRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetParameterHistoryAsync(GetParameterHistoryRequest, cb)
 	assert(GetParameterHistoryRequest, "You must provide a GetParameterHistoryRequest")
 	local headers = {
@@ -24833,19 +24932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetParameterHistoryRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetParameterHistorySync(GetParameterHistoryRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetParameterHistoryAsync(GetParameterHistoryRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetParameterHistoryAsync(GetParameterHistoryRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterTaskFromMaintenanceWindow asynchronously, invoking a callback when done
 -- @param DeregisterTaskFromMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterTaskFromMaintenanceWindowAsync(DeregisterTaskFromMaintenanceWindowRequest, cb)
 	assert(DeregisterTaskFromMaintenanceWindowRequest, "You must provide a DeregisterTaskFromMaintenanceWindowRequest")
 	local headers = {
@@ -24868,19 +24968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterTaskFromMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterTaskFromMaintenanceWindowSync(DeregisterTaskFromMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterTaskFromMaintenanceWindowAsync(DeregisterTaskFromMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterTaskFromMaintenanceWindowAsync(DeregisterTaskFromMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterPatchBaselineForPatchGroup asynchronously, invoking a callback when done
 -- @param RegisterPatchBaselineForPatchGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterPatchBaselineForPatchGroupAsync(RegisterPatchBaselineForPatchGroupRequest, cb)
 	assert(RegisterPatchBaselineForPatchGroupRequest, "You must provide a RegisterPatchBaselineForPatchGroupRequest")
 	local headers = {
@@ -24903,19 +25004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterPatchBaselineForPatchGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterPatchBaselineForPatchGroupSync(RegisterPatchBaselineForPatchGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterPatchBaselineForPatchGroupAsync(RegisterPatchBaselineForPatchGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterPatchBaselineForPatchGroupAsync(RegisterPatchBaselineForPatchGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceWindows asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceWindowsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceWindowsAsync(DescribeMaintenanceWindowsRequest, cb)
 	assert(DescribeMaintenanceWindowsRequest, "You must provide a DescribeMaintenanceWindowsRequest")
 	local headers = {
@@ -24938,19 +25040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceWindowsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceWindowsSync(DescribeMaintenanceWindowsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceWindowsAsync(DescribeMaintenanceWindowsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceWindowsAsync(DescribeMaintenanceWindowsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribePatchGroups asynchronously, invoking a callback when done
 -- @param DescribePatchGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribePatchGroupsAsync(DescribePatchGroupsRequest, cb)
 	assert(DescribePatchGroupsRequest, "You must provide a DescribePatchGroupsRequest")
 	local headers = {
@@ -24973,19 +25076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribePatchGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribePatchGroupsSync(DescribePatchGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribePatchGroupsAsync(DescribePatchGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribePatchGroupsAsync(DescribePatchGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAssociation asynchronously, invoking a callback when done
 -- @param CreateAssociationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAssociationAsync(CreateAssociationRequest, cb)
 	assert(CreateAssociationRequest, "You must provide a CreateAssociationRequest")
 	local headers = {
@@ -25008,19 +25112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAssociationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAssociationSync(CreateAssociationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAssociationAsync(CreateAssociationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAssociationAsync(CreateAssociationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMaintenanceWindowTask asynchronously, invoking a callback when done
 -- @param UpdateMaintenanceWindowTaskRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMaintenanceWindowTaskAsync(UpdateMaintenanceWindowTaskRequest, cb)
 	assert(UpdateMaintenanceWindowTaskRequest, "You must provide a UpdateMaintenanceWindowTaskRequest")
 	local headers = {
@@ -25043,19 +25148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMaintenanceWindowTaskRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMaintenanceWindowTaskSync(UpdateMaintenanceWindowTaskRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMaintenanceWindowTaskAsync(UpdateMaintenanceWindowTaskRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMaintenanceWindowTaskAsync(UpdateMaintenanceWindowTaskRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListCommands asynchronously, invoking a callback when done
 -- @param ListCommandsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListCommandsAsync(ListCommandsRequest, cb)
 	assert(ListCommandsRequest, "You must provide a ListCommandsRequest")
 	local headers = {
@@ -25078,19 +25184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListCommandsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListCommandsSync(ListCommandsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListCommandsAsync(ListCommandsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListCommandsAsync(ListCommandsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetMaintenanceWindowExecution asynchronously, invoking a callback when done
 -- @param GetMaintenanceWindowExecutionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetMaintenanceWindowExecutionAsync(GetMaintenanceWindowExecutionRequest, cb)
 	assert(GetMaintenanceWindowExecutionRequest, "You must provide a GetMaintenanceWindowExecutionRequest")
 	local headers = {
@@ -25113,19 +25220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetMaintenanceWindowExecutionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetMaintenanceWindowExecutionSync(GetMaintenanceWindowExecutionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetMaintenanceWindowExecutionAsync(GetMaintenanceWindowExecutionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetMaintenanceWindowExecutionAsync(GetMaintenanceWindowExecutionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteParameter asynchronously, invoking a callback when done
 -- @param DeleteParameterRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteParameterAsync(DeleteParameterRequest, cb)
 	assert(DeleteParameterRequest, "You must provide a DeleteParameterRequest")
 	local headers = {
@@ -25148,19 +25256,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteParameterRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteParameterSync(DeleteParameterRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteParameterAsync(DeleteParameterRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteParameterAsync(DeleteParameterRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterTargetWithMaintenanceWindow asynchronously, invoking a callback when done
 -- @param RegisterTargetWithMaintenanceWindowRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterTargetWithMaintenanceWindowAsync(RegisterTargetWithMaintenanceWindowRequest, cb)
 	assert(RegisterTargetWithMaintenanceWindowRequest, "You must provide a RegisterTargetWithMaintenanceWindowRequest")
 	local headers = {
@@ -25183,19 +25292,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterTargetWithMaintenanceWindowRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterTargetWithMaintenanceWindowSync(RegisterTargetWithMaintenanceWindowRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterTargetWithMaintenanceWindowAsync(RegisterTargetWithMaintenanceWindowRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterTargetWithMaintenanceWindowAsync(RegisterTargetWithMaintenanceWindowRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeActivations asynchronously, invoking a callback when done
 -- @param DescribeActivationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeActivationsAsync(DescribeActivationsRequest, cb)
 	assert(DescribeActivationsRequest, "You must provide a DescribeActivationsRequest")
 	local headers = {
@@ -25218,12 +25328,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeActivationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeActivationsSync(DescribeActivationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeActivationsAsync(DescribeActivationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeActivationsAsync(DescribeActivationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/states.lua
+++ b/aws-sdk/states.lua
@@ -3703,7 +3703,7 @@ end
 --
 --- Call StartExecution asynchronously, invoking a callback when done
 -- @param StartExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartExecutionAsync(StartExecutionInput, cb)
 	assert(StartExecutionInput, "You must provide a StartExecutionInput")
 	local headers = {
@@ -3726,19 +3726,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartExecutionSync(StartExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartExecutionAsync(StartExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartExecutionAsync(StartExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListExecutions asynchronously, invoking a callback when done
 -- @param ListExecutionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListExecutionsAsync(ListExecutionsInput, cb)
 	assert(ListExecutionsInput, "You must provide a ListExecutionsInput")
 	local headers = {
@@ -3761,19 +3762,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListExecutionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListExecutionsSync(ListExecutionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListExecutionsAsync(ListExecutionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListExecutionsAsync(ListExecutionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStateMachineForExecution asynchronously, invoking a callback when done
 -- @param DescribeStateMachineForExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStateMachineForExecutionAsync(DescribeStateMachineForExecutionInput, cb)
 	assert(DescribeStateMachineForExecutionInput, "You must provide a DescribeStateMachineForExecutionInput")
 	local headers = {
@@ -3796,19 +3798,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStateMachineForExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStateMachineForExecutionSync(DescribeStateMachineForExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStateMachineForExecutionAsync(DescribeStateMachineForExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStateMachineForExecutionAsync(DescribeStateMachineForExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopExecution asynchronously, invoking a callback when done
 -- @param StopExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopExecutionAsync(StopExecutionInput, cb)
 	assert(StopExecutionInput, "You must provide a StopExecutionInput")
 	local headers = {
@@ -3831,19 +3834,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopExecutionSync(StopExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopExecutionAsync(StopExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopExecutionAsync(StopExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteActivity asynchronously, invoking a callback when done
 -- @param DeleteActivityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteActivityAsync(DeleteActivityInput, cb)
 	assert(DeleteActivityInput, "You must provide a DeleteActivityInput")
 	local headers = {
@@ -3866,19 +3870,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteActivityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteActivitySync(DeleteActivityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteActivityAsync(DeleteActivityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteActivityAsync(DeleteActivityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendTaskHeartbeat asynchronously, invoking a callback when done
 -- @param SendTaskHeartbeatInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendTaskHeartbeatAsync(SendTaskHeartbeatInput, cb)
 	assert(SendTaskHeartbeatInput, "You must provide a SendTaskHeartbeatInput")
 	local headers = {
@@ -3901,19 +3906,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendTaskHeartbeatInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendTaskHeartbeatSync(SendTaskHeartbeatInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendTaskHeartbeatAsync(SendTaskHeartbeatInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendTaskHeartbeatAsync(SendTaskHeartbeatInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeExecution asynchronously, invoking a callback when done
 -- @param DescribeExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeExecutionAsync(DescribeExecutionInput, cb)
 	assert(DescribeExecutionInput, "You must provide a DescribeExecutionInput")
 	local headers = {
@@ -3936,19 +3942,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeExecutionSync(DescribeExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeExecutionAsync(DescribeExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeExecutionAsync(DescribeExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStateMachines asynchronously, invoking a callback when done
 -- @param ListStateMachinesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStateMachinesAsync(ListStateMachinesInput, cb)
 	assert(ListStateMachinesInput, "You must provide a ListStateMachinesInput")
 	local headers = {
@@ -3971,19 +3978,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStateMachinesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStateMachinesSync(ListStateMachinesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStateMachinesAsync(ListStateMachinesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStateMachinesAsync(ListStateMachinesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetExecutionHistory asynchronously, invoking a callback when done
 -- @param GetExecutionHistoryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetExecutionHistoryAsync(GetExecutionHistoryInput, cb)
 	assert(GetExecutionHistoryInput, "You must provide a GetExecutionHistoryInput")
 	local headers = {
@@ -4006,19 +4014,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetExecutionHistoryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetExecutionHistorySync(GetExecutionHistoryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetExecutionHistoryAsync(GetExecutionHistoryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetExecutionHistoryAsync(GetExecutionHistoryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetActivityTask asynchronously, invoking a callback when done
 -- @param GetActivityTaskInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetActivityTaskAsync(GetActivityTaskInput, cb)
 	assert(GetActivityTaskInput, "You must provide a GetActivityTaskInput")
 	local headers = {
@@ -4041,19 +4050,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetActivityTaskInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetActivityTaskSync(GetActivityTaskInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetActivityTaskAsync(GetActivityTaskInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetActivityTaskAsync(GetActivityTaskInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListActivities asynchronously, invoking a callback when done
 -- @param ListActivitiesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListActivitiesAsync(ListActivitiesInput, cb)
 	assert(ListActivitiesInput, "You must provide a ListActivitiesInput")
 	local headers = {
@@ -4076,19 +4086,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListActivitiesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListActivitiesSync(ListActivitiesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListActivitiesAsync(ListActivitiesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListActivitiesAsync(ListActivitiesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStateMachine asynchronously, invoking a callback when done
 -- @param CreateStateMachineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStateMachineAsync(CreateStateMachineInput, cb)
 	assert(CreateStateMachineInput, "You must provide a CreateStateMachineInput")
 	local headers = {
@@ -4111,19 +4122,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStateMachineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStateMachineSync(CreateStateMachineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStateMachineAsync(CreateStateMachineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStateMachineAsync(CreateStateMachineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStateMachine asynchronously, invoking a callback when done
 -- @param DescribeStateMachineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStateMachineAsync(DescribeStateMachineInput, cb)
 	assert(DescribeStateMachineInput, "You must provide a DescribeStateMachineInput")
 	local headers = {
@@ -4146,19 +4158,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStateMachineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStateMachineSync(DescribeStateMachineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStateMachineAsync(DescribeStateMachineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStateMachineAsync(DescribeStateMachineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeActivity asynchronously, invoking a callback when done
 -- @param DescribeActivityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeActivityAsync(DescribeActivityInput, cb)
 	assert(DescribeActivityInput, "You must provide a DescribeActivityInput")
 	local headers = {
@@ -4181,19 +4194,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeActivityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeActivitySync(DescribeActivityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeActivityAsync(DescribeActivityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeActivityAsync(DescribeActivityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteStateMachine asynchronously, invoking a callback when done
 -- @param DeleteStateMachineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteStateMachineAsync(DeleteStateMachineInput, cb)
 	assert(DeleteStateMachineInput, "You must provide a DeleteStateMachineInput")
 	local headers = {
@@ -4216,19 +4230,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteStateMachineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteStateMachineSync(DeleteStateMachineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteStateMachineAsync(DeleteStateMachineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteStateMachineAsync(DeleteStateMachineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateStateMachine asynchronously, invoking a callback when done
 -- @param UpdateStateMachineInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateStateMachineAsync(UpdateStateMachineInput, cb)
 	assert(UpdateStateMachineInput, "You must provide a UpdateStateMachineInput")
 	local headers = {
@@ -4251,19 +4266,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateStateMachineInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateStateMachineSync(UpdateStateMachineInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateStateMachineAsync(UpdateStateMachineInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateStateMachineAsync(UpdateStateMachineInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateActivity asynchronously, invoking a callback when done
 -- @param CreateActivityInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateActivityAsync(CreateActivityInput, cb)
 	assert(CreateActivityInput, "You must provide a CreateActivityInput")
 	local headers = {
@@ -4286,19 +4302,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateActivityInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateActivitySync(CreateActivityInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateActivityAsync(CreateActivityInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateActivityAsync(CreateActivityInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendTaskFailure asynchronously, invoking a callback when done
 -- @param SendTaskFailureInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendTaskFailureAsync(SendTaskFailureInput, cb)
 	assert(SendTaskFailureInput, "You must provide a SendTaskFailureInput")
 	local headers = {
@@ -4321,19 +4338,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendTaskFailureInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendTaskFailureSync(SendTaskFailureInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendTaskFailureAsync(SendTaskFailureInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendTaskFailureAsync(SendTaskFailureInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SendTaskSuccess asynchronously, invoking a callback when done
 -- @param SendTaskSuccessInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SendTaskSuccessAsync(SendTaskSuccessInput, cb)
 	assert(SendTaskSuccessInput, "You must provide a SendTaskSuccessInput")
 	local headers = {
@@ -4356,12 +4374,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SendTaskSuccessInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SendTaskSuccessSync(SendTaskSuccessInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SendTaskSuccessAsync(SendTaskSuccessInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SendTaskSuccessAsync(SendTaskSuccessInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/storagegateway.lua
+++ b/aws-sdk/storagegateway.lua
@@ -8556,7 +8556,7 @@ end
 --
 --- Call UpdateSMBFileShare asynchronously, invoking a callback when done
 -- @param UpdateSMBFileShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSMBFileShareAsync(UpdateSMBFileShareInput, cb)
 	assert(UpdateSMBFileShareInput, "You must provide a UpdateSMBFileShareInput")
 	local headers = {
@@ -8579,19 +8579,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSMBFileShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSMBFileShareSync(UpdateSMBFileShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSMBFileShareAsync(UpdateSMBFileShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSMBFileShareAsync(UpdateSMBFileShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSnapshotSchedule asynchronously, invoking a callback when done
 -- @param DescribeSnapshotScheduleInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSnapshotScheduleAsync(DescribeSnapshotScheduleInput, cb)
 	assert(DescribeSnapshotScheduleInput, "You must provide a DescribeSnapshotScheduleInput")
 	local headers = {
@@ -8614,19 +8615,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSnapshotScheduleInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSnapshotScheduleSync(DescribeSnapshotScheduleInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSnapshotScheduleAsync(DescribeSnapshotScheduleInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSnapshotScheduleAsync(DescribeSnapshotScheduleInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateNFSFileShare asynchronously, invoking a callback when done
 -- @param UpdateNFSFileShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateNFSFileShareAsync(UpdateNFSFileShareInput, cb)
 	assert(UpdateNFSFileShareInput, "You must provide a UpdateNFSFileShareInput")
 	local headers = {
@@ -8649,19 +8651,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateNFSFileShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateNFSFileShareSync(UpdateNFSFileShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateNFSFileShareAsync(UpdateNFSFileShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateNFSFileShareAsync(UpdateNFSFileShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTapeArchives asynchronously, invoking a callback when done
 -- @param DescribeTapeArchivesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTapeArchivesAsync(DescribeTapeArchivesInput, cb)
 	assert(DescribeTapeArchivesInput, "You must provide a DescribeTapeArchivesInput")
 	local headers = {
@@ -8684,19 +8687,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTapeArchivesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTapeArchivesSync(DescribeTapeArchivesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTapeArchivesAsync(DescribeTapeArchivesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTapeArchivesAsync(DescribeTapeArchivesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFileShare asynchronously, invoking a callback when done
 -- @param DeleteFileShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFileShareAsync(DeleteFileShareInput, cb)
 	assert(DeleteFileShareInput, "You must provide a DeleteFileShareInput")
 	local headers = {
@@ -8719,19 +8723,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFileShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFileShareSync(DeleteFileShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFileShareAsync(DeleteFileShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFileShareAsync(DeleteFileShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RefreshCache asynchronously, invoking a callback when done
 -- @param RefreshCacheInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RefreshCacheAsync(RefreshCacheInput, cb)
 	assert(RefreshCacheInput, "You must provide a RefreshCacheInput")
 	local headers = {
@@ -8754,19 +8759,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RefreshCacheInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RefreshCacheSync(RefreshCacheInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RefreshCacheAsync(RefreshCacheInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RefreshCacheAsync(RefreshCacheInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeMaintenanceStartTime asynchronously, invoking a callback when done
 -- @param DescribeMaintenanceStartTimeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeMaintenanceStartTimeAsync(DescribeMaintenanceStartTimeInput, cb)
 	assert(DescribeMaintenanceStartTimeInput, "You must provide a DescribeMaintenanceStartTimeInput")
 	local headers = {
@@ -8789,19 +8795,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeMaintenanceStartTimeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeMaintenanceStartTimeSync(DescribeMaintenanceStartTimeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeMaintenanceStartTimeAsync(DescribeMaintenanceStartTimeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeMaintenanceStartTimeAsync(DescribeMaintenanceStartTimeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGatewayInformation asynchronously, invoking a callback when done
 -- @param DescribeGatewayInformationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGatewayInformationAsync(DescribeGatewayInformationInput, cb)
 	assert(DescribeGatewayInformationInput, "You must provide a DescribeGatewayInformationInput")
 	local headers = {
@@ -8824,19 +8831,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGatewayInformationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGatewayInformationSync(DescribeGatewayInformationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGatewayInformationAsync(DescribeGatewayInformationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGatewayInformationAsync(DescribeGatewayInformationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGatewayInformation asynchronously, invoking a callback when done
 -- @param UpdateGatewayInformationInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGatewayInformationAsync(UpdateGatewayInformationInput, cb)
 	assert(UpdateGatewayInformationInput, "You must provide a UpdateGatewayInformationInput")
 	local headers = {
@@ -8859,19 +8867,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGatewayInformationInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGatewayInformationSync(UpdateGatewayInformationInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGatewayInformationAsync(UpdateGatewayInformationInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGatewayInformationAsync(UpdateGatewayInformationInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisableGateway asynchronously, invoking a callback when done
 -- @param DisableGatewayInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisableGatewayAsync(DisableGatewayInput, cb)
 	assert(DisableGatewayInput, "You must provide a DisableGatewayInput")
 	local headers = {
@@ -8894,19 +8903,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisableGatewayInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisableGatewaySync(DisableGatewayInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisableGatewayAsync(DisableGatewayInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisableGatewayAsync(DisableGatewayInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSMBFileShare asynchronously, invoking a callback when done
 -- @param CreateSMBFileShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSMBFileShareAsync(CreateSMBFileShareInput, cb)
 	assert(CreateSMBFileShareInput, "You must provide a CreateSMBFileShareInput")
 	local headers = {
@@ -8929,19 +8939,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSMBFileShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSMBFileShareSync(CreateSMBFileShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSMBFileShareAsync(CreateSMBFileShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSMBFileShareAsync(CreateSMBFileShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSMBSettings asynchronously, invoking a callback when done
 -- @param DescribeSMBSettingsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSMBSettingsAsync(DescribeSMBSettingsInput, cb)
 	assert(DescribeSMBSettingsInput, "You must provide a DescribeSMBSettingsInput")
 	local headers = {
@@ -8964,19 +8975,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSMBSettingsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSMBSettingsSync(DescribeSMBSettingsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSMBSettingsAsync(DescribeSMBSettingsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSMBSettingsAsync(DescribeSMBSettingsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListFileShares asynchronously, invoking a callback when done
 -- @param ListFileSharesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListFileSharesAsync(ListFileSharesInput, cb)
 	assert(ListFileSharesInput, "You must provide a ListFileSharesInput")
 	local headers = {
@@ -8999,19 +9011,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListFileSharesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListFileSharesSync(ListFileSharesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListFileSharesAsync(ListFileSharesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListFileSharesAsync(ListFileSharesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateMaintenanceStartTime asynchronously, invoking a callback when done
 -- @param UpdateMaintenanceStartTimeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateMaintenanceStartTimeAsync(UpdateMaintenanceStartTimeInput, cb)
 	assert(UpdateMaintenanceStartTimeInput, "You must provide a UpdateMaintenanceStartTimeInput")
 	local headers = {
@@ -9034,19 +9047,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateMaintenanceStartTimeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateMaintenanceStartTimeSync(UpdateMaintenanceStartTimeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateMaintenanceStartTimeAsync(UpdateMaintenanceStartTimeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateMaintenanceStartTimeAsync(UpdateMaintenanceStartTimeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTapes asynchronously, invoking a callback when done
 -- @param CreateTapesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTapesAsync(CreateTapesInput, cb)
 	assert(CreateTapesInput, "You must provide a CreateTapesInput")
 	local headers = {
@@ -9069,19 +9083,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTapesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTapesSync(CreateTapesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTapesAsync(CreateTapesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTapesAsync(CreateTapesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call NotifyWhenUploaded asynchronously, invoking a callback when done
 -- @param NotifyWhenUploadedInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.NotifyWhenUploadedAsync(NotifyWhenUploadedInput, cb)
 	assert(NotifyWhenUploadedInput, "You must provide a NotifyWhenUploadedInput")
 	local headers = {
@@ -9104,19 +9119,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param NotifyWhenUploadedInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.NotifyWhenUploadedSync(NotifyWhenUploadedInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.NotifyWhenUploadedAsync(NotifyWhenUploadedInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.NotifyWhenUploadedAsync(NotifyWhenUploadedInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCachediSCSIVolume asynchronously, invoking a callback when done
 -- @param CreateCachediSCSIVolumeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCachediSCSIVolumeAsync(CreateCachediSCSIVolumeInput, cb)
 	assert(CreateCachediSCSIVolumeInput, "You must provide a CreateCachediSCSIVolumeInput")
 	local headers = {
@@ -9139,19 +9155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCachediSCSIVolumeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCachediSCSIVolumeSync(CreateCachediSCSIVolumeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCachediSCSIVolumeAsync(CreateCachediSCSIVolumeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCachediSCSIVolumeAsync(CreateCachediSCSIVolumeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTapeWithBarcode asynchronously, invoking a callback when done
 -- @param CreateTapeWithBarcodeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTapeWithBarcodeAsync(CreateTapeWithBarcodeInput, cb)
 	assert(CreateTapeWithBarcodeInput, "You must provide a CreateTapeWithBarcodeInput")
 	local headers = {
@@ -9174,19 +9191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTapeWithBarcodeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTapeWithBarcodeSync(CreateTapeWithBarcodeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTapeWithBarcodeAsync(CreateTapeWithBarcodeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTapeWithBarcodeAsync(CreateTapeWithBarcodeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeChapCredentials asynchronously, invoking a callback when done
 -- @param DescribeChapCredentialsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeChapCredentialsAsync(DescribeChapCredentialsInput, cb)
 	assert(DescribeChapCredentialsInput, "You must provide a DescribeChapCredentialsInput")
 	local headers = {
@@ -9209,19 +9227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeChapCredentialsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeChapCredentialsSync(DescribeChapCredentialsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeChapCredentialsAsync(DescribeChapCredentialsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeChapCredentialsAsync(DescribeChapCredentialsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLocalDisks asynchronously, invoking a callback when done
 -- @param ListLocalDisksInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLocalDisksAsync(ListLocalDisksInput, cb)
 	assert(ListLocalDisksInput, "You must provide a ListLocalDisksInput")
 	local headers = {
@@ -9244,19 +9263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLocalDisksInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLocalDisksSync(ListLocalDisksInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLocalDisksAsync(ListLocalDisksInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLocalDisksAsync(ListLocalDisksInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGatewaySoftwareNow asynchronously, invoking a callback when done
 -- @param UpdateGatewaySoftwareNowInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGatewaySoftwareNowAsync(UpdateGatewaySoftwareNowInput, cb)
 	assert(UpdateGatewaySoftwareNowInput, "You must provide a UpdateGatewaySoftwareNowInput")
 	local headers = {
@@ -9279,19 +9299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGatewaySoftwareNowInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGatewaySoftwareNowSync(UpdateGatewaySoftwareNowInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGatewaySoftwareNowAsync(UpdateGatewaySoftwareNowInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGatewaySoftwareNowAsync(UpdateGatewaySoftwareNowInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetCache asynchronously, invoking a callback when done
 -- @param ResetCacheInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetCacheAsync(ResetCacheInput, cb)
 	assert(ResetCacheInput, "You must provide a ResetCacheInput")
 	local headers = {
@@ -9314,19 +9335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetCacheInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetCacheSync(ResetCacheInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetCacheAsync(ResetCacheInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetCacheAsync(ResetCacheInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddTagsToResource asynchronously, invoking a callback when done
 -- @param AddTagsToResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddTagsToResourceAsync(AddTagsToResourceInput, cb)
 	assert(AddTagsToResourceInput, "You must provide a AddTagsToResourceInput")
 	local headers = {
@@ -9349,19 +9371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddTagsToResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddTagsToResourceSync(AddTagsToResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddTagsToResourceAsync(AddTagsToResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddTagsToResourceAsync(AddTagsToResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RetrieveTapeArchive asynchronously, invoking a callback when done
 -- @param RetrieveTapeArchiveInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RetrieveTapeArchiveAsync(RetrieveTapeArchiveInput, cb)
 	assert(RetrieveTapeArchiveInput, "You must provide a RetrieveTapeArchiveInput")
 	local headers = {
@@ -9384,19 +9407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RetrieveTapeArchiveInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RetrieveTapeArchiveSync(RetrieveTapeArchiveInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RetrieveTapeArchiveAsync(RetrieveTapeArchiveInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RetrieveTapeArchiveAsync(RetrieveTapeArchiveInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call JoinDomain asynchronously, invoking a callback when done
 -- @param JoinDomainInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.JoinDomainAsync(JoinDomainInput, cb)
 	assert(JoinDomainInput, "You must provide a JoinDomainInput")
 	local headers = {
@@ -9419,19 +9443,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param JoinDomainInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.JoinDomainSync(JoinDomainInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.JoinDomainAsync(JoinDomainInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.JoinDomainAsync(JoinDomainInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateBandwidthRateLimit asynchronously, invoking a callback when done
 -- @param UpdateBandwidthRateLimitInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateBandwidthRateLimitAsync(UpdateBandwidthRateLimitInput, cb)
 	assert(UpdateBandwidthRateLimitInput, "You must provide a UpdateBandwidthRateLimitInput")
 	local headers = {
@@ -9454,19 +9479,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateBandwidthRateLimitInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateBandwidthRateLimitSync(UpdateBandwidthRateLimitInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateBandwidthRateLimitAsync(UpdateBandwidthRateLimitInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateBandwidthRateLimitAsync(UpdateBandwidthRateLimitInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetLocalConsolePassword asynchronously, invoking a callback when done
 -- @param SetLocalConsolePasswordInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetLocalConsolePasswordAsync(SetLocalConsolePasswordInput, cb)
 	assert(SetLocalConsolePasswordInput, "You must provide a SetLocalConsolePasswordInput")
 	local headers = {
@@ -9489,19 +9515,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetLocalConsolePasswordInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetLocalConsolePasswordSync(SetLocalConsolePasswordInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetLocalConsolePasswordAsync(SetLocalConsolePasswordInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetLocalConsolePasswordAsync(SetLocalConsolePasswordInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVolumeInitiators asynchronously, invoking a callback when done
 -- @param ListVolumeInitiatorsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVolumeInitiatorsAsync(ListVolumeInitiatorsInput, cb)
 	assert(ListVolumeInitiatorsInput, "You must provide a ListVolumeInitiatorsInput")
 	local headers = {
@@ -9524,19 +9551,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVolumeInitiatorsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVolumeInitiatorsSync(ListVolumeInitiatorsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVolumeInitiatorsAsync(ListVolumeInitiatorsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVolumeInitiatorsAsync(ListVolumeInitiatorsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveTagsFromResource asynchronously, invoking a callback when done
 -- @param RemoveTagsFromResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceInput, cb)
 	assert(RemoveTagsFromResourceInput, "You must provide a RemoveTagsFromResourceInput")
 	local headers = {
@@ -9559,19 +9587,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveTagsFromResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveTagsFromResourceSync(RemoveTagsFromResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveTagsFromResourceAsync(RemoveTagsFromResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSnapshotFromVolumeRecoveryPoint asynchronously, invoking a callback when done
 -- @param CreateSnapshotFromVolumeRecoveryPointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSnapshotFromVolumeRecoveryPointAsync(CreateSnapshotFromVolumeRecoveryPointInput, cb)
 	assert(CreateSnapshotFromVolumeRecoveryPointInput, "You must provide a CreateSnapshotFromVolumeRecoveryPointInput")
 	local headers = {
@@ -9594,19 +9623,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSnapshotFromVolumeRecoveryPointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSnapshotFromVolumeRecoveryPointSync(CreateSnapshotFromVolumeRecoveryPointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSnapshotFromVolumeRecoveryPointAsync(CreateSnapshotFromVolumeRecoveryPointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSnapshotFromVolumeRecoveryPointAsync(CreateSnapshotFromVolumeRecoveryPointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSMBFileShares asynchronously, invoking a callback when done
 -- @param DescribeSMBFileSharesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSMBFileSharesAsync(DescribeSMBFileSharesInput, cb)
 	assert(DescribeSMBFileSharesInput, "You must provide a DescribeSMBFileSharesInput")
 	local headers = {
@@ -9629,19 +9659,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSMBFileSharesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSMBFileSharesSync(DescribeSMBFileSharesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSMBFileSharesAsync(DescribeSMBFileSharesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSMBFileSharesAsync(DescribeSMBFileSharesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGateways asynchronously, invoking a callback when done
 -- @param ListGatewaysInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGatewaysAsync(ListGatewaysInput, cb)
 	assert(ListGatewaysInput, "You must provide a ListGatewaysInput")
 	local headers = {
@@ -9664,19 +9695,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGatewaysInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGatewaysSync(ListGatewaysInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGatewaysAsync(ListGatewaysInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGatewaysAsync(ListGatewaysInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteChapCredentials asynchronously, invoking a callback when done
 -- @param DeleteChapCredentialsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteChapCredentialsAsync(DeleteChapCredentialsInput, cb)
 	assert(DeleteChapCredentialsInput, "You must provide a DeleteChapCredentialsInput")
 	local headers = {
@@ -9699,19 +9731,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteChapCredentialsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteChapCredentialsSync(DeleteChapCredentialsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteChapCredentialsAsync(DeleteChapCredentialsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteChapCredentialsAsync(DeleteChapCredentialsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteBandwidthRateLimit asynchronously, invoking a callback when done
 -- @param DeleteBandwidthRateLimitInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteBandwidthRateLimitAsync(DeleteBandwidthRateLimitInput, cb)
 	assert(DeleteBandwidthRateLimitInput, "You must provide a DeleteBandwidthRateLimitInput")
 	local headers = {
@@ -9734,19 +9767,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteBandwidthRateLimitInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteBandwidthRateLimitSync(DeleteBandwidthRateLimitInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteBandwidthRateLimitAsync(DeleteBandwidthRateLimitInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteBandwidthRateLimitAsync(DeleteBandwidthRateLimitInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTapeRecoveryPoints asynchronously, invoking a callback when done
 -- @param DescribeTapeRecoveryPointsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTapeRecoveryPointsAsync(DescribeTapeRecoveryPointsInput, cb)
 	assert(DescribeTapeRecoveryPointsInput, "You must provide a DescribeTapeRecoveryPointsInput")
 	local headers = {
@@ -9769,19 +9803,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTapeRecoveryPointsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTapeRecoveryPointsSync(DescribeTapeRecoveryPointsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTapeRecoveryPointsAsync(DescribeTapeRecoveryPointsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTapeRecoveryPointsAsync(DescribeTapeRecoveryPointsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ActivateGateway asynchronously, invoking a callback when done
 -- @param ActivateGatewayInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ActivateGatewayAsync(ActivateGatewayInput, cb)
 	assert(ActivateGatewayInput, "You must provide a ActivateGatewayInput")
 	local headers = {
@@ -9804,19 +9839,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ActivateGatewayInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ActivateGatewaySync(ActivateGatewayInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ActivateGatewayAsync(ActivateGatewayInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ActivateGatewayAsync(ActivateGatewayInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTapeArchive asynchronously, invoking a callback when done
 -- @param DeleteTapeArchiveInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTapeArchiveAsync(DeleteTapeArchiveInput, cb)
 	assert(DeleteTapeArchiveInput, "You must provide a DeleteTapeArchiveInput")
 	local headers = {
@@ -9839,19 +9875,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTapeArchiveInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTapeArchiveSync(DeleteTapeArchiveInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTapeArchiveAsync(DeleteTapeArchiveInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTapeArchiveAsync(DeleteTapeArchiveInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeVTLDevices asynchronously, invoking a callback when done
 -- @param DescribeVTLDevicesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeVTLDevicesAsync(DescribeVTLDevicesInput, cb)
 	assert(DescribeVTLDevicesInput, "You must provide a DescribeVTLDevicesInput")
 	local headers = {
@@ -9874,19 +9911,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeVTLDevicesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeVTLDevicesSync(DescribeVTLDevicesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeVTLDevicesAsync(DescribeVTLDevicesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeVTLDevicesAsync(DescribeVTLDevicesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddCache asynchronously, invoking a callback when done
 -- @param AddCacheInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddCacheAsync(AddCacheInput, cb)
 	assert(AddCacheInput, "You must provide a AddCacheInput")
 	local headers = {
@@ -9909,19 +9947,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddCacheInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddCacheSync(AddCacheInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddCacheAsync(AddCacheInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddCacheAsync(AddCacheInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVolume asynchronously, invoking a callback when done
 -- @param DeleteVolumeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVolumeAsync(DeleteVolumeInput, cb)
 	assert(DeleteVolumeInput, "You must provide a DeleteVolumeInput")
 	local headers = {
@@ -9944,19 +9983,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVolumeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVolumeSync(DeleteVolumeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVolumeAsync(DeleteVolumeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVolumeAsync(DeleteVolumeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVolumes asynchronously, invoking a callback when done
 -- @param ListVolumesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVolumesAsync(ListVolumesInput, cb)
 	assert(ListVolumesInput, "You must provide a ListVolumesInput")
 	local headers = {
@@ -9979,19 +10019,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVolumesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVolumesSync(ListVolumesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVolumesAsync(ListVolumesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVolumesAsync(ListVolumesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCachediSCSIVolumes asynchronously, invoking a callback when done
 -- @param DescribeCachediSCSIVolumesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCachediSCSIVolumesAsync(DescribeCachediSCSIVolumesInput, cb)
 	assert(DescribeCachediSCSIVolumesInput, "You must provide a DescribeCachediSCSIVolumesInput")
 	local headers = {
@@ -10014,19 +10055,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCachediSCSIVolumesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCachediSCSIVolumesSync(DescribeCachediSCSIVolumesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCachediSCSIVolumesAsync(DescribeCachediSCSIVolumesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCachediSCSIVolumesAsync(DescribeCachediSCSIVolumesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RetrieveTapeRecoveryPoint asynchronously, invoking a callback when done
 -- @param RetrieveTapeRecoveryPointInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RetrieveTapeRecoveryPointAsync(RetrieveTapeRecoveryPointInput, cb)
 	assert(RetrieveTapeRecoveryPointInput, "You must provide a RetrieveTapeRecoveryPointInput")
 	local headers = {
@@ -10049,19 +10091,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RetrieveTapeRecoveryPointInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RetrieveTapeRecoveryPointSync(RetrieveTapeRecoveryPointInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RetrieveTapeRecoveryPointAsync(RetrieveTapeRecoveryPointInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RetrieveTapeRecoveryPointAsync(RetrieveTapeRecoveryPointInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelRetrieval asynchronously, invoking a callback when done
 -- @param CancelRetrievalInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelRetrievalAsync(CancelRetrievalInput, cb)
 	assert(CancelRetrievalInput, "You must provide a CancelRetrievalInput")
 	local headers = {
@@ -10084,19 +10127,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelRetrievalInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelRetrievalSync(CancelRetrievalInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelRetrievalAsync(CancelRetrievalInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelRetrievalAsync(CancelRetrievalInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeBandwidthRateLimit asynchronously, invoking a callback when done
 -- @param DescribeBandwidthRateLimitInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeBandwidthRateLimitAsync(DescribeBandwidthRateLimitInput, cb)
 	assert(DescribeBandwidthRateLimitInput, "You must provide a DescribeBandwidthRateLimitInput")
 	local headers = {
@@ -10119,19 +10163,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeBandwidthRateLimitInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeBandwidthRateLimitSync(DescribeBandwidthRateLimitInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeBandwidthRateLimitAsync(DescribeBandwidthRateLimitInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeBandwidthRateLimitAsync(DescribeBandwidthRateLimitInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStorediSCSIVolumes asynchronously, invoking a callback when done
 -- @param DescribeStorediSCSIVolumesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStorediSCSIVolumesAsync(DescribeStorediSCSIVolumesInput, cb)
 	assert(DescribeStorediSCSIVolumesInput, "You must provide a DescribeStorediSCSIVolumesInput")
 	local headers = {
@@ -10154,19 +10199,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStorediSCSIVolumesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStorediSCSIVolumesSync(DescribeStorediSCSIVolumesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStorediSCSIVolumesAsync(DescribeStorediSCSIVolumesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStorediSCSIVolumesAsync(DescribeStorediSCSIVolumesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVolumeRecoveryPoints asynchronously, invoking a callback when done
 -- @param ListVolumeRecoveryPointsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVolumeRecoveryPointsAsync(ListVolumeRecoveryPointsInput, cb)
 	assert(ListVolumeRecoveryPointsInput, "You must provide a ListVolumeRecoveryPointsInput")
 	local headers = {
@@ -10189,19 +10235,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVolumeRecoveryPointsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVolumeRecoveryPointsSync(ListVolumeRecoveryPointsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVolumeRecoveryPointsAsync(ListVolumeRecoveryPointsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVolumeRecoveryPointsAsync(ListVolumeRecoveryPointsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateChapCredentials asynchronously, invoking a callback when done
 -- @param UpdateChapCredentialsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateChapCredentialsAsync(UpdateChapCredentialsInput, cb)
 	assert(UpdateChapCredentialsInput, "You must provide a UpdateChapCredentialsInput")
 	local headers = {
@@ -10224,19 +10271,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateChapCredentialsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateChapCredentialsSync(UpdateChapCredentialsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateChapCredentialsAsync(UpdateChapCredentialsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateChapCredentialsAsync(UpdateChapCredentialsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartGateway asynchronously, invoking a callback when done
 -- @param StartGatewayInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartGatewayAsync(StartGatewayInput, cb)
 	assert(StartGatewayInput, "You must provide a StartGatewayInput")
 	local headers = {
@@ -10259,19 +10307,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartGatewayInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartGatewaySync(StartGatewayInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartGatewayAsync(StartGatewayInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartGatewayAsync(StartGatewayInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCache asynchronously, invoking a callback when done
 -- @param DescribeCacheInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCacheAsync(DescribeCacheInput, cb)
 	assert(DescribeCacheInput, "You must provide a DescribeCacheInput")
 	local headers = {
@@ -10294,19 +10343,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCacheInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCacheSync(DescribeCacheInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCacheAsync(DescribeCacheInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCacheAsync(DescribeCacheInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddUploadBuffer asynchronously, invoking a callback when done
 -- @param AddUploadBufferInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddUploadBufferAsync(AddUploadBufferInput, cb)
 	assert(AddUploadBufferInput, "You must provide a AddUploadBufferInput")
 	local headers = {
@@ -10329,19 +10379,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddUploadBufferInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddUploadBufferSync(AddUploadBufferInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddUploadBufferAsync(AddUploadBufferInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddUploadBufferAsync(AddUploadBufferInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSnapshotSchedule asynchronously, invoking a callback when done
 -- @param DeleteSnapshotScheduleInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSnapshotScheduleAsync(DeleteSnapshotScheduleInput, cb)
 	assert(DeleteSnapshotScheduleInput, "You must provide a DeleteSnapshotScheduleInput")
 	local headers = {
@@ -10364,19 +10415,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSnapshotScheduleInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSnapshotScheduleSync(DeleteSnapshotScheduleInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSnapshotScheduleAsync(DeleteSnapshotScheduleInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSnapshotScheduleAsync(DeleteSnapshotScheduleInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateVTLDeviceType asynchronously, invoking a callback when done
 -- @param UpdateVTLDeviceTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateVTLDeviceTypeAsync(UpdateVTLDeviceTypeInput, cb)
 	assert(UpdateVTLDeviceTypeInput, "You must provide a UpdateVTLDeviceTypeInput")
 	local headers = {
@@ -10399,19 +10451,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateVTLDeviceTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateVTLDeviceTypeSync(UpdateVTLDeviceTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateVTLDeviceTypeAsync(UpdateVTLDeviceTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateVTLDeviceTypeAsync(UpdateVTLDeviceTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTape asynchronously, invoking a callback when done
 -- @param DeleteTapeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTapeAsync(DeleteTapeInput, cb)
 	assert(DeleteTapeInput, "You must provide a DeleteTapeInput")
 	local headers = {
@@ -10434,19 +10487,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTapeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTapeSync(DeleteTapeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTapeAsync(DeleteTapeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTapeAsync(DeleteTapeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSnapshotSchedule asynchronously, invoking a callback when done
 -- @param UpdateSnapshotScheduleInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSnapshotScheduleAsync(UpdateSnapshotScheduleInput, cb)
 	assert(UpdateSnapshotScheduleInput, "You must provide a UpdateSnapshotScheduleInput")
 	local headers = {
@@ -10469,19 +10523,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSnapshotScheduleInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSnapshotScheduleSync(UpdateSnapshotScheduleInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSnapshotScheduleAsync(UpdateSnapshotScheduleInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSnapshotScheduleAsync(UpdateSnapshotScheduleInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ShutdownGateway asynchronously, invoking a callback when done
 -- @param ShutdownGatewayInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ShutdownGatewayAsync(ShutdownGatewayInput, cb)
 	assert(ShutdownGatewayInput, "You must provide a ShutdownGatewayInput")
 	local headers = {
@@ -10504,19 +10559,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ShutdownGatewayInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ShutdownGatewaySync(ShutdownGatewayInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ShutdownGatewayAsync(ShutdownGatewayInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ShutdownGatewayAsync(ShutdownGatewayInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTapes asynchronously, invoking a callback when done
 -- @param DescribeTapesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTapesAsync(DescribeTapesInput, cb)
 	assert(DescribeTapesInput, "You must provide a DescribeTapesInput")
 	local headers = {
@@ -10539,19 +10595,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTapesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTapesSync(DescribeTapesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTapesAsync(DescribeTapesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTapesAsync(DescribeTapesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNFSFileShare asynchronously, invoking a callback when done
 -- @param CreateNFSFileShareInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNFSFileShareAsync(CreateNFSFileShareInput, cb)
 	assert(CreateNFSFileShareInput, "You must provide a CreateNFSFileShareInput")
 	local headers = {
@@ -10574,19 +10631,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNFSFileShareInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNFSFileShareSync(CreateNFSFileShareInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNFSFileShareAsync(CreateNFSFileShareInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNFSFileShareAsync(CreateNFSFileShareInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateStorediSCSIVolume asynchronously, invoking a callback when done
 -- @param CreateStorediSCSIVolumeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateStorediSCSIVolumeAsync(CreateStorediSCSIVolumeInput, cb)
 	assert(CreateStorediSCSIVolumeInput, "You must provide a CreateStorediSCSIVolumeInput")
 	local headers = {
@@ -10609,19 +10667,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateStorediSCSIVolumeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateStorediSCSIVolumeSync(CreateStorediSCSIVolumeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateStorediSCSIVolumeAsync(CreateStorediSCSIVolumeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateStorediSCSIVolumeAsync(CreateStorediSCSIVolumeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CancelArchival asynchronously, invoking a callback when done
 -- @param CancelArchivalInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CancelArchivalAsync(CancelArchivalInput, cb)
 	assert(CancelArchivalInput, "You must provide a CancelArchivalInput")
 	local headers = {
@@ -10644,19 +10703,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CancelArchivalInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CancelArchivalSync(CancelArchivalInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CancelArchivalAsync(CancelArchivalInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CancelArchivalAsync(CancelArchivalInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call SetSMBGuestPassword asynchronously, invoking a callback when done
 -- @param SetSMBGuestPasswordInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SetSMBGuestPasswordAsync(SetSMBGuestPasswordInput, cb)
 	assert(SetSMBGuestPasswordInput, "You must provide a SetSMBGuestPasswordInput")
 	local headers = {
@@ -10679,19 +10739,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SetSMBGuestPasswordInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SetSMBGuestPasswordSync(SetSMBGuestPasswordInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SetSMBGuestPasswordAsync(SetSMBGuestPasswordInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SetSMBGuestPasswordAsync(SetSMBGuestPasswordInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTapes asynchronously, invoking a callback when done
 -- @param ListTapesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTapesAsync(ListTapesInput, cb)
 	assert(ListTapesInput, "You must provide a ListTapesInput")
 	local headers = {
@@ -10714,19 +10775,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTapesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTapesSync(ListTapesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTapesAsync(ListTapesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTapesAsync(ListTapesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGateway asynchronously, invoking a callback when done
 -- @param DeleteGatewayInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGatewayAsync(DeleteGatewayInput, cb)
 	assert(DeleteGatewayInput, "You must provide a DeleteGatewayInput")
 	local headers = {
@@ -10749,19 +10811,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGatewayInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGatewaySync(DeleteGatewayInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGatewayAsync(DeleteGatewayInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGatewayAsync(DeleteGatewayInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNFSFileShares asynchronously, invoking a callback when done
 -- @param DescribeNFSFileSharesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNFSFileSharesAsync(DescribeNFSFileSharesInput, cb)
 	assert(DescribeNFSFileSharesInput, "You must provide a DescribeNFSFileSharesInput")
 	local headers = {
@@ -10784,19 +10847,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNFSFileSharesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNFSFileSharesSync(DescribeNFSFileSharesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNFSFileSharesAsync(DescribeNFSFileSharesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNFSFileSharesAsync(DescribeNFSFileSharesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeWorkingStorage asynchronously, invoking a callback when done
 -- @param DescribeWorkingStorageInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeWorkingStorageAsync(DescribeWorkingStorageInput, cb)
 	assert(DescribeWorkingStorageInput, "You must provide a DescribeWorkingStorageInput")
 	local headers = {
@@ -10819,19 +10883,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeWorkingStorageInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeWorkingStorageSync(DescribeWorkingStorageInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeWorkingStorageAsync(DescribeWorkingStorageInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeWorkingStorageAsync(DescribeWorkingStorageInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUploadBuffer asynchronously, invoking a callback when done
 -- @param DescribeUploadBufferInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUploadBufferAsync(DescribeUploadBufferInput, cb)
 	assert(DescribeUploadBufferInput, "You must provide a DescribeUploadBufferInput")
 	local headers = {
@@ -10854,19 +10919,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUploadBufferInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUploadBufferSync(DescribeUploadBufferInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUploadBufferAsync(DescribeUploadBufferInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUploadBufferAsync(DescribeUploadBufferInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListTagsForResource asynchronously, invoking a callback when done
 -- @param ListTagsForResourceInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTagsForResourceAsync(ListTagsForResourceInput, cb)
 	assert(ListTagsForResourceInput, "You must provide a ListTagsForResourceInput")
 	local headers = {
@@ -10889,19 +10955,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTagsForResourceInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTagsForResourceSync(ListTagsForResourceInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTagsForResourceAsync(ListTagsForResourceInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTagsForResourceAsync(ListTagsForResourceInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddWorkingStorage asynchronously, invoking a callback when done
 -- @param AddWorkingStorageInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddWorkingStorageAsync(AddWorkingStorageInput, cb)
 	assert(AddWorkingStorageInput, "You must provide a AddWorkingStorageInput")
 	local headers = {
@@ -10924,19 +10991,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddWorkingStorageInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddWorkingStorageSync(AddWorkingStorageInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddWorkingStorageAsync(AddWorkingStorageInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddWorkingStorageAsync(AddWorkingStorageInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSnapshot asynchronously, invoking a callback when done
 -- @param CreateSnapshotInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSnapshotAsync(CreateSnapshotInput, cb)
 	assert(CreateSnapshotInput, "You must provide a CreateSnapshotInput")
 	local headers = {
@@ -10959,12 +11027,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSnapshotInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSnapshotSync(CreateSnapshotInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSnapshotAsync(CreateSnapshotInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSnapshotAsync(CreateSnapshotInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/streams_dynamodb.lua
+++ b/aws-sdk/streams_dynamodb.lua
@@ -1434,7 +1434,7 @@ end
 --
 --- Call GetRecords asynchronously, invoking a callback when done
 -- @param GetRecordsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRecordsAsync(GetRecordsInput, cb)
 	assert(GetRecordsInput, "You must provide a GetRecordsInput")
 	local headers = {
@@ -1457,19 +1457,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRecordsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRecordsSync(GetRecordsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRecordsAsync(GetRecordsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRecordsAsync(GetRecordsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListStreams asynchronously, invoking a callback when done
 -- @param ListStreamsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListStreamsAsync(ListStreamsInput, cb)
 	assert(ListStreamsInput, "You must provide a ListStreamsInput")
 	local headers = {
@@ -1492,19 +1493,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListStreamsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListStreamsSync(ListStreamsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListStreamsAsync(ListStreamsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListStreamsAsync(ListStreamsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetShardIterator asynchronously, invoking a callback when done
 -- @param GetShardIteratorInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetShardIteratorAsync(GetShardIteratorInput, cb)
 	assert(GetShardIteratorInput, "You must provide a GetShardIteratorInput")
 	local headers = {
@@ -1527,19 +1529,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetShardIteratorInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetShardIteratorSync(GetShardIteratorInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetShardIteratorAsync(GetShardIteratorInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetShardIteratorAsync(GetShardIteratorInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeStream asynchronously, invoking a callback when done
 -- @param DescribeStreamInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeStreamAsync(DescribeStreamInput, cb)
 	assert(DescribeStreamInput, "You must provide a DescribeStreamInput")
 	local headers = {
@@ -1562,12 +1565,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeStreamInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeStreamSync(DescribeStreamInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeStreamAsync(DescribeStreamInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeStreamAsync(DescribeStreamInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/sts.lua
+++ b/aws-sdk/sts.lua
@@ -1590,7 +1590,7 @@ end
 --
 --- Call GetFederationToken asynchronously, invoking a callback when done
 -- @param GetFederationTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFederationTokenAsync(GetFederationTokenRequest, cb)
 	assert(GetFederationTokenRequest, "You must provide a GetFederationTokenRequest")
 	local headers = {
@@ -1613,19 +1613,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFederationTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFederationTokenSync(GetFederationTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFederationTokenAsync(GetFederationTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFederationTokenAsync(GetFederationTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssumeRole asynchronously, invoking a callback when done
 -- @param AssumeRoleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssumeRoleAsync(AssumeRoleRequest, cb)
 	assert(AssumeRoleRequest, "You must provide a AssumeRoleRequest")
 	local headers = {
@@ -1648,19 +1649,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssumeRoleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssumeRoleSync(AssumeRoleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssumeRoleAsync(AssumeRoleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssumeRoleAsync(AssumeRoleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DecodeAuthorizationMessage asynchronously, invoking a callback when done
 -- @param DecodeAuthorizationMessageRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DecodeAuthorizationMessageAsync(DecodeAuthorizationMessageRequest, cb)
 	assert(DecodeAuthorizationMessageRequest, "You must provide a DecodeAuthorizationMessageRequest")
 	local headers = {
@@ -1683,19 +1685,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DecodeAuthorizationMessageRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DecodeAuthorizationMessageSync(DecodeAuthorizationMessageRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DecodeAuthorizationMessageAsync(DecodeAuthorizationMessageRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DecodeAuthorizationMessageAsync(DecodeAuthorizationMessageRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssumeRoleWithWebIdentity asynchronously, invoking a callback when done
 -- @param AssumeRoleWithWebIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssumeRoleWithWebIdentityAsync(AssumeRoleWithWebIdentityRequest, cb)
 	assert(AssumeRoleWithWebIdentityRequest, "You must provide a AssumeRoleWithWebIdentityRequest")
 	local headers = {
@@ -1718,19 +1721,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssumeRoleWithWebIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssumeRoleWithWebIdentitySync(AssumeRoleWithWebIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssumeRoleWithWebIdentityAsync(AssumeRoleWithWebIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssumeRoleWithWebIdentityAsync(AssumeRoleWithWebIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSessionToken asynchronously, invoking a callback when done
 -- @param GetSessionTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSessionTokenAsync(GetSessionTokenRequest, cb)
 	assert(GetSessionTokenRequest, "You must provide a GetSessionTokenRequest")
 	local headers = {
@@ -1753,19 +1757,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSessionTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSessionTokenSync(GetSessionTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSessionTokenAsync(GetSessionTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSessionTokenAsync(GetSessionTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCallerIdentity asynchronously, invoking a callback when done
 -- @param GetCallerIdentityRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCallerIdentityAsync(GetCallerIdentityRequest, cb)
 	assert(GetCallerIdentityRequest, "You must provide a GetCallerIdentityRequest")
 	local headers = {
@@ -1788,19 +1793,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCallerIdentityRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCallerIdentitySync(GetCallerIdentityRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCallerIdentityAsync(GetCallerIdentityRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCallerIdentityAsync(GetCallerIdentityRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssumeRoleWithSAML asynchronously, invoking a callback when done
 -- @param AssumeRoleWithSAMLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssumeRoleWithSAMLAsync(AssumeRoleWithSAMLRequest, cb)
 	assert(AssumeRoleWithSAMLRequest, "You must provide a AssumeRoleWithSAMLRequest")
 	local headers = {
@@ -1823,12 +1829,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssumeRoleWithSAMLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssumeRoleWithSAMLSync(AssumeRoleWithSAMLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssumeRoleWithSAMLAsync(AssumeRoleWithSAMLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssumeRoleWithSAMLAsync(AssumeRoleWithSAMLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/support.lua
+++ b/aws-sdk/support.lua
@@ -2952,7 +2952,7 @@ end
 --
 --- Call CreateCase asynchronously, invoking a callback when done
 -- @param CreateCaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCaseAsync(CreateCaseRequest, cb)
 	assert(CreateCaseRequest, "You must provide a CreateCaseRequest")
 	local headers = {
@@ -2975,19 +2975,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCaseSync(CreateCaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCaseAsync(CreateCaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCaseAsync(CreateCaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddAttachmentsToSet asynchronously, invoking a callback when done
 -- @param AddAttachmentsToSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddAttachmentsToSetAsync(AddAttachmentsToSetRequest, cb)
 	assert(AddAttachmentsToSetRequest, "You must provide a AddAttachmentsToSetRequest")
 	local headers = {
@@ -3010,19 +3011,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddAttachmentsToSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddAttachmentsToSetSync(AddAttachmentsToSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddAttachmentsToSetAsync(AddAttachmentsToSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddAttachmentsToSetAsync(AddAttachmentsToSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddCommunicationToCase asynchronously, invoking a callback when done
 -- @param AddCommunicationToCaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddCommunicationToCaseAsync(AddCommunicationToCaseRequest, cb)
 	assert(AddCommunicationToCaseRequest, "You must provide a AddCommunicationToCaseRequest")
 	local headers = {
@@ -3045,19 +3047,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddCommunicationToCaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddCommunicationToCaseSync(AddCommunicationToCaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddCommunicationToCaseAsync(AddCommunicationToCaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddCommunicationToCaseAsync(AddCommunicationToCaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTrustedAdvisorCheckRefreshStatuses asynchronously, invoking a callback when done
 -- @param DescribeTrustedAdvisorCheckRefreshStatusesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTrustedAdvisorCheckRefreshStatusesAsync(DescribeTrustedAdvisorCheckRefreshStatusesRequest, cb)
 	assert(DescribeTrustedAdvisorCheckRefreshStatusesRequest, "You must provide a DescribeTrustedAdvisorCheckRefreshStatusesRequest")
 	local headers = {
@@ -3080,19 +3083,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTrustedAdvisorCheckRefreshStatusesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTrustedAdvisorCheckRefreshStatusesSync(DescribeTrustedAdvisorCheckRefreshStatusesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTrustedAdvisorCheckRefreshStatusesAsync(DescribeTrustedAdvisorCheckRefreshStatusesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTrustedAdvisorCheckRefreshStatusesAsync(DescribeTrustedAdvisorCheckRefreshStatusesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTrustedAdvisorCheckResult asynchronously, invoking a callback when done
 -- @param DescribeTrustedAdvisorCheckResultRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTrustedAdvisorCheckResultAsync(DescribeTrustedAdvisorCheckResultRequest, cb)
 	assert(DescribeTrustedAdvisorCheckResultRequest, "You must provide a DescribeTrustedAdvisorCheckResultRequest")
 	local headers = {
@@ -3115,19 +3119,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTrustedAdvisorCheckResultRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTrustedAdvisorCheckResultSync(DescribeTrustedAdvisorCheckResultRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTrustedAdvisorCheckResultAsync(DescribeTrustedAdvisorCheckResultRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTrustedAdvisorCheckResultAsync(DescribeTrustedAdvisorCheckResultRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResolveCase asynchronously, invoking a callback when done
 -- @param ResolveCaseRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResolveCaseAsync(ResolveCaseRequest, cb)
 	assert(ResolveCaseRequest, "You must provide a ResolveCaseRequest")
 	local headers = {
@@ -3150,19 +3155,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResolveCaseRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResolveCaseSync(ResolveCaseRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResolveCaseAsync(ResolveCaseRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResolveCaseAsync(ResolveCaseRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeSeverityLevels asynchronously, invoking a callback when done
 -- @param DescribeSeverityLevelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeSeverityLevelsAsync(DescribeSeverityLevelsRequest, cb)
 	assert(DescribeSeverityLevelsRequest, "You must provide a DescribeSeverityLevelsRequest")
 	local headers = {
@@ -3185,19 +3191,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeSeverityLevelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeSeverityLevelsSync(DescribeSeverityLevelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeSeverityLevelsAsync(DescribeSeverityLevelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeSeverityLevelsAsync(DescribeSeverityLevelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCases asynchronously, invoking a callback when done
 -- @param DescribeCasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCasesAsync(DescribeCasesRequest, cb)
 	assert(DescribeCasesRequest, "You must provide a DescribeCasesRequest")
 	local headers = {
@@ -3220,19 +3227,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCasesSync(DescribeCasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCasesAsync(DescribeCasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCasesAsync(DescribeCasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RefreshTrustedAdvisorCheck asynchronously, invoking a callback when done
 -- @param RefreshTrustedAdvisorCheckRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RefreshTrustedAdvisorCheckAsync(RefreshTrustedAdvisorCheckRequest, cb)
 	assert(RefreshTrustedAdvisorCheckRequest, "You must provide a RefreshTrustedAdvisorCheckRequest")
 	local headers = {
@@ -3255,19 +3263,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RefreshTrustedAdvisorCheckRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RefreshTrustedAdvisorCheckSync(RefreshTrustedAdvisorCheckRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RefreshTrustedAdvisorCheckAsync(RefreshTrustedAdvisorCheckRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RefreshTrustedAdvisorCheckAsync(RefreshTrustedAdvisorCheckRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeAttachment asynchronously, invoking a callback when done
 -- @param DescribeAttachmentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeAttachmentAsync(DescribeAttachmentRequest, cb)
 	assert(DescribeAttachmentRequest, "You must provide a DescribeAttachmentRequest")
 	local headers = {
@@ -3290,19 +3299,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeAttachmentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeAttachmentSync(DescribeAttachmentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeAttachmentAsync(DescribeAttachmentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeAttachmentAsync(DescribeAttachmentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTrustedAdvisorChecks asynchronously, invoking a callback when done
 -- @param DescribeTrustedAdvisorChecksRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTrustedAdvisorChecksAsync(DescribeTrustedAdvisorChecksRequest, cb)
 	assert(DescribeTrustedAdvisorChecksRequest, "You must provide a DescribeTrustedAdvisorChecksRequest")
 	local headers = {
@@ -3325,19 +3335,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTrustedAdvisorChecksRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTrustedAdvisorChecksSync(DescribeTrustedAdvisorChecksRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTrustedAdvisorChecksAsync(DescribeTrustedAdvisorChecksRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTrustedAdvisorChecksAsync(DescribeTrustedAdvisorChecksRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTrustedAdvisorCheckSummaries asynchronously, invoking a callback when done
 -- @param DescribeTrustedAdvisorCheckSummariesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTrustedAdvisorCheckSummariesAsync(DescribeTrustedAdvisorCheckSummariesRequest, cb)
 	assert(DescribeTrustedAdvisorCheckSummariesRequest, "You must provide a DescribeTrustedAdvisorCheckSummariesRequest")
 	local headers = {
@@ -3360,19 +3371,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTrustedAdvisorCheckSummariesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTrustedAdvisorCheckSummariesSync(DescribeTrustedAdvisorCheckSummariesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTrustedAdvisorCheckSummariesAsync(DescribeTrustedAdvisorCheckSummariesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTrustedAdvisorCheckSummariesAsync(DescribeTrustedAdvisorCheckSummariesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeCommunications asynchronously, invoking a callback when done
 -- @param DescribeCommunicationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCommunicationsAsync(DescribeCommunicationsRequest, cb)
 	assert(DescribeCommunicationsRequest, "You must provide a DescribeCommunicationsRequest")
 	local headers = {
@@ -3395,19 +3407,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCommunicationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCommunicationsSync(DescribeCommunicationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCommunicationsAsync(DescribeCommunicationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCommunicationsAsync(DescribeCommunicationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeServices asynchronously, invoking a callback when done
 -- @param DescribeServicesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeServicesAsync(DescribeServicesRequest, cb)
 	assert(DescribeServicesRequest, "You must provide a DescribeServicesRequest")
 	local headers = {
@@ -3430,12 +3443,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeServicesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeServicesSync(DescribeServicesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeServicesAsync(DescribeServicesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeServicesAsync(DescribeServicesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/swf.lua
+++ b/aws-sdk/swf.lua
@@ -8045,7 +8045,7 @@ end
 --
 --- Call SignalWorkflowExecution asynchronously, invoking a callback when done
 -- @param SignalWorkflowExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.SignalWorkflowExecutionAsync(SignalWorkflowExecutionInput, cb)
 	assert(SignalWorkflowExecutionInput, "You must provide a SignalWorkflowExecutionInput")
 	local headers = {
@@ -8068,19 +8068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param SignalWorkflowExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.SignalWorkflowExecutionSync(SignalWorkflowExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.SignalWorkflowExecutionAsync(SignalWorkflowExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.SignalWorkflowExecutionAsync(SignalWorkflowExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeWorkflowExecution asynchronously, invoking a callback when done
 -- @param DescribeWorkflowExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeWorkflowExecutionAsync(DescribeWorkflowExecutionInput, cb)
 	assert(DescribeWorkflowExecutionInput, "You must provide a DescribeWorkflowExecutionInput")
 	local headers = {
@@ -8103,19 +8104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeWorkflowExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeWorkflowExecutionSync(DescribeWorkflowExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeWorkflowExecutionAsync(DescribeWorkflowExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeWorkflowExecutionAsync(DescribeWorkflowExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetWorkflowExecutionHistory asynchronously, invoking a callback when done
 -- @param GetWorkflowExecutionHistoryInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetWorkflowExecutionHistoryAsync(GetWorkflowExecutionHistoryInput, cb)
 	assert(GetWorkflowExecutionHistoryInput, "You must provide a GetWorkflowExecutionHistoryInput")
 	local headers = {
@@ -8138,19 +8140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetWorkflowExecutionHistoryInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetWorkflowExecutionHistorySync(GetWorkflowExecutionHistoryInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetWorkflowExecutionHistoryAsync(GetWorkflowExecutionHistoryInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetWorkflowExecutionHistoryAsync(GetWorkflowExecutionHistoryInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CountOpenWorkflowExecutions asynchronously, invoking a callback when done
 -- @param CountOpenWorkflowExecutionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CountOpenWorkflowExecutionsAsync(CountOpenWorkflowExecutionsInput, cb)
 	assert(CountOpenWorkflowExecutionsInput, "You must provide a CountOpenWorkflowExecutionsInput")
 	local headers = {
@@ -8173,19 +8176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CountOpenWorkflowExecutionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CountOpenWorkflowExecutionsSync(CountOpenWorkflowExecutionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CountOpenWorkflowExecutionsAsync(CountOpenWorkflowExecutionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CountOpenWorkflowExecutionsAsync(CountOpenWorkflowExecutionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RespondActivityTaskFailed asynchronously, invoking a callback when done
 -- @param RespondActivityTaskFailedInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RespondActivityTaskFailedAsync(RespondActivityTaskFailedInput, cb)
 	assert(RespondActivityTaskFailedInput, "You must provide a RespondActivityTaskFailedInput")
 	local headers = {
@@ -8208,19 +8212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RespondActivityTaskFailedInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RespondActivityTaskFailedSync(RespondActivityTaskFailedInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RespondActivityTaskFailedAsync(RespondActivityTaskFailedInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RespondActivityTaskFailedAsync(RespondActivityTaskFailedInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PollForActivityTask asynchronously, invoking a callback when done
 -- @param PollForActivityTaskInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PollForActivityTaskAsync(PollForActivityTaskInput, cb)
 	assert(PollForActivityTaskInput, "You must provide a PollForActivityTaskInput")
 	local headers = {
@@ -8243,19 +8248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PollForActivityTaskInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PollForActivityTaskSync(PollForActivityTaskInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PollForActivityTaskAsync(PollForActivityTaskInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PollForActivityTaskAsync(PollForActivityTaskInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListDomains asynchronously, invoking a callback when done
 -- @param ListDomainsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListDomainsAsync(ListDomainsInput, cb)
 	assert(ListDomainsInput, "You must provide a ListDomainsInput")
 	local headers = {
@@ -8278,19 +8284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListDomainsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListDomainsSync(ListDomainsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListDomainsAsync(ListDomainsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListDomainsAsync(ListDomainsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartWorkflowExecution asynchronously, invoking a callback when done
 -- @param StartWorkflowExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartWorkflowExecutionAsync(StartWorkflowExecutionInput, cb)
 	assert(StartWorkflowExecutionInput, "You must provide a StartWorkflowExecutionInput")
 	local headers = {
@@ -8313,19 +8320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartWorkflowExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartWorkflowExecutionSync(StartWorkflowExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartWorkflowExecutionAsync(StartWorkflowExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartWorkflowExecutionAsync(StartWorkflowExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RespondDecisionTaskCompleted asynchronously, invoking a callback when done
 -- @param RespondDecisionTaskCompletedInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RespondDecisionTaskCompletedAsync(RespondDecisionTaskCompletedInput, cb)
 	assert(RespondDecisionTaskCompletedInput, "You must provide a RespondDecisionTaskCompletedInput")
 	local headers = {
@@ -8348,19 +8356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RespondDecisionTaskCompletedInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RespondDecisionTaskCompletedSync(RespondDecisionTaskCompletedInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RespondDecisionTaskCompletedAsync(RespondDecisionTaskCompletedInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RespondDecisionTaskCompletedAsync(RespondDecisionTaskCompletedInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterActivityType asynchronously, invoking a callback when done
 -- @param RegisterActivityTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterActivityTypeAsync(RegisterActivityTypeInput, cb)
 	assert(RegisterActivityTypeInput, "You must provide a RegisterActivityTypeInput")
 	local headers = {
@@ -8383,19 +8392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterActivityTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterActivityTypeSync(RegisterActivityTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterActivityTypeAsync(RegisterActivityTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterActivityTypeAsync(RegisterActivityTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RequestCancelWorkflowExecution asynchronously, invoking a callback when done
 -- @param RequestCancelWorkflowExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RequestCancelWorkflowExecutionAsync(RequestCancelWorkflowExecutionInput, cb)
 	assert(RequestCancelWorkflowExecutionInput, "You must provide a RequestCancelWorkflowExecutionInput")
 	local headers = {
@@ -8418,19 +8428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RequestCancelWorkflowExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RequestCancelWorkflowExecutionSync(RequestCancelWorkflowExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RequestCancelWorkflowExecutionAsync(RequestCancelWorkflowExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RequestCancelWorkflowExecutionAsync(RequestCancelWorkflowExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListActivityTypes asynchronously, invoking a callback when done
 -- @param ListActivityTypesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListActivityTypesAsync(ListActivityTypesInput, cb)
 	assert(ListActivityTypesInput, "You must provide a ListActivityTypesInput")
 	local headers = {
@@ -8453,19 +8464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListActivityTypesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListActivityTypesSync(ListActivityTypesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListActivityTypesAsync(ListActivityTypesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListActivityTypesAsync(ListActivityTypesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PollForDecisionTask asynchronously, invoking a callback when done
 -- @param PollForDecisionTaskInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PollForDecisionTaskAsync(PollForDecisionTaskInput, cb)
 	assert(PollForDecisionTaskInput, "You must provide a PollForDecisionTaskInput")
 	local headers = {
@@ -8488,19 +8500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PollForDecisionTaskInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PollForDecisionTaskSync(PollForDecisionTaskInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PollForDecisionTaskAsync(PollForDecisionTaskInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PollForDecisionTaskAsync(PollForDecisionTaskInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOpenWorkflowExecutions asynchronously, invoking a callback when done
 -- @param ListOpenWorkflowExecutionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOpenWorkflowExecutionsAsync(ListOpenWorkflowExecutionsInput, cb)
 	assert(ListOpenWorkflowExecutionsInput, "You must provide a ListOpenWorkflowExecutionsInput")
 	local headers = {
@@ -8523,19 +8536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOpenWorkflowExecutionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOpenWorkflowExecutionsSync(ListOpenWorkflowExecutionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOpenWorkflowExecutionsAsync(ListOpenWorkflowExecutionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOpenWorkflowExecutionsAsync(ListOpenWorkflowExecutionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CountClosedWorkflowExecutions asynchronously, invoking a callback when done
 -- @param CountClosedWorkflowExecutionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CountClosedWorkflowExecutionsAsync(CountClosedWorkflowExecutionsInput, cb)
 	assert(CountClosedWorkflowExecutionsInput, "You must provide a CountClosedWorkflowExecutionsInput")
 	local headers = {
@@ -8558,19 +8572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CountClosedWorkflowExecutionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CountClosedWorkflowExecutionsSync(CountClosedWorkflowExecutionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CountClosedWorkflowExecutionsAsync(CountClosedWorkflowExecutionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CountClosedWorkflowExecutionsAsync(CountClosedWorkflowExecutionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterWorkflowType asynchronously, invoking a callback when done
 -- @param RegisterWorkflowTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterWorkflowTypeAsync(RegisterWorkflowTypeInput, cb)
 	assert(RegisterWorkflowTypeInput, "You must provide a RegisterWorkflowTypeInput")
 	local headers = {
@@ -8593,19 +8608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterWorkflowTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterWorkflowTypeSync(RegisterWorkflowTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterWorkflowTypeAsync(RegisterWorkflowTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterWorkflowTypeAsync(RegisterWorkflowTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDomain asynchronously, invoking a callback when done
 -- @param DescribeDomainInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDomainAsync(DescribeDomainInput, cb)
 	assert(DescribeDomainInput, "You must provide a DescribeDomainInput")
 	local headers = {
@@ -8628,19 +8644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDomainInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDomainSync(DescribeDomainInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDomainAsync(DescribeDomainInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDomainAsync(DescribeDomainInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListClosedWorkflowExecutions asynchronously, invoking a callback when done
 -- @param ListClosedWorkflowExecutionsInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListClosedWorkflowExecutionsAsync(ListClosedWorkflowExecutionsInput, cb)
 	assert(ListClosedWorkflowExecutionsInput, "You must provide a ListClosedWorkflowExecutionsInput")
 	local headers = {
@@ -8663,19 +8680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListClosedWorkflowExecutionsInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListClosedWorkflowExecutionsSync(ListClosedWorkflowExecutionsInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListClosedWorkflowExecutionsAsync(ListClosedWorkflowExecutionsInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListClosedWorkflowExecutionsAsync(ListClosedWorkflowExecutionsInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateWorkflowExecution asynchronously, invoking a callback when done
 -- @param TerminateWorkflowExecutionInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateWorkflowExecutionAsync(TerminateWorkflowExecutionInput, cb)
 	assert(TerminateWorkflowExecutionInput, "You must provide a TerminateWorkflowExecutionInput")
 	local headers = {
@@ -8698,19 +8716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateWorkflowExecutionInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateWorkflowExecutionSync(TerminateWorkflowExecutionInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateWorkflowExecutionAsync(TerminateWorkflowExecutionInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateWorkflowExecutionAsync(TerminateWorkflowExecutionInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeprecateWorkflowType asynchronously, invoking a callback when done
 -- @param DeprecateWorkflowTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeprecateWorkflowTypeAsync(DeprecateWorkflowTypeInput, cb)
 	assert(DeprecateWorkflowTypeInput, "You must provide a DeprecateWorkflowTypeInput")
 	local headers = {
@@ -8733,19 +8752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeprecateWorkflowTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeprecateWorkflowTypeSync(DeprecateWorkflowTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeprecateWorkflowTypeAsync(DeprecateWorkflowTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeprecateWorkflowTypeAsync(DeprecateWorkflowTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeActivityType asynchronously, invoking a callback when done
 -- @param DescribeActivityTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeActivityTypeAsync(DescribeActivityTypeInput, cb)
 	assert(DescribeActivityTypeInput, "You must provide a DescribeActivityTypeInput")
 	local headers = {
@@ -8768,19 +8788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeActivityTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeActivityTypeSync(DescribeActivityTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeActivityTypeAsync(DescribeActivityTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeActivityTypeAsync(DescribeActivityTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CountPendingDecisionTasks asynchronously, invoking a callback when done
 -- @param CountPendingDecisionTasksInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CountPendingDecisionTasksAsync(CountPendingDecisionTasksInput, cb)
 	assert(CountPendingDecisionTasksInput, "You must provide a CountPendingDecisionTasksInput")
 	local headers = {
@@ -8803,19 +8824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CountPendingDecisionTasksInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CountPendingDecisionTasksSync(CountPendingDecisionTasksInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CountPendingDecisionTasksAsync(CountPendingDecisionTasksInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CountPendingDecisionTasksAsync(CountPendingDecisionTasksInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListWorkflowTypes asynchronously, invoking a callback when done
 -- @param ListWorkflowTypesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListWorkflowTypesAsync(ListWorkflowTypesInput, cb)
 	assert(ListWorkflowTypesInput, "You must provide a ListWorkflowTypesInput")
 	local headers = {
@@ -8838,19 +8860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListWorkflowTypesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListWorkflowTypesSync(ListWorkflowTypesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListWorkflowTypesAsync(ListWorkflowTypesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListWorkflowTypesAsync(ListWorkflowTypesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeprecateDomain asynchronously, invoking a callback when done
 -- @param DeprecateDomainInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeprecateDomainAsync(DeprecateDomainInput, cb)
 	assert(DeprecateDomainInput, "You must provide a DeprecateDomainInput")
 	local headers = {
@@ -8873,19 +8896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeprecateDomainInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeprecateDomainSync(DeprecateDomainInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeprecateDomainAsync(DeprecateDomainInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeprecateDomainAsync(DeprecateDomainInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RespondActivityTaskCanceled asynchronously, invoking a callback when done
 -- @param RespondActivityTaskCanceledInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RespondActivityTaskCanceledAsync(RespondActivityTaskCanceledInput, cb)
 	assert(RespondActivityTaskCanceledInput, "You must provide a RespondActivityTaskCanceledInput")
 	local headers = {
@@ -8908,19 +8932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RespondActivityTaskCanceledInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RespondActivityTaskCanceledSync(RespondActivityTaskCanceledInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RespondActivityTaskCanceledAsync(RespondActivityTaskCanceledInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RespondActivityTaskCanceledAsync(RespondActivityTaskCanceledInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeWorkflowType asynchronously, invoking a callback when done
 -- @param DescribeWorkflowTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeWorkflowTypeAsync(DescribeWorkflowTypeInput, cb)
 	assert(DescribeWorkflowTypeInput, "You must provide a DescribeWorkflowTypeInput")
 	local headers = {
@@ -8943,19 +8968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeWorkflowTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeWorkflowTypeSync(DescribeWorkflowTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeWorkflowTypeAsync(DescribeWorkflowTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeWorkflowTypeAsync(DescribeWorkflowTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterDomain asynchronously, invoking a callback when done
 -- @param RegisterDomainInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterDomainAsync(RegisterDomainInput, cb)
 	assert(RegisterDomainInput, "You must provide a RegisterDomainInput")
 	local headers = {
@@ -8978,19 +9004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterDomainInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterDomainSync(RegisterDomainInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterDomainAsync(RegisterDomainInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterDomainAsync(RegisterDomainInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RecordActivityTaskHeartbeat asynchronously, invoking a callback when done
 -- @param RecordActivityTaskHeartbeatInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RecordActivityTaskHeartbeatAsync(RecordActivityTaskHeartbeatInput, cb)
 	assert(RecordActivityTaskHeartbeatInput, "You must provide a RecordActivityTaskHeartbeatInput")
 	local headers = {
@@ -9013,19 +9040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RecordActivityTaskHeartbeatInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RecordActivityTaskHeartbeatSync(RecordActivityTaskHeartbeatInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RecordActivityTaskHeartbeatAsync(RecordActivityTaskHeartbeatInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RecordActivityTaskHeartbeatAsync(RecordActivityTaskHeartbeatInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CountPendingActivityTasks asynchronously, invoking a callback when done
 -- @param CountPendingActivityTasksInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CountPendingActivityTasksAsync(CountPendingActivityTasksInput, cb)
 	assert(CountPendingActivityTasksInput, "You must provide a CountPendingActivityTasksInput")
 	local headers = {
@@ -9048,19 +9076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CountPendingActivityTasksInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CountPendingActivityTasksSync(CountPendingActivityTasksInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CountPendingActivityTasksAsync(CountPendingActivityTasksInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CountPendingActivityTasksAsync(CountPendingActivityTasksInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeprecateActivityType asynchronously, invoking a callback when done
 -- @param DeprecateActivityTypeInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeprecateActivityTypeAsync(DeprecateActivityTypeInput, cb)
 	assert(DeprecateActivityTypeInput, "You must provide a DeprecateActivityTypeInput")
 	local headers = {
@@ -9083,19 +9112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeprecateActivityTypeInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeprecateActivityTypeSync(DeprecateActivityTypeInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeprecateActivityTypeAsync(DeprecateActivityTypeInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeprecateActivityTypeAsync(DeprecateActivityTypeInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RespondActivityTaskCompleted asynchronously, invoking a callback when done
 -- @param RespondActivityTaskCompletedInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RespondActivityTaskCompletedAsync(RespondActivityTaskCompletedInput, cb)
 	assert(RespondActivityTaskCompletedInput, "You must provide a RespondActivityTaskCompletedInput")
 	local headers = {
@@ -9118,12 +9148,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RespondActivityTaskCompletedInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RespondActivityTaskCompletedSync(RespondActivityTaskCompletedInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RespondActivityTaskCompletedAsync(RespondActivityTaskCompletedInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RespondActivityTaskCompletedAsync(RespondActivityTaskCompletedInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/tagging.lua
+++ b/aws-sdk/tagging.lua
@@ -1089,7 +1089,7 @@ end
 --
 --- Call GetTagKeys asynchronously, invoking a callback when done
 -- @param GetTagKeysInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTagKeysAsync(GetTagKeysInput, cb)
 	assert(GetTagKeysInput, "You must provide a GetTagKeysInput")
 	local headers = {
@@ -1112,19 +1112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTagKeysInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTagKeysSync(GetTagKeysInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTagKeysAsync(GetTagKeysInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTagKeysAsync(GetTagKeysInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TagResources asynchronously, invoking a callback when done
 -- @param TagResourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TagResourcesAsync(TagResourcesInput, cb)
 	assert(TagResourcesInput, "You must provide a TagResourcesInput")
 	local headers = {
@@ -1147,19 +1148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TagResourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TagResourcesSync(TagResourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TagResourcesAsync(TagResourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TagResourcesAsync(TagResourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UntagResources asynchronously, invoking a callback when done
 -- @param UntagResourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UntagResourcesAsync(UntagResourcesInput, cb)
 	assert(UntagResourcesInput, "You must provide a UntagResourcesInput")
 	local headers = {
@@ -1182,19 +1184,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UntagResourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UntagResourcesSync(UntagResourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UntagResourcesAsync(UntagResourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UntagResourcesAsync(UntagResourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTagValues asynchronously, invoking a callback when done
 -- @param GetTagValuesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTagValuesAsync(GetTagValuesInput, cb)
 	assert(GetTagValuesInput, "You must provide a GetTagValuesInput")
 	local headers = {
@@ -1217,19 +1220,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTagValuesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTagValuesSync(GetTagValuesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTagValuesAsync(GetTagValuesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTagValuesAsync(GetTagValuesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetResources asynchronously, invoking a callback when done
 -- @param GetResourcesInput
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetResourcesAsync(GetResourcesInput, cb)
 	assert(GetResourcesInput, "You must provide a GetResourcesInput")
 	local headers = {
@@ -1252,12 +1256,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetResourcesInput
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetResourcesSync(GetResourcesInput, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetResourcesAsync(GetResourcesInput, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetResourcesAsync(GetResourcesInput, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/transcribe.lua
+++ b/aws-sdk/transcribe.lua
@@ -1314,7 +1314,7 @@ end
 --
 --- Call ListTranscriptionJobs asynchronously, invoking a callback when done
 -- @param ListTranscriptionJobsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListTranscriptionJobsAsync(ListTranscriptionJobsRequest, cb)
 	assert(ListTranscriptionJobsRequest, "You must provide a ListTranscriptionJobsRequest")
 	local headers = {
@@ -1337,19 +1337,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListTranscriptionJobsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListTranscriptionJobsSync(ListTranscriptionJobsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListTranscriptionJobsAsync(ListTranscriptionJobsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListTranscriptionJobsAsync(ListTranscriptionJobsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteTranscriptionJob asynchronously, invoking a callback when done
 -- @param DeleteTranscriptionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTranscriptionJobAsync(DeleteTranscriptionJobRequest, cb)
 	assert(DeleteTranscriptionJobRequest, "You must provide a DeleteTranscriptionJobRequest")
 	local headers = {
@@ -1372,19 +1373,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTranscriptionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTranscriptionJobSync(DeleteTranscriptionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTranscriptionJobAsync(DeleteTranscriptionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTranscriptionJobAsync(DeleteTranscriptionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateVocabulary asynchronously, invoking a callback when done
 -- @param UpdateVocabularyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateVocabularyAsync(UpdateVocabularyRequest, cb)
 	assert(UpdateVocabularyRequest, "You must provide a UpdateVocabularyRequest")
 	local headers = {
@@ -1407,19 +1409,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateVocabularyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateVocabularySync(UpdateVocabularyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateVocabularyAsync(UpdateVocabularyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateVocabularyAsync(UpdateVocabularyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateVocabulary asynchronously, invoking a callback when done
 -- @param CreateVocabularyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateVocabularyAsync(CreateVocabularyRequest, cb)
 	assert(CreateVocabularyRequest, "You must provide a CreateVocabularyRequest")
 	local headers = {
@@ -1442,19 +1445,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateVocabularyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateVocabularySync(CreateVocabularyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateVocabularyAsync(CreateVocabularyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateVocabularyAsync(CreateVocabularyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListVocabularies asynchronously, invoking a callback when done
 -- @param ListVocabulariesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListVocabulariesAsync(ListVocabulariesRequest, cb)
 	assert(ListVocabulariesRequest, "You must provide a ListVocabulariesRequest")
 	local headers = {
@@ -1477,19 +1481,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListVocabulariesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListVocabulariesSync(ListVocabulariesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListVocabulariesAsync(ListVocabulariesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListVocabulariesAsync(ListVocabulariesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartTranscriptionJob asynchronously, invoking a callback when done
 -- @param StartTranscriptionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartTranscriptionJobAsync(StartTranscriptionJobRequest, cb)
 	assert(StartTranscriptionJobRequest, "You must provide a StartTranscriptionJobRequest")
 	local headers = {
@@ -1512,19 +1517,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartTranscriptionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartTranscriptionJobSync(StartTranscriptionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartTranscriptionJobAsync(StartTranscriptionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartTranscriptionJobAsync(StartTranscriptionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetVocabulary asynchronously, invoking a callback when done
 -- @param GetVocabularyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetVocabularyAsync(GetVocabularyRequest, cb)
 	assert(GetVocabularyRequest, "You must provide a GetVocabularyRequest")
 	local headers = {
@@ -1547,19 +1553,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetVocabularyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetVocabularySync(GetVocabularyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetVocabularyAsync(GetVocabularyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetVocabularyAsync(GetVocabularyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteVocabulary asynchronously, invoking a callback when done
 -- @param DeleteVocabularyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteVocabularyAsync(DeleteVocabularyRequest, cb)
 	assert(DeleteVocabularyRequest, "You must provide a DeleteVocabularyRequest")
 	local headers = {
@@ -1582,19 +1589,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteVocabularyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteVocabularySync(DeleteVocabularyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteVocabularyAsync(DeleteVocabularyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteVocabularyAsync(DeleteVocabularyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTranscriptionJob asynchronously, invoking a callback when done
 -- @param GetTranscriptionJobRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTranscriptionJobAsync(GetTranscriptionJobRequest, cb)
 	assert(GetTranscriptionJobRequest, "You must provide a GetTranscriptionJobRequest")
 	local headers = {
@@ -1617,12 +1625,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTranscriptionJobRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTranscriptionJobSync(GetTranscriptionJobRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTranscriptionJobAsync(GetTranscriptionJobRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTranscriptionJobAsync(GetTranscriptionJobRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/translate.lua
+++ b/aws-sdk/translate.lua
@@ -464,7 +464,7 @@ end
 --
 --- Call TranslateText asynchronously, invoking a callback when done
 -- @param TranslateTextRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TranslateTextAsync(TranslateTextRequest, cb)
 	assert(TranslateTextRequest, "You must provide a TranslateTextRequest")
 	local headers = {
@@ -487,12 +487,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TranslateTextRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TranslateTextSync(TranslateTextRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TranslateTextAsync(TranslateTextRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TranslateTextAsync(TranslateTextRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/waf-regional.lua
+++ b/aws-sdk/waf-regional.lua
@@ -9798,7 +9798,7 @@ end
 --
 --- Call CreateSizeConstraintSet asynchronously, invoking a callback when done
 -- @param CreateSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSizeConstraintSetAsync(CreateSizeConstraintSetRequest, cb)
 	assert(CreateSizeConstraintSetRequest, "You must provide a CreateSizeConstraintSetRequest")
 	local headers = {
@@ -9821,19 +9821,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSizeConstraintSetSync(CreateSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSizeConstraintSetAsync(CreateSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSizeConstraintSetAsync(CreateSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRegexMatchSet asynchronously, invoking a callback when done
 -- @param UpdateRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRegexMatchSetAsync(UpdateRegexMatchSetRequest, cb)
 	assert(UpdateRegexMatchSetRequest, "You must provide a UpdateRegexMatchSetRequest")
 	local headers = {
@@ -9856,19 +9857,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRegexMatchSetSync(UpdateRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRegexMatchSetAsync(UpdateRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRegexMatchSetAsync(UpdateRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPermissionPolicy asynchronously, invoking a callback when done
 -- @param GetPermissionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPermissionPolicyAsync(GetPermissionPolicyRequest, cb)
 	assert(GetPermissionPolicyRequest, "You must provide a GetPermissionPolicyRequest")
 	local headers = {
@@ -9891,19 +9893,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPermissionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPermissionPolicySync(GetPermissionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPermissionPolicyAsync(GetPermissionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPermissionPolicyAsync(GetPermissionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateXssMatchSet asynchronously, invoking a callback when done
 -- @param UpdateXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateXssMatchSetAsync(UpdateXssMatchSetRequest, cb)
 	assert(UpdateXssMatchSetRequest, "You must provide a UpdateXssMatchSetRequest")
 	local headers = {
@@ -9926,19 +9929,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateXssMatchSetSync(UpdateXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateXssMatchSetAsync(UpdateXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateXssMatchSetAsync(UpdateXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIPSets asynchronously, invoking a callback when done
 -- @param ListIPSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIPSetsAsync(ListIPSetsRequest, cb)
 	assert(ListIPSetsRequest, "You must provide a ListIPSetsRequest")
 	local headers = {
@@ -9961,19 +9965,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIPSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIPSetsSync(ListIPSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIPSetsAsync(ListIPSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIPSetsAsync(ListIPSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRateBasedRule asynchronously, invoking a callback when done
 -- @param DeleteRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRateBasedRuleAsync(DeleteRateBasedRuleRequest, cb)
 	assert(DeleteRateBasedRuleRequest, "You must provide a DeleteRateBasedRuleRequest")
 	local headers = {
@@ -9996,19 +10001,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRateBasedRuleSync(DeleteRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRateBasedRuleAsync(DeleteRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRateBasedRuleAsync(DeleteRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRegexPatternSet asynchronously, invoking a callback when done
 -- @param GetRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRegexPatternSetAsync(GetRegexPatternSetRequest, cb)
 	assert(GetRegexPatternSetRequest, "You must provide a GetRegexPatternSetRequest")
 	local headers = {
@@ -10031,19 +10037,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRegexPatternSetSync(GetRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRegexPatternSetAsync(GetRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRegexPatternSetAsync(GetRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutLoggingConfiguration asynchronously, invoking a callback when done
 -- @param PutLoggingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutLoggingConfigurationAsync(PutLoggingConfigurationRequest, cb)
 	assert(PutLoggingConfigurationRequest, "You must provide a PutLoggingConfigurationRequest")
 	local headers = {
@@ -10066,19 +10073,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutLoggingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutLoggingConfigurationSync(PutLoggingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutLoggingConfigurationAsync(PutLoggingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutLoggingConfigurationAsync(PutLoggingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRegexMatchSet asynchronously, invoking a callback when done
 -- @param GetRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRegexMatchSetAsync(GetRegexMatchSetRequest, cb)
 	assert(GetRegexMatchSetRequest, "You must provide a GetRegexMatchSetRequest")
 	local headers = {
@@ -10101,19 +10109,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRegexMatchSetSync(GetRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRegexMatchSetAsync(GetRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRegexMatchSetAsync(GetRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetChangeTokenStatus asynchronously, invoking a callback when done
 -- @param GetChangeTokenStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetChangeTokenStatusAsync(GetChangeTokenStatusRequest, cb)
 	assert(GetChangeTokenStatusRequest, "You must provide a GetChangeTokenStatusRequest")
 	local headers = {
@@ -10136,19 +10145,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetChangeTokenStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetChangeTokenStatusSync(GetChangeTokenStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetChangeTokenStatusAsync(GetChangeTokenStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetChangeTokenStatusAsync(GetChangeTokenStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRegexPatternSet asynchronously, invoking a callback when done
 -- @param UpdateRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRegexPatternSetAsync(UpdateRegexPatternSetRequest, cb)
 	assert(UpdateRegexPatternSetRequest, "You must provide a UpdateRegexPatternSetRequest")
 	local headers = {
@@ -10171,19 +10181,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRegexPatternSetSync(UpdateRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRegexPatternSetAsync(UpdateRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRegexPatternSetAsync(UpdateRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param DeleteSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSqlInjectionMatchSetAsync(DeleteSqlInjectionMatchSetRequest, cb)
 	assert(DeleteSqlInjectionMatchSetRequest, "You must provide a DeleteSqlInjectionMatchSetRequest")
 	local headers = {
@@ -10206,19 +10217,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSqlInjectionMatchSetSync(DeleteSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSqlInjectionMatchSetAsync(DeleteSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSqlInjectionMatchSetAsync(DeleteSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListByteMatchSets asynchronously, invoking a callback when done
 -- @param ListByteMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListByteMatchSetsAsync(ListByteMatchSetsRequest, cb)
 	assert(ListByteMatchSetsRequest, "You must provide a ListByteMatchSetsRequest")
 	local headers = {
@@ -10241,19 +10253,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListByteMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListByteMatchSetsSync(ListByteMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListByteMatchSetsAsync(ListByteMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListByteMatchSetsAsync(ListByteMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRule asynchronously, invoking a callback when done
 -- @param CreateRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRuleAsync(CreateRuleRequest, cb)
 	assert(CreateRuleRequest, "You must provide a CreateRuleRequest")
 	local headers = {
@@ -10276,19 +10289,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRuleSync(CreateRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRuleAsync(CreateRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRuleAsync(CreateRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGeoMatchSet asynchronously, invoking a callback when done
 -- @param UpdateGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGeoMatchSetAsync(UpdateGeoMatchSetRequest, cb)
 	assert(UpdateGeoMatchSetRequest, "You must provide a UpdateGeoMatchSetRequest")
 	local headers = {
@@ -10311,19 +10325,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGeoMatchSetSync(UpdateGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGeoMatchSetAsync(UpdateGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGeoMatchSetAsync(UpdateGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRateBasedRuleManagedKeys asynchronously, invoking a callback when done
 -- @param GetRateBasedRuleManagedKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRateBasedRuleManagedKeysAsync(GetRateBasedRuleManagedKeysRequest, cb)
 	assert(GetRateBasedRuleManagedKeysRequest, "You must provide a GetRateBasedRuleManagedKeysRequest")
 	local headers = {
@@ -10346,19 +10361,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRateBasedRuleManagedKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRateBasedRuleManagedKeysSync(GetRateBasedRuleManagedKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRateBasedRuleManagedKeysAsync(GetRateBasedRuleManagedKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRateBasedRuleManagedKeysAsync(GetRateBasedRuleManagedKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateWebACL asynchronously, invoking a callback when done
 -- @param UpdateWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateWebACLAsync(UpdateWebACLRequest, cb)
 	assert(UpdateWebACLRequest, "You must provide a UpdateWebACLRequest")
 	local headers = {
@@ -10381,19 +10397,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateWebACLSync(UpdateWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateWebACLAsync(UpdateWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateWebACLAsync(UpdateWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRuleGroups asynchronously, invoking a callback when done
 -- @param ListRuleGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRuleGroupsAsync(ListRuleGroupsRequest, cb)
 	assert(ListRuleGroupsRequest, "You must provide a ListRuleGroupsRequest")
 	local headers = {
@@ -10416,19 +10433,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRuleGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRuleGroupsSync(ListRuleGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRuleGroupsAsync(ListRuleGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRuleGroupsAsync(ListRuleGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param CreateSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSqlInjectionMatchSetAsync(CreateSqlInjectionMatchSetRequest, cb)
 	assert(CreateSqlInjectionMatchSetRequest, "You must provide a CreateSqlInjectionMatchSetRequest")
 	local headers = {
@@ -10451,19 +10469,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSqlInjectionMatchSetSync(CreateSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSqlInjectionMatchSetAsync(CreateSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSqlInjectionMatchSetAsync(CreateSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param UpdateSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSqlInjectionMatchSetAsync(UpdateSqlInjectionMatchSetRequest, cb)
 	assert(UpdateSqlInjectionMatchSetRequest, "You must provide a UpdateSqlInjectionMatchSetRequest")
 	local headers = {
@@ -10486,19 +10505,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSqlInjectionMatchSetSync(UpdateSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSqlInjectionMatchSetAsync(UpdateSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSqlInjectionMatchSetAsync(UpdateSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRateBasedRules asynchronously, invoking a callback when done
 -- @param ListRateBasedRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRateBasedRulesAsync(ListRateBasedRulesRequest, cb)
 	assert(ListRateBasedRulesRequest, "You must provide a ListRateBasedRulesRequest")
 	local headers = {
@@ -10521,19 +10541,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRateBasedRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRateBasedRulesSync(ListRateBasedRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRateBasedRulesAsync(ListRateBasedRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRateBasedRulesAsync(ListRateBasedRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRegexMatchSets asynchronously, invoking a callback when done
 -- @param ListRegexMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRegexMatchSetsAsync(ListRegexMatchSetsRequest, cb)
 	assert(ListRegexMatchSetsRequest, "You must provide a ListRegexMatchSetsRequest")
 	local headers = {
@@ -10556,19 +10577,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRegexMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRegexMatchSetsSync(ListRegexMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRegexMatchSetsAsync(ListRegexMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRegexMatchSetsAsync(ListRegexMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutPermissionPolicy asynchronously, invoking a callback when done
 -- @param PutPermissionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutPermissionPolicyAsync(PutPermissionPolicyRequest, cb)
 	assert(PutPermissionPolicyRequest, "You must provide a PutPermissionPolicyRequest")
 	local headers = {
@@ -10591,19 +10613,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutPermissionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutPermissionPolicySync(PutPermissionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutPermissionPolicyAsync(PutPermissionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutPermissionPolicyAsync(PutPermissionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteByteMatchSet asynchronously, invoking a callback when done
 -- @param DeleteByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteByteMatchSetAsync(DeleteByteMatchSetRequest, cb)
 	assert(DeleteByteMatchSetRequest, "You must provide a DeleteByteMatchSetRequest")
 	local headers = {
@@ -10626,19 +10649,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteByteMatchSetSync(DeleteByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteByteMatchSetAsync(DeleteByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteByteMatchSetAsync(DeleteByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRegexPatternSet asynchronously, invoking a callback when done
 -- @param DeleteRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRegexPatternSetAsync(DeleteRegexPatternSetRequest, cb)
 	assert(DeleteRegexPatternSetRequest, "You must provide a DeleteRegexPatternSetRequest")
 	local headers = {
@@ -10661,19 +10685,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRegexPatternSetSync(DeleteRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRegexPatternSetAsync(DeleteRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRegexPatternSetAsync(DeleteRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRegexPatternSet asynchronously, invoking a callback when done
 -- @param CreateRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRegexPatternSetAsync(CreateRegexPatternSetRequest, cb)
 	assert(CreateRegexPatternSetRequest, "You must provide a CreateRegexPatternSetRequest")
 	local headers = {
@@ -10696,19 +10721,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRegexPatternSetSync(CreateRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRegexPatternSetAsync(CreateRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRegexPatternSetAsync(CreateRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIPSet asynchronously, invoking a callback when done
 -- @param GetIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIPSetAsync(GetIPSetRequest, cb)
 	assert(GetIPSetRequest, "You must provide a GetIPSetRequest")
 	local headers = {
@@ -10731,19 +10757,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIPSetSync(GetIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIPSetAsync(GetIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIPSetAsync(GetIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSqlInjectionMatchSets asynchronously, invoking a callback when done
 -- @param ListSqlInjectionMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSqlInjectionMatchSetsAsync(ListSqlInjectionMatchSetsRequest, cb)
 	assert(ListSqlInjectionMatchSetsRequest, "You must provide a ListSqlInjectionMatchSetsRequest")
 	local headers = {
@@ -10766,19 +10793,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSqlInjectionMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSqlInjectionMatchSetsSync(ListSqlInjectionMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSqlInjectionMatchSetsAsync(ListSqlInjectionMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSqlInjectionMatchSetsAsync(ListSqlInjectionMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRule asynchronously, invoking a callback when done
 -- @param DeleteRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRuleAsync(DeleteRuleRequest, cb)
 	assert(DeleteRuleRequest, "You must provide a DeleteRuleRequest")
 	local headers = {
@@ -10801,19 +10829,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRuleSync(DeleteRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRuleAsync(DeleteRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRuleAsync(DeleteRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSubscribedRuleGroups asynchronously, invoking a callback when done
 -- @param ListSubscribedRuleGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSubscribedRuleGroupsAsync(ListSubscribedRuleGroupsRequest, cb)
 	assert(ListSubscribedRuleGroupsRequest, "You must provide a ListSubscribedRuleGroupsRequest")
 	local headers = {
@@ -10836,19 +10865,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSubscribedRuleGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSubscribedRuleGroupsSync(ListSubscribedRuleGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSubscribedRuleGroupsAsync(ListSubscribedRuleGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSubscribedRuleGroupsAsync(ListSubscribedRuleGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteXssMatchSet asynchronously, invoking a callback when done
 -- @param DeleteXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteXssMatchSetAsync(DeleteXssMatchSetRequest, cb)
 	assert(DeleteXssMatchSetRequest, "You must provide a DeleteXssMatchSetRequest")
 	local headers = {
@@ -10871,19 +10901,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteXssMatchSetSync(DeleteXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteXssMatchSetAsync(DeleteXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteXssMatchSetAsync(DeleteXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIPSet asynchronously, invoking a callback when done
 -- @param UpdateIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIPSetAsync(UpdateIPSetRequest, cb)
 	assert(UpdateIPSetRequest, "You must provide a UpdateIPSetRequest")
 	local headers = {
@@ -10906,19 +10937,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIPSetSync(UpdateIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIPSetAsync(UpdateIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIPSetAsync(UpdateIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListWebACLs asynchronously, invoking a callback when done
 -- @param ListWebACLsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListWebACLsAsync(ListWebACLsRequest, cb)
 	assert(ListWebACLsRequest, "You must provide a ListWebACLsRequest")
 	local headers = {
@@ -10941,19 +10973,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListWebACLsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListWebACLsSync(ListWebACLsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListWebACLsAsync(ListWebACLsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListWebACLsAsync(ListWebACLsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRuleGroup asynchronously, invoking a callback when done
 -- @param UpdateRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRuleGroupAsync(UpdateRuleGroupRequest, cb)
 	assert(UpdateRuleGroupRequest, "You must provide a UpdateRuleGroupRequest")
 	local headers = {
@@ -10976,19 +11009,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRuleGroupSync(UpdateRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRuleGroupAsync(UpdateRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRuleGroupAsync(UpdateRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRule asynchronously, invoking a callback when done
 -- @param UpdateRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRuleAsync(UpdateRuleRequest, cb)
 	assert(UpdateRuleRequest, "You must provide a UpdateRuleRequest")
 	local headers = {
@@ -11011,19 +11045,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRuleSync(UpdateRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRuleAsync(UpdateRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRuleAsync(UpdateRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetByteMatchSet asynchronously, invoking a callback when done
 -- @param GetByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetByteMatchSetAsync(GetByteMatchSetRequest, cb)
 	assert(GetByteMatchSetRequest, "You must provide a GetByteMatchSetRequest")
 	local headers = {
@@ -11046,19 +11081,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetByteMatchSetSync(GetByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetByteMatchSetAsync(GetByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetByteMatchSetAsync(GetByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateXssMatchSet asynchronously, invoking a callback when done
 -- @param CreateXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateXssMatchSetAsync(CreateXssMatchSetRequest, cb)
 	assert(CreateXssMatchSetRequest, "You must provide a CreateXssMatchSetRequest")
 	local headers = {
@@ -11081,19 +11117,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateXssMatchSetSync(CreateXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateXssMatchSetAsync(CreateXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateXssMatchSetAsync(CreateXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRateBasedRule asynchronously, invoking a callback when done
 -- @param UpdateRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRateBasedRuleAsync(UpdateRateBasedRuleRequest, cb)
 	assert(UpdateRateBasedRuleRequest, "You must provide a UpdateRateBasedRuleRequest")
 	local headers = {
@@ -11116,19 +11153,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRateBasedRuleSync(UpdateRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRateBasedRuleAsync(UpdateRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRateBasedRuleAsync(UpdateRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoggingConfiguration asynchronously, invoking a callback when done
 -- @param GetLoggingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoggingConfigurationAsync(GetLoggingConfigurationRequest, cb)
 	assert(GetLoggingConfigurationRequest, "You must provide a GetLoggingConfigurationRequest")
 	local headers = {
@@ -11151,19 +11189,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoggingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoggingConfigurationSync(GetLoggingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoggingConfigurationAsync(GetLoggingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoggingConfigurationAsync(GetLoggingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateByteMatchSet asynchronously, invoking a callback when done
 -- @param CreateByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateByteMatchSetAsync(CreateByteMatchSetRequest, cb)
 	assert(CreateByteMatchSetRequest, "You must provide a CreateByteMatchSetRequest")
 	local headers = {
@@ -11186,19 +11225,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateByteMatchSetSync(CreateByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateByteMatchSetAsync(CreateByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateByteMatchSetAsync(CreateByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListXssMatchSets asynchronously, invoking a callback when done
 -- @param ListXssMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListXssMatchSetsAsync(ListXssMatchSetsRequest, cb)
 	assert(ListXssMatchSetsRequest, "You must provide a ListXssMatchSetsRequest")
 	local headers = {
@@ -11221,19 +11261,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListXssMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListXssMatchSetsSync(ListXssMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListXssMatchSetsAsync(ListXssMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListXssMatchSetsAsync(ListXssMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateWebACL asynchronously, invoking a callback when done
 -- @param AssociateWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateWebACLAsync(AssociateWebACLRequest, cb)
 	assert(AssociateWebACLRequest, "You must provide a AssociateWebACLRequest")
 	local headers = {
@@ -11256,19 +11297,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateWebACLSync(AssociateWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateWebACLAsync(AssociateWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateWebACLAsync(AssociateWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSizeConstraintSet asynchronously, invoking a callback when done
 -- @param GetSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSizeConstraintSetAsync(GetSizeConstraintSetRequest, cb)
 	assert(GetSizeConstraintSetRequest, "You must provide a GetSizeConstraintSetRequest")
 	local headers = {
@@ -11291,19 +11333,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSizeConstraintSetSync(GetSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSizeConstraintSetAsync(GetSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSizeConstraintSetAsync(GetSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLoggingConfigurations asynchronously, invoking a callback when done
 -- @param ListLoggingConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLoggingConfigurationsAsync(ListLoggingConfigurationsRequest, cb)
 	assert(ListLoggingConfigurationsRequest, "You must provide a ListLoggingConfigurationsRequest")
 	local headers = {
@@ -11326,19 +11369,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLoggingConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLoggingConfigurationsSync(ListLoggingConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLoggingConfigurationsAsync(ListLoggingConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLoggingConfigurationsAsync(ListLoggingConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGeoMatchSet asynchronously, invoking a callback when done
 -- @param GetGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGeoMatchSetAsync(GetGeoMatchSetRequest, cb)
 	assert(GetGeoMatchSetRequest, "You must provide a GetGeoMatchSetRequest")
 	local headers = {
@@ -11361,19 +11405,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGeoMatchSetSync(GetGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGeoMatchSetAsync(GetGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGeoMatchSetAsync(GetGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIPSet asynchronously, invoking a callback when done
 -- @param CreateIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIPSetAsync(CreateIPSetRequest, cb)
 	assert(CreateIPSetRequest, "You must provide a CreateIPSetRequest")
 	local headers = {
@@ -11396,19 +11441,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIPSetSync(CreateIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIPSetAsync(CreateIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIPSetAsync(CreateIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRuleGroup asynchronously, invoking a callback when done
 -- @param DeleteRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRuleGroupAsync(DeleteRuleGroupRequest, cb)
 	assert(DeleteRuleGroupRequest, "You must provide a DeleteRuleGroupRequest")
 	local headers = {
@@ -11431,19 +11477,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRuleGroupSync(DeleteRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRuleGroupAsync(DeleteRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRuleGroupAsync(DeleteRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetXssMatchSet asynchronously, invoking a callback when done
 -- @param GetXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetXssMatchSetAsync(GetXssMatchSetRequest, cb)
 	assert(GetXssMatchSetRequest, "You must provide a GetXssMatchSetRequest")
 	local headers = {
@@ -11466,19 +11513,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetXssMatchSetSync(GetXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetXssMatchSetAsync(GetXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetXssMatchSetAsync(GetXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGeoMatchSets asynchronously, invoking a callback when done
 -- @param ListGeoMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGeoMatchSetsAsync(ListGeoMatchSetsRequest, cb)
 	assert(ListGeoMatchSetsRequest, "You must provide a ListGeoMatchSetsRequest")
 	local headers = {
@@ -11501,19 +11549,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGeoMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGeoMatchSetsSync(ListGeoMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGeoMatchSetsAsync(ListGeoMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGeoMatchSetsAsync(ListGeoMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLoggingConfiguration asynchronously, invoking a callback when done
 -- @param DeleteLoggingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLoggingConfigurationAsync(DeleteLoggingConfigurationRequest, cb)
 	assert(DeleteLoggingConfigurationRequest, "You must provide a DeleteLoggingConfigurationRequest")
 	local headers = {
@@ -11536,19 +11585,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLoggingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLoggingConfigurationSync(DeleteLoggingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLoggingConfigurationAsync(DeleteLoggingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLoggingConfigurationAsync(DeleteLoggingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRateBasedRule asynchronously, invoking a callback when done
 -- @param GetRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRateBasedRuleAsync(GetRateBasedRuleRequest, cb)
 	assert(GetRateBasedRuleRequest, "You must provide a GetRateBasedRuleRequest")
 	local headers = {
@@ -11571,19 +11621,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRateBasedRuleSync(GetRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRateBasedRuleAsync(GetRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRateBasedRuleAsync(GetRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGeoMatchSet asynchronously, invoking a callback when done
 -- @param DeleteGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGeoMatchSetAsync(DeleteGeoMatchSetRequest, cb)
 	assert(DeleteGeoMatchSetRequest, "You must provide a DeleteGeoMatchSetRequest")
 	local headers = {
@@ -11606,19 +11657,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGeoMatchSetSync(DeleteGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGeoMatchSetAsync(DeleteGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGeoMatchSetAsync(DeleteGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRateBasedRule asynchronously, invoking a callback when done
 -- @param CreateRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRateBasedRuleAsync(CreateRateBasedRuleRequest, cb)
 	assert(CreateRateBasedRuleRequest, "You must provide a CreateRateBasedRuleRequest")
 	local headers = {
@@ -11641,19 +11693,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRateBasedRuleSync(CreateRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRateBasedRuleAsync(CreateRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRateBasedRuleAsync(CreateRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRuleGroup asynchronously, invoking a callback when done
 -- @param GetRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRuleGroupAsync(GetRuleGroupRequest, cb)
 	assert(GetRuleGroupRequest, "You must provide a GetRuleGroupRequest")
 	local headers = {
@@ -11676,19 +11729,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRuleGroupSync(GetRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRuleGroupAsync(GetRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRuleGroupAsync(GetRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRules asynchronously, invoking a callback when done
 -- @param ListRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRulesAsync(ListRulesRequest, cb)
 	assert(ListRulesRequest, "You must provide a ListRulesRequest")
 	local headers = {
@@ -11711,19 +11765,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRulesSync(ListRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRulesAsync(ListRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRulesAsync(ListRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSampledRequests asynchronously, invoking a callback when done
 -- @param GetSampledRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSampledRequestsAsync(GetSampledRequestsRequest, cb)
 	assert(GetSampledRequestsRequest, "You must provide a GetSampledRequestsRequest")
 	local headers = {
@@ -11746,19 +11801,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSampledRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSampledRequestsSync(GetSampledRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSampledRequestsAsync(GetSampledRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSampledRequestsAsync(GetSampledRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateWebACL asynchronously, invoking a callback when done
 -- @param CreateWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateWebACLAsync(CreateWebACLRequest, cb)
 	assert(CreateWebACLRequest, "You must provide a CreateWebACLRequest")
 	local headers = {
@@ -11781,19 +11837,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateWebACLSync(CreateWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateWebACLAsync(CreateWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateWebACLAsync(CreateWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteWebACL asynchronously, invoking a callback when done
 -- @param DeleteWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteWebACLAsync(DeleteWebACLRequest, cb)
 	assert(DeleteWebACLRequest, "You must provide a DeleteWebACLRequest")
 	local headers = {
@@ -11816,19 +11873,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteWebACLSync(DeleteWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteWebACLAsync(DeleteWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteWebACLAsync(DeleteWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRuleGroup asynchronously, invoking a callback when done
 -- @param CreateRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRuleGroupAsync(CreateRuleGroupRequest, cb)
 	assert(CreateRuleGroupRequest, "You must provide a CreateRuleGroupRequest")
 	local headers = {
@@ -11851,19 +11909,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRuleGroupSync(CreateRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRuleGroupAsync(CreateRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRuleGroupAsync(CreateRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRule asynchronously, invoking a callback when done
 -- @param GetRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRuleAsync(GetRuleRequest, cb)
 	assert(GetRuleRequest, "You must provide a GetRuleRequest")
 	local headers = {
@@ -11886,19 +11945,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRuleSync(GetRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRuleAsync(GetRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRuleAsync(GetRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSizeConstraintSet asynchronously, invoking a callback when done
 -- @param DeleteSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSizeConstraintSetAsync(DeleteSizeConstraintSetRequest, cb)
 	assert(DeleteSizeConstraintSetRequest, "You must provide a DeleteSizeConstraintSetRequest")
 	local headers = {
@@ -11921,19 +11981,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSizeConstraintSetSync(DeleteSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSizeConstraintSetAsync(DeleteSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSizeConstraintSetAsync(DeleteSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetWebACLForResource asynchronously, invoking a callback when done
 -- @param GetWebACLForResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetWebACLForResourceAsync(GetWebACLForResourceRequest, cb)
 	assert(GetWebACLForResourceRequest, "You must provide a GetWebACLForResourceRequest")
 	local headers = {
@@ -11956,19 +12017,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetWebACLForResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetWebACLForResourceSync(GetWebACLForResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetWebACLForResourceAsync(GetWebACLForResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetWebACLForResourceAsync(GetWebACLForResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSizeConstraintSet asynchronously, invoking a callback when done
 -- @param UpdateSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSizeConstraintSetAsync(UpdateSizeConstraintSetRequest, cb)
 	assert(UpdateSizeConstraintSetRequest, "You must provide a UpdateSizeConstraintSetRequest")
 	local headers = {
@@ -11991,19 +12053,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSizeConstraintSetSync(UpdateSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSizeConstraintSetAsync(UpdateSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSizeConstraintSetAsync(UpdateSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListActivatedRulesInRuleGroup asynchronously, invoking a callback when done
 -- @param ListActivatedRulesInRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListActivatedRulesInRuleGroupAsync(ListActivatedRulesInRuleGroupRequest, cb)
 	assert(ListActivatedRulesInRuleGroupRequest, "You must provide a ListActivatedRulesInRuleGroupRequest")
 	local headers = {
@@ -12026,19 +12089,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListActivatedRulesInRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListActivatedRulesInRuleGroupSync(ListActivatedRulesInRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListActivatedRulesInRuleGroupAsync(ListActivatedRulesInRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListActivatedRulesInRuleGroupAsync(ListActivatedRulesInRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourcesForWebACL asynchronously, invoking a callback when done
 -- @param ListResourcesForWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourcesForWebACLAsync(ListResourcesForWebACLRequest, cb)
 	assert(ListResourcesForWebACLRequest, "You must provide a ListResourcesForWebACLRequest")
 	local headers = {
@@ -12061,19 +12125,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourcesForWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourcesForWebACLSync(ListResourcesForWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourcesForWebACLAsync(ListResourcesForWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourcesForWebACLAsync(ListResourcesForWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetChangeToken asynchronously, invoking a callback when done
 -- @param GetChangeTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetChangeTokenAsync(GetChangeTokenRequest, cb)
 	assert(GetChangeTokenRequest, "You must provide a GetChangeTokenRequest")
 	local headers = {
@@ -12096,19 +12161,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetChangeTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetChangeTokenSync(GetChangeTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetChangeTokenAsync(GetChangeTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetChangeTokenAsync(GetChangeTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRegexMatchSet asynchronously, invoking a callback when done
 -- @param DeleteRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRegexMatchSetAsync(DeleteRegexMatchSetRequest, cb)
 	assert(DeleteRegexMatchSetRequest, "You must provide a DeleteRegexMatchSetRequest")
 	local headers = {
@@ -12131,19 +12197,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRegexMatchSetSync(DeleteRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRegexMatchSetAsync(DeleteRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRegexMatchSetAsync(DeleteRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetWebACL asynchronously, invoking a callback when done
 -- @param GetWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetWebACLAsync(GetWebACLRequest, cb)
 	assert(GetWebACLRequest, "You must provide a GetWebACLRequest")
 	local headers = {
@@ -12166,19 +12233,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetWebACLSync(GetWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetWebACLAsync(GetWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetWebACLAsync(GetWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePermissionPolicy asynchronously, invoking a callback when done
 -- @param DeletePermissionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePermissionPolicyAsync(DeletePermissionPolicyRequest, cb)
 	assert(DeletePermissionPolicyRequest, "You must provide a DeletePermissionPolicyRequest")
 	local headers = {
@@ -12201,19 +12269,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePermissionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePermissionPolicySync(DeletePermissionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePermissionPolicyAsync(DeletePermissionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePermissionPolicyAsync(DeletePermissionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateByteMatchSet asynchronously, invoking a callback when done
 -- @param UpdateByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateByteMatchSetAsync(UpdateByteMatchSetRequest, cb)
 	assert(UpdateByteMatchSetRequest, "You must provide a UpdateByteMatchSetRequest")
 	local headers = {
@@ -12236,19 +12305,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateByteMatchSetSync(UpdateByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateByteMatchSetAsync(UpdateByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateByteMatchSetAsync(UpdateByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateWebACL asynchronously, invoking a callback when done
 -- @param DisassociateWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateWebACLAsync(DisassociateWebACLRequest, cb)
 	assert(DisassociateWebACLRequest, "You must provide a DisassociateWebACLRequest")
 	local headers = {
@@ -12271,19 +12341,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateWebACLSync(DisassociateWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateWebACLAsync(DisassociateWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateWebACLAsync(DisassociateWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRegexMatchSet asynchronously, invoking a callback when done
 -- @param CreateRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRegexMatchSetAsync(CreateRegexMatchSetRequest, cb)
 	assert(CreateRegexMatchSetRequest, "You must provide a CreateRegexMatchSetRequest")
 	local headers = {
@@ -12306,19 +12377,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRegexMatchSetSync(CreateRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRegexMatchSetAsync(CreateRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRegexMatchSetAsync(CreateRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param GetSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSqlInjectionMatchSetAsync(GetSqlInjectionMatchSetRequest, cb)
 	assert(GetSqlInjectionMatchSetRequest, "You must provide a GetSqlInjectionMatchSetRequest")
 	local headers = {
@@ -12341,19 +12413,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSqlInjectionMatchSetSync(GetSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSqlInjectionMatchSetAsync(GetSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSqlInjectionMatchSetAsync(GetSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRegexPatternSets asynchronously, invoking a callback when done
 -- @param ListRegexPatternSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRegexPatternSetsAsync(ListRegexPatternSetsRequest, cb)
 	assert(ListRegexPatternSetsRequest, "You must provide a ListRegexPatternSetsRequest")
 	local headers = {
@@ -12376,19 +12449,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRegexPatternSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRegexPatternSetsSync(ListRegexPatternSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRegexPatternSetsAsync(ListRegexPatternSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRegexPatternSetsAsync(ListRegexPatternSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSizeConstraintSets asynchronously, invoking a callback when done
 -- @param ListSizeConstraintSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSizeConstraintSetsAsync(ListSizeConstraintSetsRequest, cb)
 	assert(ListSizeConstraintSetsRequest, "You must provide a ListSizeConstraintSetsRequest")
 	local headers = {
@@ -12411,19 +12485,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSizeConstraintSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSizeConstraintSetsSync(ListSizeConstraintSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSizeConstraintSetsAsync(ListSizeConstraintSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSizeConstraintSetsAsync(ListSizeConstraintSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIPSet asynchronously, invoking a callback when done
 -- @param DeleteIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIPSetAsync(DeleteIPSetRequest, cb)
 	assert(DeleteIPSetRequest, "You must provide a DeleteIPSetRequest")
 	local headers = {
@@ -12446,19 +12521,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIPSetSync(DeleteIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIPSetAsync(DeleteIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIPSetAsync(DeleteIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGeoMatchSet asynchronously, invoking a callback when done
 -- @param CreateGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGeoMatchSetAsync(CreateGeoMatchSetRequest, cb)
 	assert(CreateGeoMatchSetRequest, "You must provide a CreateGeoMatchSetRequest")
 	local headers = {
@@ -12481,12 +12557,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGeoMatchSetSync(CreateGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGeoMatchSetAsync(CreateGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGeoMatchSetAsync(CreateGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/waf.lua
+++ b/aws-sdk/waf.lua
@@ -9480,7 +9480,7 @@ end
 --
 --- Call CreateSizeConstraintSet asynchronously, invoking a callback when done
 -- @param CreateSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSizeConstraintSetAsync(CreateSizeConstraintSetRequest, cb)
 	assert(CreateSizeConstraintSetRequest, "You must provide a CreateSizeConstraintSetRequest")
 	local headers = {
@@ -9503,19 +9503,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSizeConstraintSetSync(CreateSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSizeConstraintSetAsync(CreateSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSizeConstraintSetAsync(CreateSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRegexMatchSet asynchronously, invoking a callback when done
 -- @param UpdateRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRegexMatchSetAsync(UpdateRegexMatchSetRequest, cb)
 	assert(UpdateRegexMatchSetRequest, "You must provide a UpdateRegexMatchSetRequest")
 	local headers = {
@@ -9538,19 +9539,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRegexMatchSetSync(UpdateRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRegexMatchSetAsync(UpdateRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRegexMatchSetAsync(UpdateRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetPermissionPolicy asynchronously, invoking a callback when done
 -- @param GetPermissionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetPermissionPolicyAsync(GetPermissionPolicyRequest, cb)
 	assert(GetPermissionPolicyRequest, "You must provide a GetPermissionPolicyRequest")
 	local headers = {
@@ -9573,19 +9575,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetPermissionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetPermissionPolicySync(GetPermissionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetPermissionPolicyAsync(GetPermissionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetPermissionPolicyAsync(GetPermissionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListIPSets asynchronously, invoking a callback when done
 -- @param ListIPSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListIPSetsAsync(ListIPSetsRequest, cb)
 	assert(ListIPSetsRequest, "You must provide a ListIPSetsRequest")
 	local headers = {
@@ -9608,19 +9611,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListIPSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListIPSetsSync(ListIPSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListIPSetsAsync(ListIPSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListIPSetsAsync(ListIPSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRateBasedRule asynchronously, invoking a callback when done
 -- @param DeleteRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRateBasedRuleAsync(DeleteRateBasedRuleRequest, cb)
 	assert(DeleteRateBasedRuleRequest, "You must provide a DeleteRateBasedRuleRequest")
 	local headers = {
@@ -9643,19 +9647,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRateBasedRuleSync(DeleteRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRateBasedRuleAsync(DeleteRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRateBasedRuleAsync(DeleteRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRegexPatternSet asynchronously, invoking a callback when done
 -- @param GetRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRegexPatternSetAsync(GetRegexPatternSetRequest, cb)
 	assert(GetRegexPatternSetRequest, "You must provide a GetRegexPatternSetRequest")
 	local headers = {
@@ -9678,19 +9683,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRegexPatternSetSync(GetRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRegexPatternSetAsync(GetRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRegexPatternSetAsync(GetRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutLoggingConfiguration asynchronously, invoking a callback when done
 -- @param PutLoggingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutLoggingConfigurationAsync(PutLoggingConfigurationRequest, cb)
 	assert(PutLoggingConfigurationRequest, "You must provide a PutLoggingConfigurationRequest")
 	local headers = {
@@ -9713,19 +9719,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutLoggingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutLoggingConfigurationSync(PutLoggingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutLoggingConfigurationAsync(PutLoggingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutLoggingConfigurationAsync(PutLoggingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRegexMatchSet asynchronously, invoking a callback when done
 -- @param GetRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRegexMatchSetAsync(GetRegexMatchSetRequest, cb)
 	assert(GetRegexMatchSetRequest, "You must provide a GetRegexMatchSetRequest")
 	local headers = {
@@ -9748,19 +9755,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRegexMatchSetSync(GetRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRegexMatchSetAsync(GetRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRegexMatchSetAsync(GetRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetChangeTokenStatus asynchronously, invoking a callback when done
 -- @param GetChangeTokenStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetChangeTokenStatusAsync(GetChangeTokenStatusRequest, cb)
 	assert(GetChangeTokenStatusRequest, "You must provide a GetChangeTokenStatusRequest")
 	local headers = {
@@ -9783,19 +9791,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetChangeTokenStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetChangeTokenStatusSync(GetChangeTokenStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetChangeTokenStatusAsync(GetChangeTokenStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetChangeTokenStatusAsync(GetChangeTokenStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRegexPatternSet asynchronously, invoking a callback when done
 -- @param UpdateRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRegexPatternSetAsync(UpdateRegexPatternSetRequest, cb)
 	assert(UpdateRegexPatternSetRequest, "You must provide a UpdateRegexPatternSetRequest")
 	local headers = {
@@ -9818,19 +9827,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRegexPatternSetSync(UpdateRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRegexPatternSetAsync(UpdateRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRegexPatternSetAsync(UpdateRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param DeleteSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSqlInjectionMatchSetAsync(DeleteSqlInjectionMatchSetRequest, cb)
 	assert(DeleteSqlInjectionMatchSetRequest, "You must provide a DeleteSqlInjectionMatchSetRequest")
 	local headers = {
@@ -9853,19 +9863,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSqlInjectionMatchSetSync(DeleteSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSqlInjectionMatchSetAsync(DeleteSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSqlInjectionMatchSetAsync(DeleteSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListByteMatchSets asynchronously, invoking a callback when done
 -- @param ListByteMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListByteMatchSetsAsync(ListByteMatchSetsRequest, cb)
 	assert(ListByteMatchSetsRequest, "You must provide a ListByteMatchSetsRequest")
 	local headers = {
@@ -9888,19 +9899,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListByteMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListByteMatchSetsSync(ListByteMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListByteMatchSetsAsync(ListByteMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListByteMatchSetsAsync(ListByteMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRule asynchronously, invoking a callback when done
 -- @param CreateRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRuleAsync(CreateRuleRequest, cb)
 	assert(CreateRuleRequest, "You must provide a CreateRuleRequest")
 	local headers = {
@@ -9923,19 +9935,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRuleSync(CreateRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRuleAsync(CreateRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRuleAsync(CreateRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateGeoMatchSet asynchronously, invoking a callback when done
 -- @param UpdateGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateGeoMatchSetAsync(UpdateGeoMatchSetRequest, cb)
 	assert(UpdateGeoMatchSetRequest, "You must provide a UpdateGeoMatchSetRequest")
 	local headers = {
@@ -9958,19 +9971,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateGeoMatchSetSync(UpdateGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateGeoMatchSetAsync(UpdateGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateGeoMatchSetAsync(UpdateGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRateBasedRuleManagedKeys asynchronously, invoking a callback when done
 -- @param GetRateBasedRuleManagedKeysRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRateBasedRuleManagedKeysAsync(GetRateBasedRuleManagedKeysRequest, cb)
 	assert(GetRateBasedRuleManagedKeysRequest, "You must provide a GetRateBasedRuleManagedKeysRequest")
 	local headers = {
@@ -9993,19 +10007,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRateBasedRuleManagedKeysRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRateBasedRuleManagedKeysSync(GetRateBasedRuleManagedKeysRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRateBasedRuleManagedKeysAsync(GetRateBasedRuleManagedKeysRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRateBasedRuleManagedKeysAsync(GetRateBasedRuleManagedKeysRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRuleGroups asynchronously, invoking a callback when done
 -- @param ListRuleGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRuleGroupsAsync(ListRuleGroupsRequest, cb)
 	assert(ListRuleGroupsRequest, "You must provide a ListRuleGroupsRequest")
 	local headers = {
@@ -10028,19 +10043,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRuleGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRuleGroupsSync(ListRuleGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRuleGroupsAsync(ListRuleGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRuleGroupsAsync(ListRuleGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param CreateSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSqlInjectionMatchSetAsync(CreateSqlInjectionMatchSetRequest, cb)
 	assert(CreateSqlInjectionMatchSetRequest, "You must provide a CreateSqlInjectionMatchSetRequest")
 	local headers = {
@@ -10063,19 +10079,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSqlInjectionMatchSetSync(CreateSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSqlInjectionMatchSetAsync(CreateSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSqlInjectionMatchSetAsync(CreateSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param UpdateSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSqlInjectionMatchSetAsync(UpdateSqlInjectionMatchSetRequest, cb)
 	assert(UpdateSqlInjectionMatchSetRequest, "You must provide a UpdateSqlInjectionMatchSetRequest")
 	local headers = {
@@ -10098,19 +10115,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSqlInjectionMatchSetSync(UpdateSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSqlInjectionMatchSetAsync(UpdateSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSqlInjectionMatchSetAsync(UpdateSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRateBasedRules asynchronously, invoking a callback when done
 -- @param ListRateBasedRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRateBasedRulesAsync(ListRateBasedRulesRequest, cb)
 	assert(ListRateBasedRulesRequest, "You must provide a ListRateBasedRulesRequest")
 	local headers = {
@@ -10133,19 +10151,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRateBasedRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRateBasedRulesSync(ListRateBasedRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRateBasedRulesAsync(ListRateBasedRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRateBasedRulesAsync(ListRateBasedRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRegexMatchSets asynchronously, invoking a callback when done
 -- @param ListRegexMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRegexMatchSetsAsync(ListRegexMatchSetsRequest, cb)
 	assert(ListRegexMatchSetsRequest, "You must provide a ListRegexMatchSetsRequest")
 	local headers = {
@@ -10168,19 +10187,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRegexMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRegexMatchSetsSync(ListRegexMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRegexMatchSetsAsync(ListRegexMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRegexMatchSetsAsync(ListRegexMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutPermissionPolicy asynchronously, invoking a callback when done
 -- @param PutPermissionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutPermissionPolicyAsync(PutPermissionPolicyRequest, cb)
 	assert(PutPermissionPolicyRequest, "You must provide a PutPermissionPolicyRequest")
 	local headers = {
@@ -10203,19 +10223,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutPermissionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutPermissionPolicySync(PutPermissionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutPermissionPolicyAsync(PutPermissionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutPermissionPolicyAsync(PutPermissionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteByteMatchSet asynchronously, invoking a callback when done
 -- @param DeleteByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteByteMatchSetAsync(DeleteByteMatchSetRequest, cb)
 	assert(DeleteByteMatchSetRequest, "You must provide a DeleteByteMatchSetRequest")
 	local headers = {
@@ -10238,19 +10259,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteByteMatchSetSync(DeleteByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteByteMatchSetAsync(DeleteByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteByteMatchSetAsync(DeleteByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRegexPatternSet asynchronously, invoking a callback when done
 -- @param DeleteRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRegexPatternSetAsync(DeleteRegexPatternSetRequest, cb)
 	assert(DeleteRegexPatternSetRequest, "You must provide a DeleteRegexPatternSetRequest")
 	local headers = {
@@ -10273,19 +10295,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRegexPatternSetSync(DeleteRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRegexPatternSetAsync(DeleteRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRegexPatternSetAsync(DeleteRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRegexPatternSet asynchronously, invoking a callback when done
 -- @param CreateRegexPatternSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRegexPatternSetAsync(CreateRegexPatternSetRequest, cb)
 	assert(CreateRegexPatternSetRequest, "You must provide a CreateRegexPatternSetRequest")
 	local headers = {
@@ -10308,19 +10331,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRegexPatternSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRegexPatternSetSync(CreateRegexPatternSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRegexPatternSetAsync(CreateRegexPatternSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRegexPatternSetAsync(CreateRegexPatternSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetIPSet asynchronously, invoking a callback when done
 -- @param GetIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetIPSetAsync(GetIPSetRequest, cb)
 	assert(GetIPSetRequest, "You must provide a GetIPSetRequest")
 	local headers = {
@@ -10343,19 +10367,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetIPSetSync(GetIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetIPSetAsync(GetIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetIPSetAsync(GetIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSqlInjectionMatchSets asynchronously, invoking a callback when done
 -- @param ListSqlInjectionMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSqlInjectionMatchSetsAsync(ListSqlInjectionMatchSetsRequest, cb)
 	assert(ListSqlInjectionMatchSetsRequest, "You must provide a ListSqlInjectionMatchSetsRequest")
 	local headers = {
@@ -10378,19 +10403,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSqlInjectionMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSqlInjectionMatchSetsSync(ListSqlInjectionMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSqlInjectionMatchSetsAsync(ListSqlInjectionMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSqlInjectionMatchSetsAsync(ListSqlInjectionMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRule asynchronously, invoking a callback when done
 -- @param DeleteRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRuleAsync(DeleteRuleRequest, cb)
 	assert(DeleteRuleRequest, "You must provide a DeleteRuleRequest")
 	local headers = {
@@ -10413,19 +10439,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRuleSync(DeleteRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRuleAsync(DeleteRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRuleAsync(DeleteRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSubscribedRuleGroups asynchronously, invoking a callback when done
 -- @param ListSubscribedRuleGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSubscribedRuleGroupsAsync(ListSubscribedRuleGroupsRequest, cb)
 	assert(ListSubscribedRuleGroupsRequest, "You must provide a ListSubscribedRuleGroupsRequest")
 	local headers = {
@@ -10448,19 +10475,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSubscribedRuleGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSubscribedRuleGroupsSync(ListSubscribedRuleGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSubscribedRuleGroupsAsync(ListSubscribedRuleGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSubscribedRuleGroupsAsync(ListSubscribedRuleGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteXssMatchSet asynchronously, invoking a callback when done
 -- @param DeleteXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteXssMatchSetAsync(DeleteXssMatchSetRequest, cb)
 	assert(DeleteXssMatchSetRequest, "You must provide a DeleteXssMatchSetRequest")
 	local headers = {
@@ -10483,19 +10511,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteXssMatchSetSync(DeleteXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteXssMatchSetAsync(DeleteXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteXssMatchSetAsync(DeleteXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateIPSet asynchronously, invoking a callback when done
 -- @param UpdateIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateIPSetAsync(UpdateIPSetRequest, cb)
 	assert(UpdateIPSetRequest, "You must provide a UpdateIPSetRequest")
 	local headers = {
@@ -10518,19 +10547,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateIPSetSync(UpdateIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateIPSetAsync(UpdateIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateIPSetAsync(UpdateIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListWebACLs asynchronously, invoking a callback when done
 -- @param ListWebACLsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListWebACLsAsync(ListWebACLsRequest, cb)
 	assert(ListWebACLsRequest, "You must provide a ListWebACLsRequest")
 	local headers = {
@@ -10553,19 +10583,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListWebACLsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListWebACLsSync(ListWebACLsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListWebACLsAsync(ListWebACLsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListWebACLsAsync(ListWebACLsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRuleGroup asynchronously, invoking a callback when done
 -- @param UpdateRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRuleGroupAsync(UpdateRuleGroupRequest, cb)
 	assert(UpdateRuleGroupRequest, "You must provide a UpdateRuleGroupRequest")
 	local headers = {
@@ -10588,19 +10619,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRuleGroupSync(UpdateRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRuleGroupAsync(UpdateRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRuleGroupAsync(UpdateRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRule asynchronously, invoking a callback when done
 -- @param UpdateRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRuleAsync(UpdateRuleRequest, cb)
 	assert(UpdateRuleRequest, "You must provide a UpdateRuleRequest")
 	local headers = {
@@ -10623,19 +10655,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRuleSync(UpdateRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRuleAsync(UpdateRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRuleAsync(UpdateRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetByteMatchSet asynchronously, invoking a callback when done
 -- @param GetByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetByteMatchSetAsync(GetByteMatchSetRequest, cb)
 	assert(GetByteMatchSetRequest, "You must provide a GetByteMatchSetRequest")
 	local headers = {
@@ -10658,19 +10691,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetByteMatchSetSync(GetByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetByteMatchSetAsync(GetByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetByteMatchSetAsync(GetByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateXssMatchSet asynchronously, invoking a callback when done
 -- @param CreateXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateXssMatchSetAsync(CreateXssMatchSetRequest, cb)
 	assert(CreateXssMatchSetRequest, "You must provide a CreateXssMatchSetRequest")
 	local headers = {
@@ -10693,19 +10727,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateXssMatchSetSync(CreateXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateXssMatchSetAsync(CreateXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateXssMatchSetAsync(CreateXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRateBasedRule asynchronously, invoking a callback when done
 -- @param UpdateRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRateBasedRuleAsync(UpdateRateBasedRuleRequest, cb)
 	assert(UpdateRateBasedRuleRequest, "You must provide a UpdateRateBasedRuleRequest")
 	local headers = {
@@ -10728,19 +10763,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRateBasedRuleSync(UpdateRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRateBasedRuleAsync(UpdateRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRateBasedRuleAsync(UpdateRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetLoggingConfiguration asynchronously, invoking a callback when done
 -- @param GetLoggingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetLoggingConfigurationAsync(GetLoggingConfigurationRequest, cb)
 	assert(GetLoggingConfigurationRequest, "You must provide a GetLoggingConfigurationRequest")
 	local headers = {
@@ -10763,19 +10799,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetLoggingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetLoggingConfigurationSync(GetLoggingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetLoggingConfigurationAsync(GetLoggingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetLoggingConfigurationAsync(GetLoggingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateByteMatchSet asynchronously, invoking a callback when done
 -- @param CreateByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateByteMatchSetAsync(CreateByteMatchSetRequest, cb)
 	assert(CreateByteMatchSetRequest, "You must provide a CreateByteMatchSetRequest")
 	local headers = {
@@ -10798,19 +10835,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateByteMatchSetSync(CreateByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateByteMatchSetAsync(CreateByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateByteMatchSetAsync(CreateByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListXssMatchSets asynchronously, invoking a callback when done
 -- @param ListXssMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListXssMatchSetsAsync(ListXssMatchSetsRequest, cb)
 	assert(ListXssMatchSetsRequest, "You must provide a ListXssMatchSetsRequest")
 	local headers = {
@@ -10833,19 +10871,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListXssMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListXssMatchSetsSync(ListXssMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListXssMatchSetsAsync(ListXssMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListXssMatchSetsAsync(ListXssMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSizeConstraintSet asynchronously, invoking a callback when done
 -- @param GetSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSizeConstraintSetAsync(GetSizeConstraintSetRequest, cb)
 	assert(GetSizeConstraintSetRequest, "You must provide a GetSizeConstraintSetRequest")
 	local headers = {
@@ -10868,19 +10907,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSizeConstraintSetSync(GetSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSizeConstraintSetAsync(GetSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSizeConstraintSetAsync(GetSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListLoggingConfigurations asynchronously, invoking a callback when done
 -- @param ListLoggingConfigurationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListLoggingConfigurationsAsync(ListLoggingConfigurationsRequest, cb)
 	assert(ListLoggingConfigurationsRequest, "You must provide a ListLoggingConfigurationsRequest")
 	local headers = {
@@ -10903,19 +10943,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListLoggingConfigurationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListLoggingConfigurationsSync(ListLoggingConfigurationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListLoggingConfigurationsAsync(ListLoggingConfigurationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListLoggingConfigurationsAsync(ListLoggingConfigurationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetGeoMatchSet asynchronously, invoking a callback when done
 -- @param GetGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetGeoMatchSetAsync(GetGeoMatchSetRequest, cb)
 	assert(GetGeoMatchSetRequest, "You must provide a GetGeoMatchSetRequest")
 	local headers = {
@@ -10938,19 +10979,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetGeoMatchSetSync(GetGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetGeoMatchSetAsync(GetGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetGeoMatchSetAsync(GetGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIPSet asynchronously, invoking a callback when done
 -- @param CreateIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIPSetAsync(CreateIPSetRequest, cb)
 	assert(CreateIPSetRequest, "You must provide a CreateIPSetRequest")
 	local headers = {
@@ -10973,19 +11015,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIPSetSync(CreateIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIPSetAsync(CreateIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIPSetAsync(CreateIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRuleGroup asynchronously, invoking a callback when done
 -- @param DeleteRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRuleGroupAsync(DeleteRuleGroupRequest, cb)
 	assert(DeleteRuleGroupRequest, "You must provide a DeleteRuleGroupRequest")
 	local headers = {
@@ -11008,19 +11051,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRuleGroupSync(DeleteRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRuleGroupAsync(DeleteRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRuleGroupAsync(DeleteRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetXssMatchSet asynchronously, invoking a callback when done
 -- @param GetXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetXssMatchSetAsync(GetXssMatchSetRequest, cb)
 	assert(GetXssMatchSetRequest, "You must provide a GetXssMatchSetRequest")
 	local headers = {
@@ -11043,19 +11087,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetXssMatchSetSync(GetXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetXssMatchSetAsync(GetXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetXssMatchSetAsync(GetXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGeoMatchSets asynchronously, invoking a callback when done
 -- @param ListGeoMatchSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGeoMatchSetsAsync(ListGeoMatchSetsRequest, cb)
 	assert(ListGeoMatchSetsRequest, "You must provide a ListGeoMatchSetsRequest")
 	local headers = {
@@ -11078,19 +11123,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGeoMatchSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGeoMatchSetsSync(ListGeoMatchSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGeoMatchSetsAsync(ListGeoMatchSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGeoMatchSetsAsync(ListGeoMatchSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLoggingConfiguration asynchronously, invoking a callback when done
 -- @param DeleteLoggingConfigurationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLoggingConfigurationAsync(DeleteLoggingConfigurationRequest, cb)
 	assert(DeleteLoggingConfigurationRequest, "You must provide a DeleteLoggingConfigurationRequest")
 	local headers = {
@@ -11113,19 +11159,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLoggingConfigurationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLoggingConfigurationSync(DeleteLoggingConfigurationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLoggingConfigurationAsync(DeleteLoggingConfigurationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLoggingConfigurationAsync(DeleteLoggingConfigurationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRateBasedRule asynchronously, invoking a callback when done
 -- @param GetRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRateBasedRuleAsync(GetRateBasedRuleRequest, cb)
 	assert(GetRateBasedRuleRequest, "You must provide a GetRateBasedRuleRequest")
 	local headers = {
@@ -11148,19 +11195,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRateBasedRuleSync(GetRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRateBasedRuleAsync(GetRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRateBasedRuleAsync(GetRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGeoMatchSet asynchronously, invoking a callback when done
 -- @param DeleteGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGeoMatchSetAsync(DeleteGeoMatchSetRequest, cb)
 	assert(DeleteGeoMatchSetRequest, "You must provide a DeleteGeoMatchSetRequest")
 	local headers = {
@@ -11183,19 +11231,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGeoMatchSetSync(DeleteGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGeoMatchSetAsync(DeleteGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGeoMatchSetAsync(DeleteGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRateBasedRule asynchronously, invoking a callback when done
 -- @param CreateRateBasedRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRateBasedRuleAsync(CreateRateBasedRuleRequest, cb)
 	assert(CreateRateBasedRuleRequest, "You must provide a CreateRateBasedRuleRequest")
 	local headers = {
@@ -11218,19 +11267,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRateBasedRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRateBasedRuleSync(CreateRateBasedRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRateBasedRuleAsync(CreateRateBasedRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRateBasedRuleAsync(CreateRateBasedRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRuleGroup asynchronously, invoking a callback when done
 -- @param GetRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRuleGroupAsync(GetRuleGroupRequest, cb)
 	assert(GetRuleGroupRequest, "You must provide a GetRuleGroupRequest")
 	local headers = {
@@ -11253,19 +11303,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRuleGroupSync(GetRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRuleGroupAsync(GetRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRuleGroupAsync(GetRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRules asynchronously, invoking a callback when done
 -- @param ListRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRulesAsync(ListRulesRequest, cb)
 	assert(ListRulesRequest, "You must provide a ListRulesRequest")
 	local headers = {
@@ -11288,19 +11339,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRulesSync(ListRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRulesAsync(ListRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRulesAsync(ListRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSampledRequests asynchronously, invoking a callback when done
 -- @param GetSampledRequestsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSampledRequestsAsync(GetSampledRequestsRequest, cb)
 	assert(GetSampledRequestsRequest, "You must provide a GetSampledRequestsRequest")
 	local headers = {
@@ -11323,19 +11375,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSampledRequestsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSampledRequestsSync(GetSampledRequestsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSampledRequestsAsync(GetSampledRequestsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSampledRequestsAsync(GetSampledRequestsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateWebACL asynchronously, invoking a callback when done
 -- @param CreateWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateWebACLAsync(CreateWebACLRequest, cb)
 	assert(CreateWebACLRequest, "You must provide a CreateWebACLRequest")
 	local headers = {
@@ -11358,19 +11411,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateWebACLSync(CreateWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateWebACLAsync(CreateWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateWebACLAsync(CreateWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteWebACL asynchronously, invoking a callback when done
 -- @param DeleteWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteWebACLAsync(DeleteWebACLRequest, cb)
 	assert(DeleteWebACLRequest, "You must provide a DeleteWebACLRequest")
 	local headers = {
@@ -11393,19 +11447,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteWebACLSync(DeleteWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteWebACLAsync(DeleteWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteWebACLAsync(DeleteWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRuleGroup asynchronously, invoking a callback when done
 -- @param CreateRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRuleGroupAsync(CreateRuleGroupRequest, cb)
 	assert(CreateRuleGroupRequest, "You must provide a CreateRuleGroupRequest")
 	local headers = {
@@ -11428,19 +11483,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRuleGroupSync(CreateRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRuleGroupAsync(CreateRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRuleGroupAsync(CreateRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetRule asynchronously, invoking a callback when done
 -- @param GetRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetRuleAsync(GetRuleRequest, cb)
 	assert(GetRuleRequest, "You must provide a GetRuleRequest")
 	local headers = {
@@ -11463,19 +11519,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetRuleSync(GetRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetRuleAsync(GetRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetRuleAsync(GetRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSizeConstraintSet asynchronously, invoking a callback when done
 -- @param DeleteSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSizeConstraintSetAsync(DeleteSizeConstraintSetRequest, cb)
 	assert(DeleteSizeConstraintSetRequest, "You must provide a DeleteSizeConstraintSetRequest")
 	local headers = {
@@ -11498,19 +11555,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSizeConstraintSetSync(DeleteSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSizeConstraintSetAsync(DeleteSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSizeConstraintSetAsync(DeleteSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSizeConstraintSet asynchronously, invoking a callback when done
 -- @param UpdateSizeConstraintSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSizeConstraintSetAsync(UpdateSizeConstraintSetRequest, cb)
 	assert(UpdateSizeConstraintSetRequest, "You must provide a UpdateSizeConstraintSetRequest")
 	local headers = {
@@ -11533,19 +11591,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSizeConstraintSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSizeConstraintSetSync(UpdateSizeConstraintSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSizeConstraintSetAsync(UpdateSizeConstraintSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSizeConstraintSetAsync(UpdateSizeConstraintSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListActivatedRulesInRuleGroup asynchronously, invoking a callback when done
 -- @param ListActivatedRulesInRuleGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListActivatedRulesInRuleGroupAsync(ListActivatedRulesInRuleGroupRequest, cb)
 	assert(ListActivatedRulesInRuleGroupRequest, "You must provide a ListActivatedRulesInRuleGroupRequest")
 	local headers = {
@@ -11568,19 +11627,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListActivatedRulesInRuleGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListActivatedRulesInRuleGroupSync(ListActivatedRulesInRuleGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListActivatedRulesInRuleGroupAsync(ListActivatedRulesInRuleGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListActivatedRulesInRuleGroupAsync(ListActivatedRulesInRuleGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateWebACL asynchronously, invoking a callback when done
 -- @param UpdateWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateWebACLAsync(UpdateWebACLRequest, cb)
 	assert(UpdateWebACLRequest, "You must provide a UpdateWebACLRequest")
 	local headers = {
@@ -11603,19 +11663,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateWebACLSync(UpdateWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateWebACLAsync(UpdateWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateWebACLAsync(UpdateWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetChangeToken asynchronously, invoking a callback when done
 -- @param GetChangeTokenRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetChangeTokenAsync(GetChangeTokenRequest, cb)
 	assert(GetChangeTokenRequest, "You must provide a GetChangeTokenRequest")
 	local headers = {
@@ -11638,19 +11699,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetChangeTokenRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetChangeTokenSync(GetChangeTokenRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetChangeTokenAsync(GetChangeTokenRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetChangeTokenAsync(GetChangeTokenRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteRegexMatchSet asynchronously, invoking a callback when done
 -- @param DeleteRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteRegexMatchSetAsync(DeleteRegexMatchSetRequest, cb)
 	assert(DeleteRegexMatchSetRequest, "You must provide a DeleteRegexMatchSetRequest")
 	local headers = {
@@ -11673,19 +11735,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteRegexMatchSetSync(DeleteRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteRegexMatchSetAsync(DeleteRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteRegexMatchSetAsync(DeleteRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetWebACL asynchronously, invoking a callback when done
 -- @param GetWebACLRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetWebACLAsync(GetWebACLRequest, cb)
 	assert(GetWebACLRequest, "You must provide a GetWebACLRequest")
 	local headers = {
@@ -11708,19 +11771,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetWebACLRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetWebACLSync(GetWebACLRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetWebACLAsync(GetWebACLRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetWebACLAsync(GetWebACLRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeletePermissionPolicy asynchronously, invoking a callback when done
 -- @param DeletePermissionPolicyRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeletePermissionPolicyAsync(DeletePermissionPolicyRequest, cb)
 	assert(DeletePermissionPolicyRequest, "You must provide a DeletePermissionPolicyRequest")
 	local headers = {
@@ -11743,19 +11807,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeletePermissionPolicyRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeletePermissionPolicySync(DeletePermissionPolicyRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeletePermissionPolicyAsync(DeletePermissionPolicyRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeletePermissionPolicyAsync(DeletePermissionPolicyRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateByteMatchSet asynchronously, invoking a callback when done
 -- @param UpdateByteMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateByteMatchSetAsync(UpdateByteMatchSetRequest, cb)
 	assert(UpdateByteMatchSetRequest, "You must provide a UpdateByteMatchSetRequest")
 	local headers = {
@@ -11778,19 +11843,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateByteMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateByteMatchSetSync(UpdateByteMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateByteMatchSetAsync(UpdateByteMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateByteMatchSetAsync(UpdateByteMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateXssMatchSet asynchronously, invoking a callback when done
 -- @param UpdateXssMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateXssMatchSetAsync(UpdateXssMatchSetRequest, cb)
 	assert(UpdateXssMatchSetRequest, "You must provide a UpdateXssMatchSetRequest")
 	local headers = {
@@ -11813,19 +11879,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateXssMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateXssMatchSetSync(UpdateXssMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateXssMatchSetAsync(UpdateXssMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateXssMatchSetAsync(UpdateXssMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateRegexMatchSet asynchronously, invoking a callback when done
 -- @param CreateRegexMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateRegexMatchSetAsync(CreateRegexMatchSetRequest, cb)
 	assert(CreateRegexMatchSetRequest, "You must provide a CreateRegexMatchSetRequest")
 	local headers = {
@@ -11848,19 +11915,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateRegexMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateRegexMatchSetSync(CreateRegexMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateRegexMatchSetAsync(CreateRegexMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateRegexMatchSetAsync(CreateRegexMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSqlInjectionMatchSet asynchronously, invoking a callback when done
 -- @param GetSqlInjectionMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSqlInjectionMatchSetAsync(GetSqlInjectionMatchSetRequest, cb)
 	assert(GetSqlInjectionMatchSetRequest, "You must provide a GetSqlInjectionMatchSetRequest")
 	local headers = {
@@ -11883,19 +11951,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSqlInjectionMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSqlInjectionMatchSetSync(GetSqlInjectionMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSqlInjectionMatchSetAsync(GetSqlInjectionMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSqlInjectionMatchSetAsync(GetSqlInjectionMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListRegexPatternSets asynchronously, invoking a callback when done
 -- @param ListRegexPatternSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListRegexPatternSetsAsync(ListRegexPatternSetsRequest, cb)
 	assert(ListRegexPatternSetsRequest, "You must provide a ListRegexPatternSetsRequest")
 	local headers = {
@@ -11918,19 +11987,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListRegexPatternSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListRegexPatternSetsSync(ListRegexPatternSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListRegexPatternSetsAsync(ListRegexPatternSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListRegexPatternSetsAsync(ListRegexPatternSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListSizeConstraintSets asynchronously, invoking a callback when done
 -- @param ListSizeConstraintSetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListSizeConstraintSetsAsync(ListSizeConstraintSetsRequest, cb)
 	assert(ListSizeConstraintSetsRequest, "You must provide a ListSizeConstraintSetsRequest")
 	local headers = {
@@ -11953,19 +12023,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListSizeConstraintSetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListSizeConstraintSetsSync(ListSizeConstraintSetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListSizeConstraintSetsAsync(ListSizeConstraintSetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListSizeConstraintSetsAsync(ListSizeConstraintSetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIPSet asynchronously, invoking a callback when done
 -- @param DeleteIPSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIPSetAsync(DeleteIPSetRequest, cb)
 	assert(DeleteIPSetRequest, "You must provide a DeleteIPSetRequest")
 	local headers = {
@@ -11988,19 +12059,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIPSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIPSetSync(DeleteIPSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIPSetAsync(DeleteIPSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIPSetAsync(DeleteIPSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGeoMatchSet asynchronously, invoking a callback when done
 -- @param CreateGeoMatchSetRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGeoMatchSetAsync(CreateGeoMatchSetRequest, cb)
 	assert(CreateGeoMatchSetRequest, "You must provide a CreateGeoMatchSetRequest")
 	local headers = {
@@ -12023,12 +12095,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGeoMatchSetRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGeoMatchSetSync(CreateGeoMatchSetRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGeoMatchSetAsync(CreateGeoMatchSetRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGeoMatchSetAsync(CreateGeoMatchSetRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/workdocs.lua
+++ b/aws-sdk/workdocs.lua
@@ -6163,7 +6163,7 @@ end
 --
 --- Call DeactivateUser asynchronously, invoking a callback when done
 -- @param DeactivateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeactivateUserAsync(DeactivateUserRequest, cb)
 	assert(DeactivateUserRequest, "You must provide a DeactivateUserRequest")
 	local headers = {
@@ -6186,19 +6186,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeactivateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeactivateUserSync(DeactivateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeactivateUserAsync(DeactivateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeactivateUserAsync(DeactivateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeRootFolders asynchronously, invoking a callback when done
 -- @param DescribeRootFoldersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeRootFoldersAsync(DescribeRootFoldersRequest, cb)
 	assert(DescribeRootFoldersRequest, "You must provide a DescribeRootFoldersRequest")
 	local headers = {
@@ -6221,19 +6222,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeRootFoldersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeRootFoldersSync(DescribeRootFoldersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeRootFoldersAsync(DescribeRootFoldersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeRootFoldersAsync(DescribeRootFoldersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AddResourcePermissions asynchronously, invoking a callback when done
 -- @param AddResourcePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AddResourcePermissionsAsync(AddResourcePermissionsRequest, cb)
 	assert(AddResourcePermissionsRequest, "You must provide a AddResourcePermissionsRequest")
 	local headers = {
@@ -6256,19 +6258,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AddResourcePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AddResourcePermissionsSync(AddResourcePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AddResourcePermissionsAsync(AddResourcePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AddResourcePermissionsAsync(AddResourcePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFolder asynchronously, invoking a callback when done
 -- @param DeleteFolderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFolderAsync(DeleteFolderRequest, cb)
 	assert(DeleteFolderRequest, "You must provide a DeleteFolderRequest")
 	local headers = {
@@ -6291,19 +6294,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFolderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFolderSync(DeleteFolderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFolderAsync(DeleteFolderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFolderAsync(DeleteFolderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUsers asynchronously, invoking a callback when done
 -- @param DescribeUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUsersAsync(DescribeUsersRequest, cb)
 	assert(DescribeUsersRequest, "You must provide a DescribeUsersRequest")
 	local headers = {
@@ -6326,19 +6330,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUsersSync(DescribeUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUsersAsync(DescribeUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUsersAsync(DescribeUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDocumentVersion asynchronously, invoking a callback when done
 -- @param UpdateDocumentVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDocumentVersionAsync(UpdateDocumentVersionRequest, cb)
 	assert(UpdateDocumentVersionRequest, "You must provide a UpdateDocumentVersionRequest")
 	local headers = {
@@ -6361,19 +6366,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDocumentVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDocumentVersionSync(UpdateDocumentVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDocumentVersionAsync(UpdateDocumentVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDocumentVersionAsync(UpdateDocumentVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteCustomMetadata asynchronously, invoking a callback when done
 -- @param DeleteCustomMetadataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCustomMetadataAsync(DeleteCustomMetadataRequest, cb)
 	assert(DeleteCustomMetadataRequest, "You must provide a DeleteCustomMetadataRequest")
 	local headers = {
@@ -6396,19 +6402,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCustomMetadataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCustomMetadataSync(DeleteCustomMetadataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCustomMetadataAsync(DeleteCustomMetadataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCustomMetadataAsync(DeleteCustomMetadataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateLabels asynchronously, invoking a callback when done
 -- @param CreateLabelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateLabelsAsync(CreateLabelsRequest, cb)
 	assert(CreateLabelsRequest, "You must provide a CreateLabelsRequest")
 	local headers = {
@@ -6431,19 +6438,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateLabelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateLabelsSync(CreateLabelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateLabelsAsync(CreateLabelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateLabelsAsync(CreateLabelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call InitiateDocumentVersionUpload asynchronously, invoking a callback when done
 -- @param InitiateDocumentVersionUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.InitiateDocumentVersionUploadAsync(InitiateDocumentVersionUploadRequest, cb)
 	assert(InitiateDocumentVersionUploadRequest, "You must provide a InitiateDocumentVersionUploadRequest")
 	local headers = {
@@ -6466,19 +6474,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param InitiateDocumentVersionUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.InitiateDocumentVersionUploadSync(InitiateDocumentVersionUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.InitiateDocumentVersionUploadAsync(InitiateDocumentVersionUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.InitiateDocumentVersionUploadAsync(InitiateDocumentVersionUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateCustomMetadata asynchronously, invoking a callback when done
 -- @param CreateCustomMetadataRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCustomMetadataAsync(CreateCustomMetadataRequest, cb)
 	assert(CreateCustomMetadataRequest, "You must provide a CreateCustomMetadataRequest")
 	local headers = {
@@ -6501,19 +6510,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCustomMetadataRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCustomMetadataSync(CreateCustomMetadataRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCustomMetadataAsync(CreateCustomMetadataRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCustomMetadataAsync(CreateCustomMetadataRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocument asynchronously, invoking a callback when done
 -- @param GetDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentAsync(GetDocumentRequest, cb)
 	assert(GetDocumentRequest, "You must provide a GetDocumentRequest")
 	local headers = {
@@ -6536,19 +6546,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentSync(GetDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentAsync(GetDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentAsync(GetDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocumentPath asynchronously, invoking a callback when done
 -- @param GetDocumentPathRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentPathAsync(GetDocumentPathRequest, cb)
 	assert(GetDocumentPathRequest, "You must provide a GetDocumentPathRequest")
 	local headers = {
@@ -6571,19 +6582,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentPathRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentPathSync(GetDocumentPathRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentPathAsync(GetDocumentPathRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentPathAsync(GetDocumentPathRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveAllResourcePermissions asynchronously, invoking a callback when done
 -- @param RemoveAllResourcePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveAllResourcePermissionsAsync(RemoveAllResourcePermissionsRequest, cb)
 	assert(RemoveAllResourcePermissionsRequest, "You must provide a RemoveAllResourcePermissionsRequest")
 	local headers = {
@@ -6606,19 +6618,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveAllResourcePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveAllResourcePermissionsSync(RemoveAllResourcePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveAllResourcePermissionsAsync(RemoveAllResourcePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveAllResourcePermissionsAsync(RemoveAllResourcePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateUser asynchronously, invoking a callback when done
 -- @param UpdateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateUserAsync(UpdateUserRequest, cb)
 	assert(UpdateUserRequest, "You must provide a UpdateUserRequest")
 	local headers = {
@@ -6641,19 +6654,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateUserSync(UpdateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateUserAsync(UpdateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateUserAsync(UpdateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetCurrentUser asynchronously, invoking a callback when done
 -- @param GetCurrentUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetCurrentUserAsync(GetCurrentUserRequest, cb)
 	assert(GetCurrentUserRequest, "You must provide a GetCurrentUserRequest")
 	local headers = {
@@ -6676,19 +6690,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetCurrentUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetCurrentUserSync(GetCurrentUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetCurrentUserAsync(GetCurrentUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetCurrentUserAsync(GetCurrentUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateFolder asynchronously, invoking a callback when done
 -- @param UpdateFolderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateFolderAsync(UpdateFolderRequest, cb)
 	assert(UpdateFolderRequest, "You must provide a UpdateFolderRequest")
 	local headers = {
@@ -6711,19 +6726,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateFolderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateFolderSync(UpdateFolderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateFolderAsync(UpdateFolderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateFolderAsync(UpdateFolderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteComment asynchronously, invoking a callback when done
 -- @param DeleteCommentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteCommentAsync(DeleteCommentRequest, cb)
 	assert(DeleteCommentRequest, "You must provide a DeleteCommentRequest")
 	local headers = {
@@ -6746,19 +6762,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteCommentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteCommentSync(DeleteCommentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteCommentAsync(DeleteCommentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteCommentAsync(DeleteCommentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUser asynchronously, invoking a callback when done
 -- @param CreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserAsync(CreateUserRequest, cb)
 	assert(CreateUserRequest, "You must provide a CreateUserRequest")
 	local headers = {
@@ -6781,19 +6798,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserSync(CreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserAsync(CreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserAsync(CreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteFolderContents asynchronously, invoking a callback when done
 -- @param DeleteFolderContentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteFolderContentsAsync(DeleteFolderContentsRequest, cb)
 	assert(DeleteFolderContentsRequest, "You must provide a DeleteFolderContentsRequest")
 	local headers = {
@@ -6816,19 +6834,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteFolderContentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteFolderContentsSync(DeleteFolderContentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteFolderContentsAsync(DeleteFolderContentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteFolderContentsAsync(DeleteFolderContentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteNotificationSubscription asynchronously, invoking a callback when done
 -- @param DeleteNotificationSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteNotificationSubscriptionAsync(DeleteNotificationSubscriptionRequest, cb)
 	assert(DeleteNotificationSubscriptionRequest, "You must provide a DeleteNotificationSubscriptionRequest")
 	local headers = {
@@ -6851,19 +6870,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteNotificationSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteNotificationSubscriptionSync(DeleteNotificationSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteNotificationSubscriptionAsync(DeleteNotificationSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteNotificationSubscriptionAsync(DeleteNotificationSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AbortDocumentVersionUpload asynchronously, invoking a callback when done
 -- @param AbortDocumentVersionUploadRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AbortDocumentVersionUploadAsync(AbortDocumentVersionUploadRequest, cb)
 	assert(AbortDocumentVersionUploadRequest, "You must provide a AbortDocumentVersionUploadRequest")
 	local headers = {
@@ -6886,19 +6906,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AbortDocumentVersionUploadRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AbortDocumentVersionUploadSync(AbortDocumentVersionUploadRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AbortDocumentVersionUploadAsync(AbortDocumentVersionUploadRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AbortDocumentVersionUploadAsync(AbortDocumentVersionUploadRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeNotificationSubscriptions asynchronously, invoking a callback when done
 -- @param DescribeNotificationSubscriptionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeNotificationSubscriptionsAsync(DescribeNotificationSubscriptionsRequest, cb)
 	assert(DescribeNotificationSubscriptionsRequest, "You must provide a DescribeNotificationSubscriptionsRequest")
 	local headers = {
@@ -6921,19 +6942,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeNotificationSubscriptionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeNotificationSubscriptionsSync(DescribeNotificationSubscriptionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeNotificationSubscriptionsAsync(DescribeNotificationSubscriptionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeNotificationSubscriptionsAsync(DescribeNotificationSubscriptionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateComment asynchronously, invoking a callback when done
 -- @param CreateCommentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateCommentAsync(CreateCommentRequest, cb)
 	assert(CreateCommentRequest, "You must provide a CreateCommentRequest")
 	local headers = {
@@ -6956,19 +6978,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateCommentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateCommentSync(CreateCommentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateCommentAsync(CreateCommentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateCommentAsync(CreateCommentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetDocumentVersion asynchronously, invoking a callback when done
 -- @param GetDocumentVersionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetDocumentVersionAsync(GetDocumentVersionRequest, cb)
 	assert(GetDocumentVersionRequest, "You must provide a GetDocumentVersionRequest")
 	local headers = {
@@ -6991,19 +7014,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetDocumentVersionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetDocumentVersionSync(GetDocumentVersionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetDocumentVersionAsync(GetDocumentVersionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetDocumentVersionAsync(GetDocumentVersionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFolderPath asynchronously, invoking a callback when done
 -- @param GetFolderPathRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFolderPathAsync(GetFolderPathRequest, cb)
 	assert(GetFolderPathRequest, "You must provide a GetFolderPathRequest")
 	local headers = {
@@ -7026,19 +7050,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFolderPathRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFolderPathSync(GetFolderPathRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFolderPathAsync(GetFolderPathRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFolderPathAsync(GetFolderPathRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeFolderContents asynchronously, invoking a callback when done
 -- @param DescribeFolderContentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeFolderContentsAsync(DescribeFolderContentsRequest, cb)
 	assert(DescribeFolderContentsRequest, "You must provide a DescribeFolderContentsRequest")
 	local headers = {
@@ -7061,19 +7086,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeFolderContentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeFolderContentsSync(DescribeFolderContentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeFolderContentsAsync(DescribeFolderContentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeFolderContentsAsync(DescribeFolderContentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateFolder asynchronously, invoking a callback when done
 -- @param CreateFolderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateFolderAsync(CreateFolderRequest, cb)
 	assert(CreateFolderRequest, "You must provide a CreateFolderRequest")
 	local headers = {
@@ -7096,19 +7122,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateFolderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateFolderSync(CreateFolderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateFolderAsync(CreateFolderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateFolderAsync(CreateFolderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGroups asynchronously, invoking a callback when done
 -- @param DescribeGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGroupsAsync(DescribeGroupsRequest, cb)
 	assert(DescribeGroupsRequest, "You must provide a DescribeGroupsRequest")
 	local headers = {
@@ -7131,19 +7158,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGroupsSync(DescribeGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGroupsAsync(DescribeGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGroupsAsync(DescribeGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeResourcePermissions asynchronously, invoking a callback when done
 -- @param DescribeResourcePermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeResourcePermissionsAsync(DescribeResourcePermissionsRequest, cb)
 	assert(DescribeResourcePermissionsRequest, "You must provide a DescribeResourcePermissionsRequest")
 	local headers = {
@@ -7166,19 +7194,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeResourcePermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeResourcePermissionsSync(DescribeResourcePermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeResourcePermissionsAsync(DescribeResourcePermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeResourcePermissionsAsync(DescribeResourcePermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateNotificationSubscription asynchronously, invoking a callback when done
 -- @param CreateNotificationSubscriptionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateNotificationSubscriptionAsync(CreateNotificationSubscriptionRequest, cb)
 	assert(CreateNotificationSubscriptionRequest, "You must provide a CreateNotificationSubscriptionRequest")
 	local headers = {
@@ -7201,19 +7230,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateNotificationSubscriptionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateNotificationSubscriptionSync(CreateNotificationSubscriptionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateNotificationSubscriptionAsync(CreateNotificationSubscriptionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateNotificationSubscriptionAsync(CreateNotificationSubscriptionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateDocument asynchronously, invoking a callback when done
 -- @param UpdateDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateDocumentAsync(UpdateDocumentRequest, cb)
 	assert(UpdateDocumentRequest, "You must provide a UpdateDocumentRequest")
 	local headers = {
@@ -7236,19 +7266,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateDocumentSync(UpdateDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateDocumentAsync(UpdateDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateDocumentAsync(UpdateDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeComments asynchronously, invoking a callback when done
 -- @param DescribeCommentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeCommentsAsync(DescribeCommentsRequest, cb)
 	assert(DescribeCommentsRequest, "You must provide a DescribeCommentsRequest")
 	local headers = {
@@ -7271,19 +7302,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeCommentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeCommentsSync(DescribeCommentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeCommentsAsync(DescribeCommentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeCommentsAsync(DescribeCommentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -7306,19 +7338,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteDocument asynchronously, invoking a callback when done
 -- @param DeleteDocumentRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteDocumentAsync(DeleteDocumentRequest, cb)
 	assert(DeleteDocumentRequest, "You must provide a DeleteDocumentRequest")
 	local headers = {
@@ -7341,19 +7374,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteDocumentRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteDocumentSync(DeleteDocumentRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteDocumentAsync(DeleteDocumentRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteDocumentAsync(DeleteDocumentRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeActivities asynchronously, invoking a callback when done
 -- @param DescribeActivitiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeActivitiesAsync(DescribeActivitiesRequest, cb)
 	assert(DescribeActivitiesRequest, "You must provide a DescribeActivitiesRequest")
 	local headers = {
@@ -7376,19 +7410,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeActivitiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeActivitiesSync(DescribeActivitiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeActivitiesAsync(DescribeActivitiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeActivitiesAsync(DescribeActivitiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ActivateUser asynchronously, invoking a callback when done
 -- @param ActivateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ActivateUserAsync(ActivateUserRequest, cb)
 	assert(ActivateUserRequest, "You must provide a ActivateUserRequest")
 	local headers = {
@@ -7411,19 +7446,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ActivateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ActivateUserSync(ActivateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ActivateUserAsync(ActivateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ActivateUserAsync(ActivateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetFolder asynchronously, invoking a callback when done
 -- @param GetFolderRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetFolderAsync(GetFolderRequest, cb)
 	assert(GetFolderRequest, "You must provide a GetFolderRequest")
 	local headers = {
@@ -7446,19 +7482,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetFolderRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetFolderSync(GetFolderRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetFolderAsync(GetFolderRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetFolderAsync(GetFolderRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RemoveResourcePermission asynchronously, invoking a callback when done
 -- @param RemoveResourcePermissionRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RemoveResourcePermissionAsync(RemoveResourcePermissionRequest, cb)
 	assert(RemoveResourcePermissionRequest, "You must provide a RemoveResourcePermissionRequest")
 	local headers = {
@@ -7481,19 +7518,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RemoveResourcePermissionRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RemoveResourcePermissionSync(RemoveResourcePermissionRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RemoveResourcePermissionAsync(RemoveResourcePermissionRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RemoveResourcePermissionAsync(RemoveResourcePermissionRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteLabels asynchronously, invoking a callback when done
 -- @param DeleteLabelsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteLabelsAsync(DeleteLabelsRequest, cb)
 	assert(DeleteLabelsRequest, "You must provide a DeleteLabelsRequest")
 	local headers = {
@@ -7516,19 +7554,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteLabelsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteLabelsSync(DeleteLabelsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteLabelsAsync(DeleteLabelsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteLabelsAsync(DeleteLabelsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeDocumentVersions asynchronously, invoking a callback when done
 -- @param DescribeDocumentVersionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeDocumentVersionsAsync(DescribeDocumentVersionsRequest, cb)
 	assert(DescribeDocumentVersionsRequest, "You must provide a DescribeDocumentVersionsRequest")
 	local headers = {
@@ -7551,12 +7590,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeDocumentVersionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeDocumentVersionsSync(DescribeDocumentVersionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeDocumentVersionsAsync(DescribeDocumentVersionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeDocumentVersionsAsync(DescribeDocumentVersionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/workmail.lua
+++ b/aws-sdk/workmail.lua
@@ -4081,7 +4081,7 @@ end
 --
 --- Call ListGroupMembers asynchronously, invoking a callback when done
 -- @param ListGroupMembersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupMembersAsync(ListGroupMembersRequest, cb)
 	assert(ListGroupMembersRequest, "You must provide a ListGroupMembersRequest")
 	local headers = {
@@ -4104,19 +4104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupMembersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupMembersSync(ListGroupMembersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupMembersAsync(ListGroupMembersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupMembersAsync(ListGroupMembersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdatePrimaryEmailAddress asynchronously, invoking a callback when done
 -- @param UpdatePrimaryEmailAddressRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdatePrimaryEmailAddressAsync(UpdatePrimaryEmailAddressRequest, cb)
 	assert(UpdatePrimaryEmailAddressRequest, "You must provide a UpdatePrimaryEmailAddressRequest")
 	local headers = {
@@ -4139,19 +4140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdatePrimaryEmailAddressRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdatePrimaryEmailAddressSync(UpdatePrimaryEmailAddressRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdatePrimaryEmailAddressAsync(UpdatePrimaryEmailAddressRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdatePrimaryEmailAddressAsync(UpdatePrimaryEmailAddressRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutMailboxPermissions asynchronously, invoking a callback when done
 -- @param PutMailboxPermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutMailboxPermissionsAsync(PutMailboxPermissionsRequest, cb)
 	assert(PutMailboxPermissionsRequest, "You must provide a PutMailboxPermissionsRequest")
 	local headers = {
@@ -4174,19 +4176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutMailboxPermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutMailboxPermissionsSync(PutMailboxPermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutMailboxPermissionsAsync(PutMailboxPermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutMailboxPermissionsAsync(PutMailboxPermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListUsers asynchronously, invoking a callback when done
 -- @param ListUsersRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListUsersAsync(ListUsersRequest, cb)
 	assert(ListUsersRequest, "You must provide a ListUsersRequest")
 	local headers = {
@@ -4209,19 +4212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListUsersRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListUsersSync(ListUsersRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListUsersAsync(ListUsersRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListUsersAsync(ListUsersRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateMemberFromGroup asynchronously, invoking a callback when done
 -- @param DisassociateMemberFromGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateMemberFromGroupAsync(DisassociateMemberFromGroupRequest, cb)
 	assert(DisassociateMemberFromGroupRequest, "You must provide a DisassociateMemberFromGroupRequest")
 	local headers = {
@@ -4244,19 +4248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateMemberFromGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateMemberFromGroupSync(DisassociateMemberFromGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateMemberFromGroupAsync(DisassociateMemberFromGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateMemberFromGroupAsync(DisassociateMemberFromGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeResource asynchronously, invoking a callback when done
 -- @param DescribeResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeResourceAsync(DescribeResourceRequest, cb)
 	assert(DescribeResourceRequest, "You must provide a DescribeResourceRequest")
 	local headers = {
@@ -4279,19 +4284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeResourceSync(DescribeResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeResourceAsync(DescribeResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeResourceAsync(DescribeResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateGroup asynchronously, invoking a callback when done
 -- @param CreateGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateGroupAsync(CreateGroupRequest, cb)
 	assert(CreateGroupRequest, "You must provide a CreateGroupRequest")
 	local headers = {
@@ -4314,19 +4320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateGroupSync(CreateGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateGroupAsync(CreateGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateGroupAsync(CreateGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListAliases asynchronously, invoking a callback when done
 -- @param ListAliasesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListAliasesAsync(ListAliasesRequest, cb)
 	assert(ListAliasesRequest, "You must provide a ListAliasesRequest")
 	local headers = {
@@ -4349,19 +4356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListAliasesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListAliasesSync(ListAliasesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListAliasesAsync(ListAliasesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListAliasesAsync(ListAliasesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeGroup asynchronously, invoking a callback when done
 -- @param DescribeGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeGroupAsync(DescribeGroupRequest, cb)
 	assert(DescribeGroupRequest, "You must provide a DescribeGroupRequest")
 	local headers = {
@@ -4384,19 +4392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeGroupSync(DescribeGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeGroupAsync(DescribeGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeGroupAsync(DescribeGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ResetPassword asynchronously, invoking a callback when done
 -- @param ResetPasswordRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ResetPasswordAsync(ResetPasswordRequest, cb)
 	assert(ResetPasswordRequest, "You must provide a ResetPasswordRequest")
 	local headers = {
@@ -4419,19 +4428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ResetPasswordRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ResetPasswordSync(ResetPasswordRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ResetPasswordAsync(ResetPasswordRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ResetPasswordAsync(ResetPasswordRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteMailboxPermissions asynchronously, invoking a callback when done
 -- @param DeleteMailboxPermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteMailboxPermissionsAsync(DeleteMailboxPermissionsRequest, cb)
 	assert(DeleteMailboxPermissionsRequest, "You must provide a DeleteMailboxPermissionsRequest")
 	local headers = {
@@ -4454,19 +4464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteMailboxPermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteMailboxPermissionsSync(DeleteMailboxPermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteMailboxPermissionsAsync(DeleteMailboxPermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteMailboxPermissionsAsync(DeleteMailboxPermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateDelegateFromResource asynchronously, invoking a callback when done
 -- @param DisassociateDelegateFromResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateDelegateFromResourceAsync(DisassociateDelegateFromResourceRequest, cb)
 	assert(DisassociateDelegateFromResourceRequest, "You must provide a DisassociateDelegateFromResourceRequest")
 	local headers = {
@@ -4489,19 +4500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateDelegateFromResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateDelegateFromResourceSync(DisassociateDelegateFromResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateDelegateFromResourceAsync(DisassociateDelegateFromResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateDelegateFromResourceAsync(DisassociateDelegateFromResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListOrganizations asynchronously, invoking a callback when done
 -- @param ListOrganizationsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListOrganizationsAsync(ListOrganizationsRequest, cb)
 	assert(ListOrganizationsRequest, "You must provide a ListOrganizationsRequest")
 	local headers = {
@@ -4524,19 +4536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListOrganizationsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListOrganizationsSync(ListOrganizationsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListOrganizationsAsync(ListOrganizationsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListOrganizationsAsync(ListOrganizationsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RegisterToWorkMail asynchronously, invoking a callback when done
 -- @param RegisterToWorkMailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RegisterToWorkMailAsync(RegisterToWorkMailRequest, cb)
 	assert(RegisterToWorkMailRequest, "You must provide a RegisterToWorkMailRequest")
 	local headers = {
@@ -4559,19 +4572,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RegisterToWorkMailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RegisterToWorkMailSync(RegisterToWorkMailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RegisterToWorkMailAsync(RegisterToWorkMailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RegisterToWorkMailAsync(RegisterToWorkMailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteAlias asynchronously, invoking a callback when done
 -- @param DeleteAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteAliasAsync(DeleteAliasRequest, cb)
 	assert(DeleteAliasRequest, "You must provide a DeleteAliasRequest")
 	local headers = {
@@ -4594,19 +4608,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteAliasSync(DeleteAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteAliasAsync(DeleteAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteAliasAsync(DeleteAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteGroup asynchronously, invoking a callback when done
 -- @param DeleteGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteGroupAsync(DeleteGroupRequest, cb)
 	assert(DeleteGroupRequest, "You must provide a DeleteGroupRequest")
 	local headers = {
@@ -4629,19 +4644,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteGroupSync(DeleteGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteGroupAsync(DeleteGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeUser asynchronously, invoking a callback when done
 -- @param DescribeUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeUserAsync(DescribeUserRequest, cb)
 	assert(DescribeUserRequest, "You must provide a DescribeUserRequest")
 	local headers = {
@@ -4664,19 +4680,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeUserSync(DescribeUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeUserAsync(DescribeUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeUserAsync(DescribeUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListMailboxPermissions asynchronously, invoking a callback when done
 -- @param ListMailboxPermissionsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListMailboxPermissionsAsync(ListMailboxPermissionsRequest, cb)
 	assert(ListMailboxPermissionsRequest, "You must provide a ListMailboxPermissionsRequest")
 	local headers = {
@@ -4699,19 +4716,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListMailboxPermissionsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListMailboxPermissionsSync(ListMailboxPermissionsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListMailboxPermissionsAsync(ListMailboxPermissionsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListMailboxPermissionsAsync(ListMailboxPermissionsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateDelegateToResource asynchronously, invoking a callback when done
 -- @param AssociateDelegateToResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateDelegateToResourceAsync(AssociateDelegateToResourceRequest, cb)
 	assert(AssociateDelegateToResourceRequest, "You must provide a AssociateDelegateToResourceRequest")
 	local headers = {
@@ -4734,19 +4752,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateDelegateToResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateDelegateToResourceSync(AssociateDelegateToResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateDelegateToResourceAsync(AssociateDelegateToResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateDelegateToResourceAsync(AssociateDelegateToResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResourceDelegates asynchronously, invoking a callback when done
 -- @param ListResourceDelegatesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourceDelegatesAsync(ListResourceDelegatesRequest, cb)
 	assert(ListResourceDelegatesRequest, "You must provide a ListResourceDelegatesRequest")
 	local headers = {
@@ -4769,19 +4788,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourceDelegatesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourceDelegatesSync(ListResourceDelegatesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourceDelegatesAsync(ListResourceDelegatesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourceDelegatesAsync(ListResourceDelegatesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListGroups asynchronously, invoking a callback when done
 -- @param ListGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListGroupsAsync(ListGroupsRequest, cb)
 	assert(ListGroupsRequest, "You must provide a ListGroupsRequest")
 	local headers = {
@@ -4804,19 +4824,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListGroupsSync(ListGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListGroupsAsync(ListGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListGroupsAsync(ListGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeregisterFromWorkMail asynchronously, invoking a callback when done
 -- @param DeregisterFromWorkMailRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeregisterFromWorkMailAsync(DeregisterFromWorkMailRequest, cb)
 	assert(DeregisterFromWorkMailRequest, "You must provide a DeregisterFromWorkMailRequest")
 	local headers = {
@@ -4839,19 +4860,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeregisterFromWorkMailRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeregisterFromWorkMailSync(DeregisterFromWorkMailRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeregisterFromWorkMailAsync(DeregisterFromWorkMailRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeregisterFromWorkMailAsync(DeregisterFromWorkMailRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeOrganization asynchronously, invoking a callback when done
 -- @param DescribeOrganizationRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeOrganizationAsync(DescribeOrganizationRequest, cb)
 	assert(DescribeOrganizationRequest, "You must provide a DescribeOrganizationRequest")
 	local headers = {
@@ -4874,19 +4896,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeOrganizationRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeOrganizationSync(DescribeOrganizationRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeOrganizationAsync(DescribeOrganizationRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeOrganizationAsync(DescribeOrganizationRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateMemberToGroup asynchronously, invoking a callback when done
 -- @param AssociateMemberToGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateMemberToGroupAsync(AssociateMemberToGroupRequest, cb)
 	assert(AssociateMemberToGroupRequest, "You must provide a AssociateMemberToGroupRequest")
 	local headers = {
@@ -4909,19 +4932,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateMemberToGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateMemberToGroupSync(AssociateMemberToGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateMemberToGroupAsync(AssociateMemberToGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateMemberToGroupAsync(AssociateMemberToGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteUser asynchronously, invoking a callback when done
 -- @param DeleteUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteUserAsync(DeleteUserRequest, cb)
 	assert(DeleteUserRequest, "You must provide a DeleteUserRequest")
 	local headers = {
@@ -4944,19 +4968,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteUserSync(DeleteUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteUserAsync(DeleteUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteUserAsync(DeleteUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateAlias asynchronously, invoking a callback when done
 -- @param CreateAliasRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateAliasAsync(CreateAliasRequest, cb)
 	assert(CreateAliasRequest, "You must provide a CreateAliasRequest")
 	local headers = {
@@ -4979,19 +5004,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateAliasRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateAliasSync(CreateAliasRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateAliasAsync(CreateAliasRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateAliasAsync(CreateAliasRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ListResources asynchronously, invoking a callback when done
 -- @param ListResourcesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ListResourcesAsync(ListResourcesRequest, cb)
 	assert(ListResourcesRequest, "You must provide a ListResourcesRequest")
 	local headers = {
@@ -5014,19 +5040,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ListResourcesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ListResourcesSync(ListResourcesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ListResourcesAsync(ListResourcesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ListResourcesAsync(ListResourcesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteResource asynchronously, invoking a callback when done
 -- @param DeleteResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteResourceAsync(DeleteResourceRequest, cb)
 	assert(DeleteResourceRequest, "You must provide a DeleteResourceRequest")
 	local headers = {
@@ -5049,19 +5076,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteResourceSync(DeleteResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteResourceAsync(DeleteResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteResourceAsync(DeleteResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateResource asynchronously, invoking a callback when done
 -- @param CreateResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateResourceAsync(CreateResourceRequest, cb)
 	assert(CreateResourceRequest, "You must provide a CreateResourceRequest")
 	local headers = {
@@ -5084,19 +5112,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateResourceSync(CreateResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateResourceAsync(CreateResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateResourceAsync(CreateResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateUser asynchronously, invoking a callback when done
 -- @param CreateUserRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateUserAsync(CreateUserRequest, cb)
 	assert(CreateUserRequest, "You must provide a CreateUserRequest")
 	local headers = {
@@ -5119,19 +5148,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateUserRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateUserSync(CreateUserRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateUserAsync(CreateUserRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateUserAsync(CreateUserRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateResource asynchronously, invoking a callback when done
 -- @param UpdateResourceRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateResourceAsync(UpdateResourceRequest, cb)
 	assert(UpdateResourceRequest, "You must provide a UpdateResourceRequest")
 	local headers = {
@@ -5154,12 +5184,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateResourceRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateResourceSync(UpdateResourceRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateResourceAsync(UpdateResourceRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateResourceAsync(UpdateResourceRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/workspaces.lua
+++ b/aws-sdk/workspaces.lua
@@ -3757,7 +3757,7 @@ end
 --
 --- Call DeleteTags asynchronously, invoking a callback when done
 -- @param DeleteTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteTagsAsync(DeleteTagsRequest, cb)
 	assert(DeleteTagsRequest, "You must provide a DeleteTagsRequest")
 	local headers = {
@@ -3780,19 +3780,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteTagsSync(DeleteTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteTagsAsync(DeleteTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call TerminateWorkspaces asynchronously, invoking a callback when done
 -- @param TerminateWorkspacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.TerminateWorkspacesAsync(TerminateWorkspacesRequest, cb)
 	assert(TerminateWorkspacesRequest, "You must provide a TerminateWorkspacesRequest")
 	local headers = {
@@ -3815,19 +3816,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param TerminateWorkspacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.TerminateWorkspacesSync(TerminateWorkspacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.TerminateWorkspacesAsync(TerminateWorkspacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.TerminateWorkspacesAsync(TerminateWorkspacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeWorkspaceBundles asynchronously, invoking a callback when done
 -- @param DescribeWorkspaceBundlesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeWorkspaceBundlesAsync(DescribeWorkspaceBundlesRequest, cb)
 	assert(DescribeWorkspaceBundlesRequest, "You must provide a DescribeWorkspaceBundlesRequest")
 	local headers = {
@@ -3850,19 +3852,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeWorkspaceBundlesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeWorkspaceBundlesSync(DescribeWorkspaceBundlesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeWorkspaceBundlesAsync(DescribeWorkspaceBundlesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeWorkspaceBundlesAsync(DescribeWorkspaceBundlesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeIpGroups asynchronously, invoking a callback when done
 -- @param DescribeIpGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeIpGroupsAsync(DescribeIpGroupsRequest, cb)
 	assert(DescribeIpGroupsRequest, "You must provide a DescribeIpGroupsRequest")
 	local headers = {
@@ -3885,19 +3888,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeIpGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeIpGroupsSync(DescribeIpGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeIpGroupsAsync(DescribeIpGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeIpGroupsAsync(DescribeIpGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebootWorkspaces asynchronously, invoking a callback when done
 -- @param RebootWorkspacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebootWorkspacesAsync(RebootWorkspacesRequest, cb)
 	assert(RebootWorkspacesRequest, "You must provide a RebootWorkspacesRequest")
 	local headers = {
@@ -3920,19 +3924,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebootWorkspacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebootWorkspacesSync(RebootWorkspacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebootWorkspacesAsync(RebootWorkspacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebootWorkspacesAsync(RebootWorkspacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateWorkspaces asynchronously, invoking a callback when done
 -- @param CreateWorkspacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateWorkspacesAsync(CreateWorkspacesRequest, cb)
 	assert(CreateWorkspacesRequest, "You must provide a CreateWorkspacesRequest")
 	local headers = {
@@ -3955,19 +3960,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateWorkspacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateWorkspacesSync(CreateWorkspacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateWorkspacesAsync(CreateWorkspacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateWorkspacesAsync(CreateWorkspacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyWorkspaceState asynchronously, invoking a callback when done
 -- @param ModifyWorkspaceStateRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyWorkspaceStateAsync(ModifyWorkspaceStateRequest, cb)
 	assert(ModifyWorkspaceStateRequest, "You must provide a ModifyWorkspaceStateRequest")
 	local headers = {
@@ -3990,19 +3996,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyWorkspaceStateRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyWorkspaceStateSync(ModifyWorkspaceStateRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyWorkspaceStateAsync(ModifyWorkspaceStateRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyWorkspaceStateAsync(ModifyWorkspaceStateRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateRulesOfIpGroup asynchronously, invoking a callback when done
 -- @param UpdateRulesOfIpGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateRulesOfIpGroupAsync(UpdateRulesOfIpGroupRequest, cb)
 	assert(UpdateRulesOfIpGroupRequest, "You must provide a UpdateRulesOfIpGroupRequest")
 	local headers = {
@@ -4025,19 +4032,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateRulesOfIpGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateRulesOfIpGroupSync(UpdateRulesOfIpGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateRulesOfIpGroupAsync(UpdateRulesOfIpGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateRulesOfIpGroupAsync(UpdateRulesOfIpGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call ModifyWorkspaceProperties asynchronously, invoking a callback when done
 -- @param ModifyWorkspacePropertiesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.ModifyWorkspacePropertiesAsync(ModifyWorkspacePropertiesRequest, cb)
 	assert(ModifyWorkspacePropertiesRequest, "You must provide a ModifyWorkspacePropertiesRequest")
 	local headers = {
@@ -4060,19 +4068,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param ModifyWorkspacePropertiesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.ModifyWorkspacePropertiesSync(ModifyWorkspacePropertiesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.ModifyWorkspacePropertiesAsync(ModifyWorkspacePropertiesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.ModifyWorkspacePropertiesAsync(ModifyWorkspacePropertiesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteIpGroup asynchronously, invoking a callback when done
 -- @param DeleteIpGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteIpGroupAsync(DeleteIpGroupRequest, cb)
 	assert(DeleteIpGroupRequest, "You must provide a DeleteIpGroupRequest")
 	local headers = {
@@ -4095,19 +4104,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteIpGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteIpGroupSync(DeleteIpGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteIpGroupAsync(DeleteIpGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteIpGroupAsync(DeleteIpGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeWorkspaces asynchronously, invoking a callback when done
 -- @param DescribeWorkspacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeWorkspacesAsync(DescribeWorkspacesRequest, cb)
 	assert(DescribeWorkspacesRequest, "You must provide a DescribeWorkspacesRequest")
 	local headers = {
@@ -4130,19 +4140,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeWorkspacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeWorkspacesSync(DescribeWorkspacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeWorkspacesAsync(DescribeWorkspacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeWorkspacesAsync(DescribeWorkspacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DisassociateIpGroups asynchronously, invoking a callback when done
 -- @param DisassociateIpGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DisassociateIpGroupsAsync(DisassociateIpGroupsRequest, cb)
 	assert(DisassociateIpGroupsRequest, "You must provide a DisassociateIpGroupsRequest")
 	local headers = {
@@ -4165,19 +4176,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DisassociateIpGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DisassociateIpGroupsSync(DisassociateIpGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DisassociateIpGroupsAsync(DisassociateIpGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DisassociateIpGroupsAsync(DisassociateIpGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RevokeIpRules asynchronously, invoking a callback when done
 -- @param RevokeIpRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RevokeIpRulesAsync(RevokeIpRulesRequest, cb)
 	assert(RevokeIpRulesRequest, "You must provide a RevokeIpRulesRequest")
 	local headers = {
@@ -4200,19 +4212,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RevokeIpRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RevokeIpRulesSync(RevokeIpRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RevokeIpRulesAsync(RevokeIpRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RevokeIpRulesAsync(RevokeIpRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StopWorkspaces asynchronously, invoking a callback when done
 -- @param StopWorkspacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StopWorkspacesAsync(StopWorkspacesRequest, cb)
 	assert(StopWorkspacesRequest, "You must provide a StopWorkspacesRequest")
 	local headers = {
@@ -4235,19 +4248,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StopWorkspacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StopWorkspacesSync(StopWorkspacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StopWorkspacesAsync(StopWorkspacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StopWorkspacesAsync(StopWorkspacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call StartWorkspaces asynchronously, invoking a callback when done
 -- @param StartWorkspacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.StartWorkspacesAsync(StartWorkspacesRequest, cb)
 	assert(StartWorkspacesRequest, "You must provide a StartWorkspacesRequest")
 	local headers = {
@@ -4270,19 +4284,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param StartWorkspacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.StartWorkspacesSync(StartWorkspacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.StartWorkspacesAsync(StartWorkspacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.StartWorkspacesAsync(StartWorkspacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call RebuildWorkspaces asynchronously, invoking a callback when done
 -- @param RebuildWorkspacesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.RebuildWorkspacesAsync(RebuildWorkspacesRequest, cb)
 	assert(RebuildWorkspacesRequest, "You must provide a RebuildWorkspacesRequest")
 	local headers = {
@@ -4305,19 +4320,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param RebuildWorkspacesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.RebuildWorkspacesSync(RebuildWorkspacesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.RebuildWorkspacesAsync(RebuildWorkspacesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.RebuildWorkspacesAsync(RebuildWorkspacesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeTags asynchronously, invoking a callback when done
 -- @param DescribeTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeTagsAsync(DescribeTagsRequest, cb)
 	assert(DescribeTagsRequest, "You must provide a DescribeTagsRequest")
 	local headers = {
@@ -4340,19 +4356,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeTagsSync(DescribeTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeTagsAsync(DescribeTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateIpGroup asynchronously, invoking a callback when done
 -- @param CreateIpGroupRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateIpGroupAsync(CreateIpGroupRequest, cb)
 	assert(CreateIpGroupRequest, "You must provide a CreateIpGroupRequest")
 	local headers = {
@@ -4375,19 +4392,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateIpGroupRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateIpGroupSync(CreateIpGroupRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateIpGroupAsync(CreateIpGroupRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateIpGroupAsync(CreateIpGroupRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateTags asynchronously, invoking a callback when done
 -- @param CreateTagsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateTagsAsync(CreateTagsRequest, cb)
 	assert(CreateTagsRequest, "You must provide a CreateTagsRequest")
 	local headers = {
@@ -4410,19 +4428,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateTagsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateTagsSync(CreateTagsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateTagsAsync(CreateTagsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateTagsAsync(CreateTagsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeWorkspaceDirectories asynchronously, invoking a callback when done
 -- @param DescribeWorkspaceDirectoriesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeWorkspaceDirectoriesAsync(DescribeWorkspaceDirectoriesRequest, cb)
 	assert(DescribeWorkspaceDirectoriesRequest, "You must provide a DescribeWorkspaceDirectoriesRequest")
 	local headers = {
@@ -4445,19 +4464,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeWorkspaceDirectoriesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeWorkspaceDirectoriesSync(DescribeWorkspaceDirectoriesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeWorkspaceDirectoriesAsync(DescribeWorkspaceDirectoriesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeWorkspaceDirectoriesAsync(DescribeWorkspaceDirectoriesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DescribeWorkspacesConnectionStatus asynchronously, invoking a callback when done
 -- @param DescribeWorkspacesConnectionStatusRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DescribeWorkspacesConnectionStatusAsync(DescribeWorkspacesConnectionStatusRequest, cb)
 	assert(DescribeWorkspacesConnectionStatusRequest, "You must provide a DescribeWorkspacesConnectionStatusRequest")
 	local headers = {
@@ -4480,19 +4500,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DescribeWorkspacesConnectionStatusRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DescribeWorkspacesConnectionStatusSync(DescribeWorkspacesConnectionStatusRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DescribeWorkspacesConnectionStatusAsync(DescribeWorkspacesConnectionStatusRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DescribeWorkspacesConnectionStatusAsync(DescribeWorkspacesConnectionStatusRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AssociateIpGroups asynchronously, invoking a callback when done
 -- @param AssociateIpGroupsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AssociateIpGroupsAsync(AssociateIpGroupsRequest, cb)
 	assert(AssociateIpGroupsRequest, "You must provide a AssociateIpGroupsRequest")
 	local headers = {
@@ -4515,19 +4536,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AssociateIpGroupsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AssociateIpGroupsSync(AssociateIpGroupsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AssociateIpGroupsAsync(AssociateIpGroupsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AssociateIpGroupsAsync(AssociateIpGroupsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call AuthorizeIpRules asynchronously, invoking a callback when done
 -- @param AuthorizeIpRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.AuthorizeIpRulesAsync(AuthorizeIpRulesRequest, cb)
 	assert(AuthorizeIpRulesRequest, "You must provide a AuthorizeIpRulesRequest")
 	local headers = {
@@ -4550,12 +4572,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param AuthorizeIpRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.AuthorizeIpRulesSync(AuthorizeIpRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.AuthorizeIpRulesAsync(AuthorizeIpRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.AuthorizeIpRulesAsync(AuthorizeIpRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/aws-sdk/xray.lua
+++ b/aws-sdk/xray.lua
@@ -3332,7 +3332,7 @@ end
 --
 --- Call GetServiceGraph asynchronously, invoking a callback when done
 -- @param GetServiceGraphRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetServiceGraphAsync(GetServiceGraphRequest, cb)
 	assert(GetServiceGraphRequest, "You must provide a GetServiceGraphRequest")
 	local headers = {
@@ -3355,19 +3355,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetServiceGraphRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetServiceGraphSync(GetServiceGraphRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetServiceGraphAsync(GetServiceGraphRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetServiceGraphAsync(GetServiceGraphRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutTelemetryRecords asynchronously, invoking a callback when done
 -- @param PutTelemetryRecordsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutTelemetryRecordsAsync(PutTelemetryRecordsRequest, cb)
 	assert(PutTelemetryRecordsRequest, "You must provide a PutTelemetryRecordsRequest")
 	local headers = {
@@ -3390,19 +3391,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutTelemetryRecordsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutTelemetryRecordsSync(PutTelemetryRecordsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutTelemetryRecordsAsync(PutTelemetryRecordsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutTelemetryRecordsAsync(PutTelemetryRecordsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSamplingRules asynchronously, invoking a callback when done
 -- @param GetSamplingRulesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSamplingRulesAsync(GetSamplingRulesRequest, cb)
 	assert(GetSamplingRulesRequest, "You must provide a GetSamplingRulesRequest")
 	local headers = {
@@ -3425,19 +3427,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSamplingRulesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSamplingRulesSync(GetSamplingRulesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSamplingRulesAsync(GetSamplingRulesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSamplingRulesAsync(GetSamplingRulesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSamplingTargets asynchronously, invoking a callback when done
 -- @param GetSamplingTargetsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSamplingTargetsAsync(GetSamplingTargetsRequest, cb)
 	assert(GetSamplingTargetsRequest, "You must provide a GetSamplingTargetsRequest")
 	local headers = {
@@ -3460,19 +3463,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSamplingTargetsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSamplingTargetsSync(GetSamplingTargetsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSamplingTargetsAsync(GetSamplingTargetsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSamplingTargetsAsync(GetSamplingTargetsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTraceSummaries asynchronously, invoking a callback when done
 -- @param GetTraceSummariesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTraceSummariesAsync(GetTraceSummariesRequest, cb)
 	assert(GetTraceSummariesRequest, "You must provide a GetTraceSummariesRequest")
 	local headers = {
@@ -3495,19 +3499,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTraceSummariesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTraceSummariesSync(GetTraceSummariesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTraceSummariesAsync(GetTraceSummariesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTraceSummariesAsync(GetTraceSummariesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetSamplingStatisticSummaries asynchronously, invoking a callback when done
 -- @param GetSamplingStatisticSummariesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetSamplingStatisticSummariesAsync(GetSamplingStatisticSummariesRequest, cb)
 	assert(GetSamplingStatisticSummariesRequest, "You must provide a GetSamplingStatisticSummariesRequest")
 	local headers = {
@@ -3530,19 +3535,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetSamplingStatisticSummariesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetSamplingStatisticSummariesSync(GetSamplingStatisticSummariesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetSamplingStatisticSummariesAsync(GetSamplingStatisticSummariesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetSamplingStatisticSummariesAsync(GetSamplingStatisticSummariesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call UpdateSamplingRule asynchronously, invoking a callback when done
 -- @param UpdateSamplingRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.UpdateSamplingRuleAsync(UpdateSamplingRuleRequest, cb)
 	assert(UpdateSamplingRuleRequest, "You must provide a UpdateSamplingRuleRequest")
 	local headers = {
@@ -3565,19 +3571,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param UpdateSamplingRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.UpdateSamplingRuleSync(UpdateSamplingRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.UpdateSamplingRuleAsync(UpdateSamplingRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.UpdateSamplingRuleAsync(UpdateSamplingRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutTraceSegments asynchronously, invoking a callback when done
 -- @param PutTraceSegmentsRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutTraceSegmentsAsync(PutTraceSegmentsRequest, cb)
 	assert(PutTraceSegmentsRequest, "You must provide a PutTraceSegmentsRequest")
 	local headers = {
@@ -3600,19 +3607,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutTraceSegmentsRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutTraceSegmentsSync(PutTraceSegmentsRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutTraceSegmentsAsync(PutTraceSegmentsRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutTraceSegmentsAsync(PutTraceSegmentsRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetTraceGraph asynchronously, invoking a callback when done
 -- @param GetTraceGraphRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetTraceGraphAsync(GetTraceGraphRequest, cb)
 	assert(GetTraceGraphRequest, "You must provide a GetTraceGraphRequest")
 	local headers = {
@@ -3635,19 +3643,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetTraceGraphRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetTraceGraphSync(GetTraceGraphRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetTraceGraphAsync(GetTraceGraphRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetTraceGraphAsync(GetTraceGraphRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call GetEncryptionConfig asynchronously, invoking a callback when done
 -- @param GetEncryptionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.GetEncryptionConfigAsync(GetEncryptionConfigRequest, cb)
 	assert(GetEncryptionConfigRequest, "You must provide a GetEncryptionConfigRequest")
 	local headers = {
@@ -3670,19 +3679,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param GetEncryptionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.GetEncryptionConfigSync(GetEncryptionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.GetEncryptionConfigAsync(GetEncryptionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.GetEncryptionConfigAsync(GetEncryptionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call CreateSamplingRule asynchronously, invoking a callback when done
 -- @param CreateSamplingRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.CreateSamplingRuleAsync(CreateSamplingRuleRequest, cb)
 	assert(CreateSamplingRuleRequest, "You must provide a CreateSamplingRuleRequest")
 	local headers = {
@@ -3705,19 +3715,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param CreateSamplingRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.CreateSamplingRuleSync(CreateSamplingRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.CreateSamplingRuleAsync(CreateSamplingRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.CreateSamplingRuleAsync(CreateSamplingRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call BatchGetTraces asynchronously, invoking a callback when done
 -- @param BatchGetTracesRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.BatchGetTracesAsync(BatchGetTracesRequest, cb)
 	assert(BatchGetTracesRequest, "You must provide a BatchGetTracesRequest")
 	local headers = {
@@ -3740,19 +3751,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param BatchGetTracesRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.BatchGetTracesSync(BatchGetTracesRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.BatchGetTracesAsync(BatchGetTracesRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.BatchGetTracesAsync(BatchGetTracesRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call PutEncryptionConfig asynchronously, invoking a callback when done
 -- @param PutEncryptionConfigRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.PutEncryptionConfigAsync(PutEncryptionConfigRequest, cb)
 	assert(PutEncryptionConfigRequest, "You must provide a PutEncryptionConfigRequest")
 	local headers = {
@@ -3775,19 +3787,20 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param PutEncryptionConfigRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.PutEncryptionConfigSync(PutEncryptionConfigRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.PutEncryptionConfigAsync(PutEncryptionConfigRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.PutEncryptionConfigAsync(PutEncryptionConfigRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end
 
 --- Call DeleteSamplingRule asynchronously, invoking a callback when done
 -- @param DeleteSamplingRuleRequest
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.DeleteSamplingRuleAsync(DeleteSamplingRuleRequest, cb)
 	assert(DeleteSamplingRuleRequest, "You must provide a DeleteSamplingRuleRequest")
 	local headers = {
@@ -3810,12 +3823,13 @@ end
 -- This assumes that the function is called from within a coroutine
 -- @param DeleteSamplingRuleRequest
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.DeleteSamplingRuleSync(DeleteSamplingRuleRequest, ...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.DeleteSamplingRuleAsync(DeleteSamplingRuleRequest, function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.DeleteSamplingRuleAsync(DeleteSamplingRuleRequest, function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end

--- a/operations.mtl
+++ b/operations.mtl
@@ -253,7 +253,7 @@ end
 {{#operations}}
 --- Call {{name}} asynchronously, invoking a callback when done{{#input}}
 -- @param {{shape}}{{/input}}
--- @param cb Callback function accepting two args: response, error_message
+-- @param cb Callback function accepting three args: response, error_type, error_message
 function M.{{name}}Async({{#input}}{{shape}}, {{/input}}cb){{#input}}
 	assert({{shape}}, "You must provide a {{shape}}"){{/input}}
 	local headers = {
@@ -277,12 +277,13 @@ end
 -- This assumes that the function is called from within a coroutine{{#input}}
 -- @param {{shape}}{{/input}}
 -- @return response
+-- @return error_type
 -- @return error_message
 function M.{{name}}Sync({{#input}}{{shape}}, {{/input}}...)
 	local co = coroutine.running()
 	assert(co, "You must call this function from within a coroutine")
-	M.{{name}}Async({{#input}}{{shape}}, {{/input}}function(response, error_message)
-		assert(coroutine.resume(co, response, error_message))
+	M.{{name}}Async({{#input}}{{shape}}, {{/input}}function(response, error_type, error_message)
+		assert(coroutine.resume(co, response, error_type, error_message))
 	end)
 	return coroutine.yield()
 end


### PR DESCRIPTION
I removed the `pprint` debug call and fixed error handling by adding a third parameter, so now you have `success, error_type, error_message`.

I only tested the json part of it.