### PR TITLE
add PUT method to rest-xml protocol

### DIFF
--- a/aws-sdk/core/request_handlers/rest_xml.lua
+++ b/aws-sdk/core/request_handlers/rest_xml.lua
@@ -43,4 +43,43 @@ function M.get(base_uri, request_uri, args, headers, settings, cb)
 	end)
 end
 
+function M.put(base_uri, request_uri, args, headers, settings, cb)
+	for arg,value in pairs(args.uri) do
+		-- some S3 requests have {Key+} in request uri, but it requires Key in args.uri
+		-- so we try to replace {arg} or {arg+} with value
+		request_uri = request_uri:gsub(arg:gsub('}', '[+]?}'), value)
+	end
+
+	local body = args.all.Body
+
+	if not credentials.is_empty() then
+		headers[request_headers.AWS_DATE_HEADER] = os.date('!%Y%m%dT%H%M%SZ')
+		headers[request_headers.HOST_HEADER] = settings.endpoint
+		headers[request_headers.CONTENT_TYPE_HEADER] = nil
+		headers[request_headers.AMZ_TARGET_HEADER] = nil
+		local authorization, err = request_signer.sign(settings.signature_version,
+														"PUT",
+														request_uri,
+														body,
+														headers,
+														settings.service,
+														settings.region)
+		if not authorization then
+			cb(false, err)
+			return
+		end
+		headers[request_headers.AUTHORIZATION_HEADER] = authorization
+		headers[request_headers.HOST_HEADER] = nil
+	end
+
+	config.http_request(base_uri .. request_uri, "PUT", headers, body, function(response)
+		local data = assert(xml.parse(response.response))
+		if response.status >= 200 and response.status < 300 then
+			cb(data)
+		else
+			cb(false, data.__type, data.Error.Message)
+		end
+	end)
+end
+
 return M


### PR DESCRIPTION
I have tested this method with upload file to S3, and I get error (Code: SignatureDoesNotMatch, Message: The request signature we calculated does not match the signature you provided. Check your key and signing method.)

However, I don't see why signature is wrong, signing is working for GET requests. Error response has CanonicalRequest and StringToSign, canonical request matches with calculated value in request_signers.lua, but string to sign has different hash for canonical request.

Do you see what's wrong?